### PR TITLE
구글 시트 스케줄러 비동기 배치 처리로 변경

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import team.startup.gwangjutalentfestival.domain.slogan.properties.SloganSubmissionProperties;

--- a/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import team.startup.gwangjutalentfestival.domain.slogan.properties.SloganSubmissionProperties;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProperties;
 import team.startup.gwangjutalentfestival.global.security.properties.CorsProperties;
@@ -13,6 +15,7 @@ import team.startup.gwangjutalentfestival.global.sms.properties.SolapiProperties
 
 @EnableFeignClients
 @EnableAsync
+@EnableScheduling
 @EnableConfigurationProperties({JwtProperties.class, CorsProperties.class, SolapiProperties.class, SmsVerifyProperties.class,SloganSubmissionProperties.class})
 @SpringBootApplication
 public class GwangjutalentfestivalApplication {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/entity/SloganEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/entity/SloganEntity.java
@@ -2,6 +2,9 @@ package team.startup.gwangjutalentfestival.domain.slogan.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import team.startup.gwangjutalentfestival.domain.slogan.enums.SheetSyncStatus;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -35,4 +38,40 @@ public class SloganEntity {
 
     @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
+
+    @Column(name = "retry_count")
+    private int retryCount;
+
+    @Column(name = "next_retry_at")
+    private LocalDateTime nextRetryAt;
+
+    @Column(columnDefinition = "TEXT")
+    private String lastError;
+
+    @Column(name = "synced_at")
+    private LocalDateTime syncedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sheet_sync_status", nullable = false)
+    private SheetSyncStatus sheetSyncStatus;
+
+    public void processSheetSyncStatus() {
+        this.sheetSyncStatus = SheetSyncStatus.PROCESSING;
+    }
+
+    public void markDone() {
+        this.sheetSyncStatus = SheetSyncStatus.COMPLETED;
+        this.syncedAt = LocalDateTime.now();
+    }
+
+    public void markFailed(LocalDateTime nextRetryAt, String lastError) {
+        this.sheetSyncStatus = SheetSyncStatus.REJECTED;
+        this.nextRetryAt = nextRetryAt;
+        this.lastError = lastError;
+        this.retryCount += 1;
+    }
+
+    public void markExhausted() {
+        this.sheetSyncStatus = SheetSyncStatus.EXHAUSTED;
+    }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/entity/SloganEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/entity/SloganEntity.java
@@ -3,6 +3,7 @@ package team.startup.gwangjutalentfestival.domain.slogan.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import team.startup.gwangjutalentfestival.domain.slogan.enums.SheetSyncStatus;
+import team.startup.gwangjutalentfestival.global.constant.TimeConstants;
 
 import java.time.LocalDateTime;
 
@@ -61,7 +62,7 @@ public class SloganEntity {
 
     public void markDone() {
         this.sheetSyncStatus = SheetSyncStatus.COMPLETED;
-        this.syncedAt = LocalDateTime.now();
+        this.syncedAt = LocalDateTime.now(TimeConstants.SEOUL_ZONE_ID);
     }
 
     public void markFailed(LocalDateTime nextRetryAt, String lastError) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/enums/SheetSyncStatus.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/enums/SheetSyncStatus.java
@@ -1,0 +1,9 @@
+package team.startup.gwangjutalentfestival.domain.slogan.enums;
+
+public enum SheetSyncStatus {
+    PENDING,
+    PROCESSING,
+    REJECTED,
+    COMPLETED,
+    EXHAUSTED
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/SloganSheetRowData.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/SloganSheetRowData.java
@@ -1,0 +1,18 @@
+package team.startup.gwangjutalentfestival.domain.slogan.presentation.data;
+
+public record SloganSheetRowData(
+        String slogan,
+
+        String description,
+
+        String school,
+
+        String name,
+
+        Integer grade,
+
+        Integer classNum,
+
+        String phoneNumber
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/repository/SloganRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/repository/SloganRepository.java
@@ -2,7 +2,15 @@ package team.startup.gwangjutalentfestival.domain.slogan.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.startup.gwangjutalentfestival.domain.slogan.entity.SloganEntity;
+import team.startup.gwangjutalentfestival.domain.slogan.enums.SheetSyncStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface SloganRepository extends JpaRepository<SloganEntity, Long> {
     boolean existsByPhoneNumber(String phoneNumber);
-}
+
+    List<SloganEntity> findTop50BySheetSyncStatusInAndNextRetryAtBeforeOrderByIdAsc(
+            List<SheetSyncStatus> statuses,
+            LocalDateTime now
+    );}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/scheduler/SloganSheetSyncScheduler.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/scheduler/SloganSheetSyncScheduler.java
@@ -9,6 +9,7 @@ import team.startup.gwangjutalentfestival.domain.slogan.entity.SloganEntity;
 import team.startup.gwangjutalentfestival.domain.slogan.enums.SheetSyncStatus;
 import team.startup.gwangjutalentfestival.domain.slogan.presentation.data.SloganSheetRowData;
 import team.startup.gwangjutalentfestival.domain.slogan.repository.SloganRepository;
+import team.startup.gwangjutalentfestival.global.constant.TimeConstants;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleSheetsAdapter;
 
 import java.time.LocalDateTime;
@@ -31,7 +32,7 @@ public class SloganSheetSyncScheduler {
         List<SloganEntity> slogans = sloganRepository
                 .findTop50BySheetSyncStatusInAndNextRetryAtBeforeOrderByIdAsc(
                         List.of(SheetSyncStatus.PENDING, SheetSyncStatus.REJECTED),
-                        LocalDateTime.now());
+                        LocalDateTime.now(TimeConstants.SEOUL_ZONE_ID));
 
         if (slogans.isEmpty()) {
             return;
@@ -69,7 +70,7 @@ public class SloganSheetSyncScheduler {
                 ? "Unknown error"
                 : errorMessage.substring(0, Math.min(errorMessage.length(), ERROR_MESSAGE_MAX_LENGTH));
 
-        LocalDateTime nextRetryAt = LocalDateTime.now().plusSeconds(30);
+        LocalDateTime nextRetryAt = LocalDateTime.now(TimeConstants.SEOUL_ZONE_ID).plusSeconds(30);
 
         for (SloganEntity sloganEntity : slogans) {
             if (sloganEntity.getRetryCount() >= MAX_RETRY_COUNT) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/scheduler/SloganSheetSyncScheduler.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/scheduler/SloganSheetSyncScheduler.java
@@ -1,0 +1,83 @@
+package team.startup.gwangjutalentfestival.domain.slogan.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.slogan.entity.SloganEntity;
+import team.startup.gwangjutalentfestival.domain.slogan.enums.SheetSyncStatus;
+import team.startup.gwangjutalentfestival.domain.slogan.presentation.data.SloganSheetRowData;
+import team.startup.gwangjutalentfestival.domain.slogan.repository.SloganRepository;
+import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleSheetsAdapter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SloganSheetSyncScheduler {
+
+    private static final int MAX_RETRY_COUNT = 10;
+    private static final int ERROR_MESSAGE_MAX_LENGTH = 2000;
+
+    private final SloganRepository sloganRepository;
+    private final GoogleSheetsAdapter googleSheetsAdapter;
+
+    @Transactional
+    @Scheduled(fixedDelay = 10000)
+    public void execute() {
+        List<SloganEntity> slogans = sloganRepository
+                .findTop50BySheetSyncStatusInAndNextRetryAtBeforeOrderByIdAsc(
+                        List.of(SheetSyncStatus.PENDING, SheetSyncStatus.REJECTED),
+                        LocalDateTime.now());
+
+        if (slogans.isEmpty()) {
+            return;
+        }
+
+        try {
+            slogans.forEach(SloganEntity::processSheetSyncStatus);
+
+            List<SloganSheetRowData> rows = slogans.stream()
+                    .map(this::toRowData)
+                    .toList();
+
+            googleSheetsAdapter.appendSlogan(rows);
+            slogans.forEach(SloganEntity::markDone);
+        } catch (Exception e) {
+            markFailed(slogans, e);
+        }
+    }
+
+    private SloganSheetRowData toRowData(SloganEntity s) {
+        return new SloganSheetRowData(
+                s.getSlogan(),
+                s.getDescription(),
+                s.getSchool(),
+                s.getName(),
+                s.getGrade(),
+                s.getClassNum(),
+                s.getPhoneNumber()
+        );
+    }
+
+    private void markFailed(List<SloganEntity> slogans, Exception e) {
+        String errorMessage = e.getMessage();
+        String truncatedError = (errorMessage == null)
+                ? "Unknown error"
+                : errorMessage.substring(0, Math.min(errorMessage.length(), ERROR_MESSAGE_MAX_LENGTH));
+
+        LocalDateTime nextRetryAt = LocalDateTime.now().plusSeconds(30);
+
+        for (SloganEntity sloganEntity : slogans) {
+            if (sloganEntity.getRetryCount() >= MAX_RETRY_COUNT) {
+                log.error("슬로건 시트 동기화 최대 재시도 횟수 초과 - sloganId: {}", sloganEntity.getId());
+                sloganEntity.markExhausted();
+                continue;
+            }
+            sloganEntity.markFailed(nextRetryAt, truncatedError);
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/scheduler/SloganSheetSyncScheduler.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/scheduler/SloganSheetSyncScheduler.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import team.startup.gwangjutalentfestival.domain.slogan.entity.SloganEntity;
 import team.startup.gwangjutalentfestival.domain.slogan.enums.SheetSyncStatus;
 import team.startup.gwangjutalentfestival.domain.slogan.presentation.data.SloganSheetRowData;
@@ -25,30 +25,34 @@ public class SloganSheetSyncScheduler {
 
     private final SloganRepository sloganRepository;
     private final GoogleSheetsAdapter googleSheetsAdapter;
+    private final TransactionTemplate transactionTemplate;
 
-    @Transactional
     @Scheduled(fixedDelay = 10000)
     public void execute() {
-        List<SloganEntity> slogans = sloganRepository
-                .findTop50BySheetSyncStatusInAndNextRetryAtBeforeOrderByIdAsc(
-                        List.of(SheetSyncStatus.PENDING, SheetSyncStatus.REJECTED),
-                        LocalDateTime.now(TimeConstants.SEOUL_ZONE_ID));
+        List<SloganEntity> slogans = transactionTemplate.execute(status -> {
+            List<SloganEntity> fetched = sloganRepository
+                    .findTop50BySheetSyncStatusInAndNextRetryAtBeforeOrderByIdAsc(
+                            List.of(SheetSyncStatus.PENDING, SheetSyncStatus.REJECTED),
+                            LocalDateTime.now(TimeConstants.SEOUL_ZONE_ID));
+            fetched.forEach(SloganEntity::processSheetSyncStatus);
+            return fetched;
+        });
 
-        if (slogans.isEmpty()) {
+        if (slogans == null || slogans.isEmpty()) {
             return;
         }
 
+        List<SloganSheetRowData> rows = slogans.stream()
+                .map(this::toRowData)
+                .toList();
+
         try {
-            slogans.forEach(SloganEntity::processSheetSyncStatus);
-
-            List<SloganSheetRowData> rows = slogans.stream()
-                    .map(this::toRowData)
-                    .toList();
-
             googleSheetsAdapter.appendSlogan(rows);
-            slogans.forEach(SloganEntity::markDone);
+            transactionTemplate.executeWithoutResult(status ->
+                    slogans.forEach(SloganEntity::markDone));
         } catch (Exception e) {
-            markFailed(slogans, e);
+            transactionTemplate.executeWithoutResult(status ->
+                    markFailed(slogans, e));
         }
     }
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.auth.exception.DuplicatePhoneNumberException;
+import team.startup.gwangjutalentfestival.domain.slogan.enums.SheetSyncStatus;
 import team.startup.gwangjutalentfestival.domain.slogan.presentation.data.request.CreateSloganRequest;
 import team.startup.gwangjutalentfestival.domain.slogan.entity.SloganEntity;
 import team.startup.gwangjutalentfestival.domain.slogan.exception.SloganSubmissionPeriodException;
@@ -39,10 +40,11 @@ public class CreateSloganServiceImpl implements CreateSloganService {
                 .classNum(request.classNum())
                 .name(request.name())
                 .phoneNumber(request.phoneNumber())
+                .sheetSyncStatus(SheetSyncStatus.PENDING)
+                .nextRetryAt(LocalDateTime.now())
                 .build();
 
         sloganRepository.save(slogan);
-        googleSheetsAdapter.appendSlogan(request);
     }
 
     private void validateDuplicatePhoneNumber(String phoneNumber) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
@@ -11,20 +11,16 @@ import team.startup.gwangjutalentfestival.domain.slogan.exception.SloganSubmissi
 import team.startup.gwangjutalentfestival.domain.slogan.properties.SloganSubmissionProperties;
 import team.startup.gwangjutalentfestival.domain.slogan.repository.SloganRepository;
 import team.startup.gwangjutalentfestival.domain.slogan.service.CreateSloganService;
-import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleSheetsAdapter;
+import team.startup.gwangjutalentfestival.global.constant.TimeConstants;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 @Service
 @RequiredArgsConstructor
 public class CreateSloganServiceImpl implements CreateSloganService {
 
     private final SloganRepository sloganRepository;
-    private final GoogleSheetsAdapter googleSheetsAdapter;
     private final SloganSubmissionProperties sloganSubmissionProperties;
-
-    private static final String SEOUL_ZONE_ID  = "Asia/Seoul";
 
     @Override
     @Transactional
@@ -41,7 +37,7 @@ public class CreateSloganServiceImpl implements CreateSloganService {
                 .name(request.name())
                 .phoneNumber(request.phoneNumber())
                 .sheetSyncStatus(SheetSyncStatus.PENDING)
-                .nextRetryAt(LocalDateTime.now())
+                .nextRetryAt(LocalDateTime.now(TimeConstants.SEOUL_ZONE_ID))
                 .build();
 
         sloganRepository.save(slogan);
@@ -54,7 +50,7 @@ public class CreateSloganServiceImpl implements CreateSloganService {
     }
 
     private void validateSloganSubmissionPeriod() {
-        LocalDateTime now = LocalDateTime.now(ZoneId.of(SEOUL_ZONE_ID));
+        LocalDateTime now = LocalDateTime.now(TimeConstants.SEOUL_ZONE_ID);
 
         if (now.isBefore(sloganSubmissionProperties.startAt()) ||
                 now.isAfter(sloganSubmissionProperties.endAt())) {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/constant/TimeConstants.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/constant/TimeConstants.java
@@ -1,0 +1,11 @@
+package team.startup.gwangjutalentfestival.global.constant;
+
+import java.time.ZoneId;
+
+public final class TimeConstants {
+
+    public static final ZoneId SEOUL_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private TimeConstants() {
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapter.java
@@ -5,7 +5,7 @@ import com.google.api.services.sheets.v4.Sheets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import team.startup.gwangjutalentfestival.domain.slogan.presentation.data.request.CreateSloganRequest;
+import team.startup.gwangjutalentfestival.domain.slogan.presentation.data.SloganSheetRowData;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.exception.GoogleSheetsApiException;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.exception.GoogleSheetsException;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.exception.GoogleSheetsIoException;
@@ -23,8 +23,8 @@ public class GoogleSheetsAdapter {
     private final Sheets sheets;
     private final GoogleSheetsProperties properties;
 
-    public void appendSlogan(CreateSloganRequest request) {
-        List<List<Object>> rows = getList(request);
+    public void appendSlogan(List<SloganSheetRowData> data) {
+        List<List<Object>> rows = getList(data);
         String sheetId = properties.sheetId();
         String sheetPage = properties.sheetPage();
 
@@ -49,16 +49,17 @@ public class GoogleSheetsAdapter {
         }
     }
 
-    private List<List<Object>> getList(CreateSloganRequest request){
-        List<Object> sloganList = List.of(
-                request.slogan(),
-                request.description(),
-                request.school(),
-                request.name(),
-                request.grade(),
-                request.classNum(),
-                request.phoneNumber()
-        );
-        return List.of(sloganList);
+    private List<List<Object>> getList(List<SloganSheetRowData> data) {
+        return data.stream()
+                .map(s -> List.<Object>of(
+                        s.slogan(),
+                        s.description(),
+                        s.school(),
+                        s.name(),
+                        s.grade(),
+                        s.classNum(),
+                        s.phoneNumber()
+                ))
+                .toList();
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
> 기존에 슬로건 응모를 하면 구글 시트로 동기로 반영되는 것을 스케줄러를 통해 비동기 배치 처리로 전환하였습니다.

---

## 🔍 리뷰 시 참고사항
- 현재 스케줄러는 10초 주기로 처리되도록 설정해두었습니다. 해당 주기에 대해 다른 의견이나 더 적절한 방향이 있다면 말씀 부탁드립니다.
---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #42 