### PR TITLE
조회 API Caffeine 캐시 적용 및 무효화 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     // Data
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     // Mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
@@ -1,7 +1,9 @@
 package team.startup.gwangjutalentfestival.domain.judge.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
 import team.startup.gwangjutalentfestival.domain.judge.exception.JudgementTotalScoreExceededException;
@@ -24,6 +26,7 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.TEAM_RANKING, allEntries = true)
     public void execute(SaveJudgementScoreRequest request, Long teamId) {
         UserEntity user = userUtil.getCurrentUser();
         TeamEntity team = teamRepository.findById(teamId)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImpl.java
@@ -1,9 +1,12 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException;
@@ -22,6 +25,10 @@ public class CancelSeatReservationServiceImpl implements CancelSeatReservationSe
 
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheConfig.SEATS_ALL, allEntries = true),
+            @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
+    })
     public void execute() {
         UserEntity user = userUtil.getCurrentUser();
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
@@ -13,7 +13,6 @@ import team.startup.gwangjutalentfestival.domain.seat.repository.custom.SeatRese
 import team.startup.gwangjutalentfestival.domain.seat.service.GetAllSeatsService;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
-import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -32,7 +31,7 @@ public class GetAllSeatsServiceImpl implements GetAllSeatsService {
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.SEATS_ALL, key = "@userUtil.currentUserRole()")
     public GetAllSeatsResponse execute() {
-        Role role = UserUtil.getCurrentUserRole();
+        Role role = userUtil.currentUserRole();
 
         List<SectionSeatNumber> seatBans = seatBanCustomRepository.findSeatNumbersByRole(role);
         List<SectionSeatNumber> seatReservations = seatReservationCustomRepository.findAllSeatNumbers();

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
@@ -13,6 +13,7 @@ import team.startup.gwangjutalentfestival.domain.seat.repository.custom.SeatRese
 import team.startup.gwangjutalentfestival.domain.seat.service.GetAllSeatsService;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
@@ -32,7 +32,7 @@ public class GetAllSeatsServiceImpl implements GetAllSeatsService {
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.SEATS_ALL, key = "@userUtil.currentUserRole()")
     public GetAllSeatsResponse execute() {
-        Role role = userUtil.getCurrentUser().getRole();
+        Role role = UserUtil.getCurrentUserRole();
 
         List<SectionSeatNumber> seatBans = seatBanCustomRepository.findSeatNumbersByRole(role);
         List<SectionSeatNumber> seatReservations = seatReservationCustomRepository.findAllSeatNumbers();

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetAllSeatsResponse;
@@ -28,6 +30,7 @@ public class GetAllSeatsServiceImpl implements GetAllSeatsService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = CacheConfig.SEATS_ALL, key = "@userUtil.currentUserRole()")
     public GetAllSeatsResponse execute() {
         Role role = userUtil.getCurrentUser().getRole();
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
@@ -11,7 +11,6 @@ import team.startup.gwangjutalentfestival.domain.seat.repository.custom.SeatRese
 import team.startup.gwangjutalentfestival.domain.seat.service.GetSeatsBySectionService;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
-import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.util.List;
 import java.util.Set;
@@ -30,7 +29,7 @@ public class GetSeatsBySectionServiceImpl implements GetSeatsBySectionService {
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.SEATS_SECTION, key = "#section + ':' + @userUtil.currentUserRole()")
     public GetSeatsBySectionResponse execute(String section) {
-        Role role = UserUtil.getCurrentUserRole();
+        Role role = userUtil.currentUserRole();
         Integer seatLastNumber = seatUtil.getMaxSeats(section);
 
         Set<Integer> reservedSeatNumbers = seatReservationCustomRepository.findSeatNumbersBySeatSection(section);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
@@ -30,7 +30,7 @@ public class GetSeatsBySectionServiceImpl implements GetSeatsBySectionService {
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.SEATS_SECTION, key = "#section + ':' + @userUtil.currentUserRole()")
     public GetSeatsBySectionResponse execute(String section) {
-        Role role = userUtil.getCurrentUser().getRole();
+        Role role = UserUtil.getCurrentUserRole();
         Integer seatLastNumber = seatUtil.getMaxSeats(section);
 
         Set<Integer> reservedSeatNumbers = seatReservationCustomRepository.findSeatNumbersBySeatSection(section);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetSeatsBySectionResponse;
@@ -26,6 +28,7 @@ public class GetSeatsBySectionServiceImpl implements GetSeatsBySectionService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = CacheConfig.SEATS_SECTION, key = "#section + ':' + @userUtil.currentUserRole()")
     public GetSeatsBySectionResponse execute(String section) {
         Role role = userUtil.getCurrentUser().getRole();
         Integer seatLastNumber = seatUtil.getMaxSeats(section);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
@@ -11,6 +11,7 @@ import team.startup.gwangjutalentfestival.domain.seat.repository.custom.SeatRese
 import team.startup.gwangjutalentfestival.domain.seat.service.GetSeatsBySectionService;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImpl.java
@@ -1,9 +1,12 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException;
@@ -23,6 +26,10 @@ public class PerformerCancelSeatReservationServiceImpl implements PerformerCance
 
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheConfig.SEATS_ALL, allEntries = true),
+            @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
+    })
     public void execute(PerformerCancelSeatReservationRequest request) {
         UserEntity user = userUtil.getCurrentUser();
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -1,10 +1,13 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
@@ -35,6 +38,10 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
 
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheConfig.SEATS_ALL, allEntries = true),
+            @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
+    })
     public void execute(ReservationSeatRequest request) {
         String seatSection = request.seatSection();
         Integer seatNumber = request.seatNumber();

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetAllTeamServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetAllTeamServiceImpl.java
@@ -1,11 +1,13 @@
 package team.startup.gwangjutalentfestival.domain.team.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.team.presentation.data.response.GetTeamResponse;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.team.service.GetAllTeamService;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 
 import java.util.List;
 
@@ -16,6 +18,7 @@ public class GetAllTeamServiceImpl implements GetAllTeamService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = CacheConfig.TEAM_ALL, unless = "#result.isEmpty()")
     public List<GetTeamResponse> execute() {
         return teamRepository.findAllByOrderByPerformOrderAsc()
                 .stream()

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetTeamRankingServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetTeamRankingServiceImpl.java
@@ -1,11 +1,13 @@
 package team.startup.gwangjutalentfestival.domain.team.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.team.presentation.data.response.GetTeamRankingResponse;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.team.service.GetTeamRankingService;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 
 import java.util.List;
 
@@ -16,6 +18,7 @@ public class GetTeamRankingServiceImpl implements GetTeamRankingService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = CacheConfig.TEAM_RANKING, unless = "#result.isEmpty()")
     public List<GetTeamRankingResponse> execute() {
         return teamRepository.getRanking();
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/UpdateTeamOrderServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/UpdateTeamOrderServiceImpl.java
@@ -1,7 +1,9 @@
 package team.startup.gwangjutalentfestival.domain.team.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
@@ -23,6 +25,7 @@ public class UpdateTeamOrderServiceImpl implements UpdateTeamOrderService {
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.TEAM_ALL, allEntries = true)
     public void execute(List<TeamOrderItem> orders) {
         List<Long> teamIds = orders.stream()
                 .map(TeamOrderItem::teamId)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/UpdateTeamPerformanceServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/UpdateTeamPerformanceServiceImpl.java
@@ -1,7 +1,10 @@
 package team.startup.gwangjutalentfestival.domain.team.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.judge.event.JudgementTeamEvent;
@@ -18,6 +21,10 @@ public class UpdateTeamPerformanceServiceImpl implements UpdateTeamPerformanceSe
 
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CacheConfig.TEAM_ALL,     allEntries = true),
+            @CacheEvict(cacheNames = CacheConfig.TEAM_RANKING, allEntries = true)
+    })
     public void execute(Long teamId) {
         TeamEntity team = teamRepository.findById(teamId)
                 .orElseThrow(TeamNotFoundException::new);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/CacheConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/CacheConfig.java
@@ -1,0 +1,43 @@
+package team.startup.gwangjutalentfestival.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    public static final String TEAM_ALL      = "team:all";
+    public static final String TEAM_RANKING  = "team:ranking";
+    public static final String SEATS_ALL     = "seats:all";
+    public static final String SEATS_SECTION = "seats:section";
+    public static final String USERS_CURRENT = "users:current";
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(List.of(
+                build(TEAM_ALL,       5,  200),
+                build(TEAM_RANKING,   5,  200),
+                build(SEATS_ALL,      1,  500),
+                build(SEATS_SECTION,  1, 1000),
+                build(USERS_CURRENT, 10, 1000)
+        ));
+        return cacheManager;
+    }
+
+    private CaffeineCache build(String name, int ttlMinutes, int maxSize) {
+        return new CaffeineCache(name, Caffeine.newBuilder()
+                .expireAfterWrite(ttlMinutes, TimeUnit.MINUTES)
+                .maximumSize(maxSize)
+                .build());
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/CacheConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/CacheConfig.java
@@ -19,17 +19,15 @@ public class CacheConfig {
     public static final String TEAM_RANKING  = "team:ranking";
     public static final String SEATS_ALL     = "seats:all";
     public static final String SEATS_SECTION = "seats:section";
-    public static final String USERS_CURRENT = "users:current";
 
     @Bean
     public CacheManager cacheManager() {
         SimpleCacheManager cacheManager = new SimpleCacheManager();
         cacheManager.setCaches(List.of(
-                build(TEAM_ALL,       5,  200),
-                build(TEAM_RANKING,   5,  200),
-                build(SEATS_ALL,      1,  500),
-                build(SEATS_SECTION,  1, 1000),
-                build(USERS_CURRENT, 10, 1000)
+                build(TEAM_ALL,      5,  200),
+                build(TEAM_RANKING,  5,  200),
+                build(SEATS_ALL,     1,  500),
+                build(SEATS_SECTION, 1, 1000)
         ));
         return cacheManager;
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/UserUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/UserUtil.java
@@ -1,8 +1,6 @@
 package team.startup.gwangjutalentfestival.global.util;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
-import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
@@ -31,7 +29,6 @@ public class UserUtil {
                 .getRole();
     }
 
-    @Cacheable(value = CacheConfig.USERS_CURRENT, key = "@userUtil.currentUserId()")
     public UserEntity getCurrentUser() {
         return userRepository.findById(getCurrentUserId())
                 .orElseThrow(UserNotFoundException::new);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/UserUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/UserUtil.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.global.util;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
@@ -29,6 +31,7 @@ public class UserUtil {
                 .getRole();
     }
 
+    @Cacheable(value = CacheConfig.USERS_CURRENT, key = "@userUtil.currentUserId()")
     public UserEntity getCurrentUser() {
         return userRepository.findById(getCurrentUserId())
                 .orElseThrow(UserNotFoundException::new);
@@ -36,5 +39,13 @@ public class UserUtil {
 
     public UserEntity getCurrentUserRef() {
         return userRepository.getReferenceById(getCurrentUserId());
+    }
+
+    public Long currentUserId() {
+        return getCurrentUserId();
+    }
+
+    public Role currentUserRole() {
+        return getCurrentUserRole();
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용

반복 호출이 많은 조회 API에 Caffeine 로컬 캐시를 도입하여 DB 직접 조회 횟수를 줄이고 응답 성능을 개선하였습니다.

- `CacheConfig`에 캐시 설정 및 캐시명 상수를 정의하였습니다.
- `GetAllTeamService`, `GetTeamRankingService`, `GetAllSeatsService`, `GetSeatsBySectionService`, `UserUtil.getCurrentUser()`에 `@Cacheable`을 적용하였습니다.
- 심사 점수 저장, 팀 상태/순서 변경 시 `@CacheEvict`를 적용하여 캐시 일관성을 유지하였습니다.
- SpEL의 `T(...)` 전체 클래스 경로 표기를 `@userUtil.currentUserRole()` 방식으로 개선하였습니다.

---

## 🔍 리뷰 시 참고사항

- 좌석 캐시 키를 `section + ':' + role` 형태로 구성하여 역할별 뷰가 충돌 없이 관리되도록 하였습니다.
- 좌석 서비스(예약·취소·금지)는 SSE로 실시간 반영 중이며 TTL이 1분으로 짧아 `@CacheEvict`를 적용하지 않았습니다.
- `@CacheEvict`는 쓰기 빈도가 낮은 team 도메인에만 적용하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #52
