### PR TITLE
commit 스킬 브랜치 생성 플로우 및 커밋 규칙 개선

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -7,6 +7,7 @@ allowed-tools: Bash
 ## Step 0 — Branch Check (Required)
 
 Check the current branch first:
+
 ```bash
 git branch --show-current
 ```
@@ -17,13 +18,13 @@ This project uses Git Flow. Feature branches must be created from `develop` and 
 
 1. Analyze all changes with `git status` and `git diff`
 2. Infer an appropriate branch name from the changes:
-    - Format: `<type>/<kebab-case-description>`
-    - Reflect the domain scope in the name
-    - Examples: `add/add-team-list`, `fix/auth-login`, `update/optimize-seat-query`
+   - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit
+   - Reflect the domain scope in the name
+   - Examples: `add/add-team-list-api`, `fix/auth-login-bug`, `update/optimize-seat-query`
 3. Create and checkout the branch:
-```bash
-git checkout -b <type>/<inferred-name>
-```
+   ```bash
+   git checkout -b <type>/<inferred-name>
+   ```
 4. Proceed with the commit flow below
 
 **If current branch is NOT `develop`:** proceed directly to the commit flow.
@@ -35,8 +36,8 @@ git checkout -b <type>/<inferred-name>
 Format: `type :: description`
 
 - **Types**: `add` / `update` / `fix` / `delete` / `docs` / `test` / `merge` / `init`
-- **Description**: Korean, no period, avoid noun-ending style
-    - Good: `엔티티 필드 추가`, `트랜잭션 롤백 방지`, `로직 개선`
+- **Description**: Korean, no period, avoid noun-ending style and endings: `~한다/~된다`, `~하기`, `~합니다/~됩니다`, `~했습니다`
+   - Good: `엔티티 필드 추가`, `트랜잭션 롤백 방지`, `로직 개선`
 - Subject line only (no body)
 - Do NOT add AI as co-author
 
@@ -44,13 +45,13 @@ Format: `type :: description`
 
 1. Inspect changes: `git status`, `git diff`
 2. Group changed files by logical unit of change:
-    - Same feature or bug fix → one commit
-    - Different concerns (e.g. entity + service + controller for one feature) → one commit
-    - Unrelated changes → separate commits
+   - Same feature or bug fix → one commit
+   - Related files that must change together (e.g. entity + service + controller for one feature) → one commit
+   - Unrelated changes → separate commits
 3. For each logical group:
-    - Stage the relevant files: `git add <file1> <file2> ...`
-    - Write a commit message that describes the change as a whole
-    - `git commit -m "message"`
+   - Stage the relevant files: `git add <file1> <file2> ...`
+   - Write a commit message that describes the change as a whole
+   - `git commit -m "message"`
 4. Verify with `git log --oneline -n <count>`
 
 > **Rule**: One logical change = One commit. Files that must change together belong in the same commit. Unrelated changes must be split.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -36,7 +36,7 @@ This project uses Git Flow. Feature branches must be created from `develop` and 
 Format: `type :: description`
 
 - **Types**: `add` / `update` / `fix` / `delete` / `docs` / `test` / `merge` / `init`
-- **Description**: Korean, no period, avoid noun-ending style and endings: `~한다/~된다`, `~하기`, `~합니다/~됩니다`, `~했습니다`
+- **Description**: Korean, no period, use noun-ending style; forbidden endings: `~한다/~된다`, `~하기`, `~합니다/~됩니다`, `~했습니다`
    - Good: `엔티티 필드 추가`, `트랜잭션 롤백 방지`, `로직 개선`
 - Subject line only (no body)
 - Do NOT add AI as co-author


### PR DESCRIPTION
## ✨ 작업 내용
commit 스킬(`SKILL.md`)에서 develop 브랜치 감지 시 feature 브랜치를 자동 생성하는 Step 0 플로우와 커밋 규칙을 개선하였습니다.

- 브랜치 이름 형식에 커밋 타입과 동일하게 맞추도록 설명을 추가하였습니다 (`use the same type as the planned commit`)
- 브랜치 이름 예시를 더 구체적으로 수정하였습니다 (`add/add-team-list` → `add/add-team-list-api`)
- `git checkout -b` 코드 블록을 Step 0 목록 안으로 들여써 흐름이 자연스럽게 이어지도록 하였습니다
- 커밋 메시지 금지 어미를 명시하였습니다 (`~한다/~된다`, `~하기`, `~합니다/~됩니다`, `~했습니다`)
- "Different concerns" → "Related files that must change together"로 문구를 명확히 하였습니다

---

## 🔍 리뷰 시 참고사항
- 기능 변경 없이 스킬 문서(SKILL.md) 내용만 수정된 PR입니다.
- Step 0의 브랜치 생성 절차를 더 직관적으로 따를 수 있도록 구조를 정비하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #