### PR TITLE
전체 도메인 JavaDoc 작성

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
@@ -12,6 +12,10 @@ import team.startup.gwangjutalentfestival.global.security.properties.CorsPropert
 import team.startup.gwangjutalentfestival.global.sms.properties.SmsVerifyProperties;
 import team.startup.gwangjutalentfestival.global.sms.properties.SolapiProperties;
 
+/**
+ * 광주 탤런트 페스티벌 서버 애플리케이션의 진입점.
+ * <p>비동기 처리, 스케줄링, OpenFeign 클라이언트, 설정 프로퍼티를 활성화한다.</p>
+ */
 @EnableFeignClients
 @EnableAsync
 @EnableScheduling
@@ -19,6 +23,11 @@ import team.startup.gwangjutalentfestival.global.sms.properties.SolapiProperties
 @SpringBootApplication
 public class GwangjutalentfestivalApplication {
 
+    /**
+     * 애플리케이션을 시작한다.
+     *
+     * @param args 커맨드라인 인수
+     */
     public static void main(String[] args) {
         SpringApplication.run(GwangjutalentfestivalApplication.class, args);
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/entity/RefreshToken.java
@@ -8,6 +8,10 @@ import org.springframework.data.redis.core.index.Indexed;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Redis에 저장되는 RefreshToken 엔티티.
+ * <p>사용자 ID를 키로 하며, TTL이 만료되면 자동으로 삭제됩니다.</p>
+ */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,12 +19,15 @@ import java.util.concurrent.TimeUnit;
 @RedisHash(value = "refresh_token")
 public class RefreshToken {
 
+    /** Redis 키로 사용되는 사용자 ID */
     @Id
     private String userId;
 
+    /** JWT RefreshToken 문자열 */
     @Indexed
     private String token;
 
+    /** 만료 시간 (초 단위) */
     @TimeToLive(unit = TimeUnit.SECONDS)
     private Long expiresIn;
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/entity/VerifyCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/entity/VerifyCode.java
@@ -10,6 +10,10 @@ import org.springframework.data.redis.core.TimeToLive;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Redis에 저장되는 SMS 인증번호 엔티티.
+ * <p>휴대폰 번호를 키로 하며, TTL이 만료되면 자동으로 삭제됩니다.</p>
+ */
 @Getter
 @Builder
 @NoArgsConstructor
@@ -17,11 +21,14 @@ import java.util.concurrent.TimeUnit;
 @RedisHash("verify:code")
 public class VerifyCode {
 
+    /** Redis 키로 사용되는 휴대폰 번호 */
     @Id
     private String phoneNumber;
 
+    /** 발급된 인증번호 문자열 */
     private String code;
 
+    /** 만료 시간 (초 단위) */
     @TimeToLive(unit = TimeUnit.SECONDS)
     private long ttl;
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/AlreadyVerifyCodeExistsException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/AlreadyVerifyCodeExistsException.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.domain.auth.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 동일한 휴대폰 번호로 인증번호가 이미 발급되어 있거나,
+ * 허용된 최대 발송 횟수를 초과했을 때 발생하는 예외.
+ */
 public class AlreadyVerifyCodeExistsException extends GlobalException {
     public AlreadyVerifyCodeExistsException() {
         super(ErrorCode.ALREADY_VERIFY_CODE_EXISTS);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/DuplicatePhoneNumberException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/DuplicatePhoneNumberException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.auth.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 이미 가입된 휴대폰 번호로 회원가입을 시도할 때 발생하는 예외.
+ */
 public class DuplicatePhoneNumberException extends GlobalException {
     public DuplicatePhoneNumberException() {
         super(ErrorCode.DUPLICATE_PHONE_NUMBER);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/ExpiredVerifyCodeException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/ExpiredVerifyCodeException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.auth.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 인증번호가 만료되어 Redis에서 조회되지 않을 때 발생하는 예외.
+ */
 public class ExpiredVerifyCodeException extends GlobalException {
     public ExpiredVerifyCodeException() {
         super(ErrorCode.EXPIRED_VERIFY_CODE);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/InvalidAccessTokenException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/InvalidAccessTokenException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.auth.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * AccessToken이 유효하지 않거나 파싱에 실패했을 때 발생하는 예외.
+ */
 public class InvalidAccessTokenException extends GlobalException {
     public InvalidAccessTokenException() {
         super(ErrorCode.INVALID_ACCESS_TOKEN);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/InvalidPasswordException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/InvalidPasswordException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.auth.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 입력한 비밀번호가 저장된 비밀번호와 일치하지 않을 때 발생하는 예외.
+ */
 public class InvalidPasswordException extends GlobalException {
     public InvalidPasswordException() {
         super(ErrorCode.INVALID_PASSWORD);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/InvalidRefreshTokenException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.auth.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * RefreshToken이 유효하지 않거나 저장된 토큰과 일치하지 않을 때 발생하는 예외.
+ */
 public class InvalidRefreshTokenException extends GlobalException {
     public InvalidRefreshTokenException() {
         super(ErrorCode.INVALID_REFRESH_TOKEN);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/InvalidVerifyCodeException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/InvalidVerifyCodeException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.auth.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 입력한 인증번호가 발급된 인증번호와 일치하지 않을 때 발생하는 예외.
+ */
 public class InvalidVerifyCodeException extends GlobalException {
     public InvalidVerifyCodeException() {
         super(ErrorCode.INVALID_VERIFY_CODE);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/exception/RefreshTokenNotFoundException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.auth.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * Redis에서 해당 사용자의 RefreshToken을 찾을 수 없을 때 발생하는 예외.
+ */
 public class RefreshTokenNotFoundException extends GlobalException {
     public RefreshTokenNotFoundException() {
         super(ErrorCode.REFRESH_TOKEN_NOT_FOUND);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/controller/AuthController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/controller/AuthController.java
@@ -21,6 +21,10 @@ import team.startup.gwangjutalentfestival.domain.auth.service.ReissueTokenServic
 import team.startup.gwangjutalentfestival.domain.auth.service.SendVerifyCodeService;
 import team.startup.gwangjutalentfestival.domain.auth.service.SignUpService;
 
+/**
+ * 인증 관련 API 엔드포인트를 처리하는 컨트롤러.
+ * <p>인증번호 발송, 회원가입, 로그인, 로그아웃, 토큰 재발급 기능을 제공합니다.</p>
+ */
 @Tag(name = "Auth", description = "인증 API")
 @RestController
 @RequestMapping("/auth")
@@ -33,6 +37,12 @@ public class AuthController {
     private final LogoutService logoutService;
     private final ReissueTokenService reissueTokenService;
 
+    /**
+     * 입력한 휴대폰 번호로 SMS 인증번호를 발송합니다.
+     *
+     * @param request 인증번호를 발송할 휴대폰 번호 요청 객체
+     * @return 204 No Content
+     */
     @Operation(summary = "인증번호 발송", description = "입력한 휴대폰 번호로 SMS 인증번호를 발송합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "인증번호 발송 성공"),
@@ -45,6 +55,12 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * 휴대폰 인증 후 비밀번호를 설정하여 회원가입합니다.
+     *
+     * @param request 휴대폰 번호, 비밀번호, 인증번호를 포함한 회원가입 요청 객체
+     * @return 201 Created
+     */
     @Operation(summary = "회원가입", description = "휴대폰 인증 후 비밀번호를 설정하여 회원가입합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "회원가입 성공"),
@@ -58,6 +74,12 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    /**
+     * 휴대폰 번호와 비밀번호로 로그인하고 JWT 토큰을 반환합니다.
+     *
+     * @param request 휴대폰 번호와 비밀번호를 포함한 로그인 요청 객체
+     * @return AccessToken 및 RefreshToken을 포함한 {@link TokenResponse}
+     */
     @Operation(summary = "로그인", description = "휴대폰 번호와 비밀번호로 로그인합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
@@ -70,6 +92,12 @@ public class AuthController {
         return ResponseEntity.ok(loginService.execute(request));
     }
 
+    /**
+     * 현재 로그인된 사용자의 RefreshToken을 삭제하고 AccessToken을 블랙리스트에 등록합니다.
+     *
+     * @param authorization Bearer 형식의 AccessToken이 담긴 Authorization 헤더
+     * @return 204 No Content
+     */
     @Operation(summary = "로그아웃", description = "현재 로그인된 사용자의 RefreshToken을 삭제합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -83,6 +111,12 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * RefreshToken으로 새로운 AccessToken과 RefreshToken을 재발급합니다.
+     *
+     * @param refreshToken Refresh-Token 헤더에 담긴 RefreshToken 문자열
+     * @return 새로 발급된 AccessToken 및 RefreshToken을 포함한 {@link TokenResponse}
+     */
     @Operation(summary = "토큰 재발급", description = "RefreshToken으로 새로운 AccessToken과 RefreshToken을 발급합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/request/LoginRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/request/LoginRequest.java
@@ -3,6 +3,12 @@ package team.startup.gwangjutalentfestival.domain.auth.presentation.data.request
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
+/**
+ * 로그인 요청 DTO.
+ *
+ * @param phoneNumber 로그인에 사용할 휴대폰 번호 (010으로 시작하는 11자리)
+ * @param password    계정 비밀번호
+ */
 public record LoginRequest(
         @Pattern(
                 regexp = "^010\\d{8}$",

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/request/SendVerifyCodeRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/request/SendVerifyCodeRequest.java
@@ -2,6 +2,11 @@ package team.startup.gwangjutalentfestival.domain.auth.presentation.data.request
 
 import jakarta.validation.constraints.Pattern;
 
+/**
+ * SMS 인증번호 발송 요청 DTO.
+ *
+ * @param phoneNumber 인증번호를 받을 휴대폰 번호 (010으로 시작하는 11자리)
+ */
 public record SendVerifyCodeRequest(
         @Pattern(
                 regexp = "^010\\d{8}$",

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/request/SignUpRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/request/SignUpRequest.java
@@ -3,6 +3,13 @@ package team.startup.gwangjutalentfestival.domain.auth.presentation.data.request
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
+/**
+ * 회원가입 요청 DTO.
+ *
+ * @param phoneNumber 가입에 사용할 휴대폰 번호 (010으로 시작하는 11자리)
+ * @param password    계정 비밀번호 (영문, 숫자, 특수문자 포함 8자리 이상)
+ * @param code        SMS로 수신한 인증번호
+ */
 public record SignUpRequest(
         @Pattern(
                 regexp = "^010\\d{8}$",

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/response/TokenResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/response/TokenResponse.java
@@ -5,6 +5,15 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
 import java.time.LocalDateTime;
 
+/**
+ * 로그인 및 토큰 재발급 시 반환되는 JWT 토큰 응답 DTO.
+ *
+ * @param accessToken            발급된 AccessToken 문자열
+ * @param accessTokenExpiresAt   AccessToken 만료 일시
+ * @param refreshToken           발급된 RefreshToken 문자열
+ * @param refreshTokenExpiresAt  RefreshToken 만료 일시
+ * @param role                   사용자 권한 역할
+ */
 public record TokenResponse(
         String accessToken,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/repository/RefreshTokenRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import team.startup.gwangjutalentfestival.domain.auth.entity.RefreshToken;
 
+/**
+ * Redis에 저장된 {@link team.startup.gwangjutalentfestival.domain.auth.entity.RefreshToken}을 관리하는 레포지토리.
+ */
 @Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/repository/TokenBlacklistRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/repository/TokenBlacklistRepository.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Repository;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * 로그아웃된 AccessToken의 JTI(JWT ID)를 Redis 블랙리스트로 관리하는 레포지토리.
+ * <p>토큰 만료 시간까지 블랙리스트에 보관하여 재사용을 방지합니다.</p>
+ */
 @Repository
 @Slf4j
 @RequiredArgsConstructor
@@ -14,6 +18,12 @@ public class TokenBlacklistRepository {
     private final StringRedisTemplate redisTemplate;
     private static final String BLACKLIST_PREFIX = "blacklist:";
 
+    /**
+     * 로그아웃된 AccessToken의 JTI를 블랙리스트에 등록합니다.
+     *
+     * @param jti                 블랙리스트에 등록할 JWT ID
+     * @param remainingExpiration 토큰의 남은 만료 시간 (밀리초)
+     */
     public void save(String jti, long remainingExpiration) {
         redisTemplate.opsForValue().set(
                 BLACKLIST_PREFIX + jti,
@@ -23,6 +33,12 @@ public class TokenBlacklistRepository {
         );
     }
 
+    /**
+     * 해당 JTI가 블랙리스트에 등록되어 있는지 확인합니다.
+     *
+     * @param jti 확인할 JWT ID
+     * @return 블랙리스트에 존재하면 {@code true}, 아니면 {@code false}
+     */
     public boolean isBlacklisted(String jti) {
         try {
             return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + jti));

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/repository/VerifyCodeRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/repository/VerifyCodeRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import team.startup.gwangjutalentfestival.domain.auth.entity.VerifyCode;
 
+/**
+ * Redis에 저장된 {@link team.startup.gwangjutalentfestival.domain.auth.entity.VerifyCode}를 관리하는 레포지토리.
+ */
 @Repository
 public interface VerifyCodeRepository extends CrudRepository<VerifyCode, String> {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/LoginService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/LoginService.java
@@ -3,6 +3,15 @@ package team.startup.gwangjutalentfestival.domain.auth.service;
 import team.startup.gwangjutalentfestival.domain.auth.presentation.data.request.LoginRequest;
 import team.startup.gwangjutalentfestival.domain.auth.presentation.data.response.TokenResponse;
 
+/**
+ * 로그인 처리 서비스 인터페이스.
+ */
 public interface LoginService {
+    /**
+     * 휴대폰 번호와 비밀번호로 로그인하고 JWT 토큰을 발급합니다.
+     *
+     * @param loginRequest 로그인 요청 정보
+     * @return 발급된 AccessToken 및 RefreshToken 정보
+     */
     TokenResponse execute(LoginRequest loginRequest);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/LogoutService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/LogoutService.java
@@ -1,5 +1,13 @@
 package team.startup.gwangjutalentfestival.domain.auth.service;
 
+/**
+ * 로그아웃 처리 서비스 인터페이스.
+ */
 public interface LogoutService {
+    /**
+     * 사용자의 RefreshToken을 삭제하고 AccessToken을 블랙리스트에 등록합니다.
+     *
+     * @param token 로그아웃할 사용자의 AccessToken 문자열
+     */
     void execute(String token);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/ReissueTokenService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/ReissueTokenService.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.auth.service;
 
 import team.startup.gwangjutalentfestival.domain.auth.presentation.data.response.TokenResponse;
 
+/**
+ * JWT 토큰 재발급 서비스 인터페이스.
+ */
 public interface ReissueTokenService {
+    /**
+     * RefreshToken을 검증하고 새로운 AccessToken과 RefreshToken을 재발급합니다.
+     *
+     * @param refreshToken 재발급에 사용할 RefreshToken 문자열
+     * @return 새로 발급된 AccessToken 및 RefreshToken 정보
+     */
     TokenResponse execute(String refreshToken);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/SendVerifyCodeService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/SendVerifyCodeService.java
@@ -2,6 +2,14 @@ package team.startup.gwangjutalentfestival.domain.auth.service;
 
 import team.startup.gwangjutalentfestival.domain.auth.presentation.data.request.SendVerifyCodeRequest;
 
+/**
+ * SMS 인증번호 발송 서비스 인터페이스.
+ */
 public interface SendVerifyCodeService {
+    /**
+     * 입력한 휴대폰 번호로 SMS 인증번호를 생성하고 발송합니다.
+     *
+     * @param request 인증번호를 발송할 휴대폰 번호 요청 정보
+     */
     void execute(SendVerifyCodeRequest request);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/SignUpService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/SignUpService.java
@@ -2,6 +2,14 @@ package team.startup.gwangjutalentfestival.domain.auth.service;
 
 import team.startup.gwangjutalentfestival.domain.auth.presentation.data.request.SignUpRequest;
 
+/**
+ * 회원가입 처리 서비스 인터페이스.
+ */
 public interface SignUpService {
+    /**
+     * 인증번호를 검증하고 신규 회원을 등록합니다.
+     *
+     * @param request 휴대폰 번호, 비밀번호, 인증번호를 포함한 회원가입 요청 정보
+     */
     void execute(SignUpRequest request);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/LoginServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/LoginServiceImpl.java
@@ -16,6 +16,10 @@ import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProperties;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProvider;
 
+/**
+ * {@link LoginService} 구현체.
+ * <p>비밀번호를 검증하고 JWT 토큰을 발급한 뒤 RefreshToken을 Redis에 저장합니다.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class LoginServiceImpl implements LoginService {
@@ -26,6 +30,14 @@ public class LoginServiceImpl implements LoginService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProperties jwtProperties;
 
+    /**
+     * 휴대폰 번호로 사용자를 조회하고 비밀번호를 검증한 뒤 JWT 토큰을 발급합니다.
+     *
+     * @param request 로그인 요청 정보 (휴대폰 번호, 비밀번호)
+     * @return 발급된 AccessToken 및 RefreshToken 정보
+     * @throws team.startup.gwangjutalentfestival.domain.user.exception.UserNotFoundException 존재하지 않는 사용자인 경우
+     * @throws InvalidPasswordException 비밀번호가 일치하지 않는 경우
+     */
     @Override
     @Transactional
     public TokenResponse execute(LoginRequest request) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/LogoutServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/LogoutServiceImpl.java
@@ -12,6 +12,10 @@ import team.startup.gwangjutalentfestival.domain.auth.service.LogoutService;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProvider;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
+/**
+ * {@link LogoutService} 구현체.
+ * <p>현재 사용자의 RefreshToken을 삭제하고, AccessToken을 블랙리스트에 등록하여 재사용을 방지합니다.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class LogoutServiceImpl implements LogoutService {
@@ -20,6 +24,12 @@ public class LogoutServiceImpl implements LogoutService {
     private final JwtProvider jwtProvider;
     private final TokenBlacklistRepository tokenBlacklistRepository;
 
+    /**
+     * 현재 인증된 사용자의 RefreshToken을 삭제하고 AccessToken을 블랙리스트에 등록합니다.
+     *
+     * @param token 로그아웃할 사용자의 AccessToken 문자열
+     * @throws InvalidAccessTokenException 토큰 파싱에 실패한 경우
+     */
     @Override
     @Transactional
     public void execute(String token) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/ReissueTokenServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/ReissueTokenServiceImpl.java
@@ -15,6 +15,10 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProperties;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProvider;
 
+/**
+ * {@link ReissueTokenService} 구현체.
+ * <p>RefreshToken의 유효성을 검증하고 새로운 AccessToken과 RefreshToken을 재발급합니다.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class ReissueTokenServiceImpl implements ReissueTokenService {
@@ -23,6 +27,14 @@ public class ReissueTokenServiceImpl implements ReissueTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProperties jwtProperties;
 
+    /**
+     * RefreshToken을 검증하고 기존 토큰을 교체한 뒤 새로운 JWT 토큰을 반환합니다.
+     *
+     * @param refreshToken 재발급에 사용할 RefreshToken 문자열
+     * @return 새로 발급된 AccessToken 및 RefreshToken 정보
+     * @throws InvalidRefreshTokenException RefreshToken이 유효하지 않거나 저장된 값과 다른 경우
+     * @throws RefreshTokenNotFoundException Redis에서 RefreshToken을 찾을 수 없는 경우
+     */
     @Override
     @Transactional
     public TokenResponse execute(String refreshToken) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/SendVerifyCodeServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/SendVerifyCodeServiceImpl.java
@@ -16,6 +16,10 @@ import team.startup.gwangjutalentfestival.global.util.RandomUtil;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * {@link SendVerifyCodeService} 구현체.
+ * <p>발송 횟수를 검증하고 6자리 인증번호를 생성하여 Redis에 저장한 뒤 SMS 발송 이벤트를 발행합니다.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class SendVerifyCodeServiceImpl implements SendVerifyCodeService {
@@ -26,6 +30,12 @@ public class SendVerifyCodeServiceImpl implements SendVerifyCodeService {
     private final RedisTemplate<String, String> redisTemplate;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    /**
+     * 발송 횟수를 검증한 뒤 인증번호를 생성하고 SMS 발송 이벤트를 발행합니다.
+     *
+     * @param request 인증번호를 발송할 휴대폰 번호 요청 정보
+     * @throws AlreadyVerifyCodeExistsException 이미 인증번호가 존재하거나 최대 발송 횟수를 초과한 경우
+     */
     @Override
     @Transactional
     public void execute(SendVerifyCodeRequest request) {
@@ -46,6 +56,13 @@ public class SendVerifyCodeServiceImpl implements SendVerifyCodeService {
         applicationEventPublisher.publishEvent(new VerifyCodeCreatedEvent(request.phoneNumber(), code));
     }
 
+    /**
+     * 해당 휴대폰 번호의 인증번호 발송 횟수를 검증합니다.
+     * <p>최대 허용 횟수를 초과하면 {@link AlreadyVerifyCodeExistsException}을 발생시킵니다.</p>
+     *
+     * @param phoneNumber 발송 횟수를 확인할 휴대폰 번호
+     * @throws AlreadyVerifyCodeExistsException 최대 발송 횟수를 초과한 경우
+     */
     private void validateSendCount(String phoneNumber) {
         String key = smsVerifyProperties.getVerifyCountKey(phoneNumber);
         Long count = redisTemplate.opsForValue().increment(key);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/service/impl/SignUpServiceImpl.java
@@ -15,6 +15,10 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.domain.auth.exception.DuplicatePhoneNumberException;
 import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 
+/**
+ * {@link SignUpService} 구현체.
+ * <p>인증번호 검증, 휴대폰 번호 중복 확인 후 신규 회원을 등록합니다.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class SignUpServiceImpl implements SignUpService {
@@ -23,6 +27,14 @@ public class SignUpServiceImpl implements SignUpService {
     private final VerifyCodeRepository verifyCodeRepository;
     private final PasswordEncoder passwordEncoder;
 
+    /**
+     * 인증번호를 검증하고 휴대폰 번호 중복 확인 후 신규 회원을 저장합니다.
+     *
+     * @param request 휴대폰 번호, 비밀번호, 인증번호를 포함한 회원가입 요청 정보
+     * @throws ExpiredVerifyCodeException    인증번호가 만료된 경우
+     * @throws InvalidVerifyCodeException    입력한 인증번호가 일치하지 않는 경우
+     * @throws DuplicatePhoneNumberException 이미 가입된 휴대폰 번호인 경우
+     */
     @Override
     @Transactional
     public void execute(SignUpRequest request) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgementEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgementEntity.java
@@ -10,6 +10,11 @@ import org.hibernate.annotations.OnDeleteAction;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
+/**
+ * 심사 점수를 저장하는 엔티티.
+ * 한 심사위원이 한 팀에 대해 입력한 5개 항목의 점수를 관리하며,
+ * (team_id, user_id) 조합에 유니크 제약이 적용된다.
+ */
 @Entity
 @Getter
 @AllArgsConstructor
@@ -54,6 +59,15 @@ public class JudgementEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
+    /**
+     * 심사 점수를 새로운 값으로 갱신한다.
+     *
+     * @param expressionCommunicationScore  표현·소통 점수
+     * @param technicalCompletenessScore    기술·완성도 점수
+     * @param creativityCompositionScore    창의·구성 점수
+     * @param stagePresencePerformanceScore 무대 장악력·퍼포먼스 점수
+     * @param teamworkStageHarmonyScore     팀워크·무대 조화 점수
+     */
     public void updateScore(
             Integer expressionCommunicationScore,
             Integer technicalCompletenessScore,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/event/JudgementTeamEvent.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/event/JudgementTeamEvent.java
@@ -4,9 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 심사 점수 저장 후 발행되는 이벤트.
+ * SSE를 통해 팀 점수 변경 사실을 구독자에게 알리기 위해 사용된다.
+ */
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class JudgementTeamEvent {
+    /** 점수가 변경된 팀의 식별자 */
     private Long teamId;
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/event/handler/JudgementTeamEventListener.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/event/handler/JudgementTeamEventListener.java
@@ -10,6 +10,10 @@ import team.startup.gwangjutalentfestival.global.sse.AbstractSseEmitterManager;
 import team.startup.gwangjutalentfestival.global.sse.AbstractSseEventListener;
 import team.startup.gwangjutalentfestival.global.sse.JudgeSseEmitterManager;
 
+/**
+ * {@link JudgementTeamEvent} 를 수신하여 SSE 구독자 전원에게 이벤트를 전송하는 리스너.
+ * 트랜잭션 커밋 이후 비동기로 동작한다.
+ */
 @Component
 @RequiredArgsConstructor
 public class JudgementTeamEventListener extends AbstractSseEventListener<JudgementTeamEvent> {
@@ -26,6 +30,11 @@ public class JudgementTeamEventListener extends AbstractSseEventListener<Judgeme
         return "PERFORM_TEAM_CHANGE";
     }
 
+    /**
+     * 트랜잭션 커밋 이후 비동기로 호출되어 모든 SSE 구독자에게 이벤트를 전송한다.
+     *
+     * @param event 발행된 {@link JudgementTeamEvent}
+     */
     @Async("asyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void execute(JudgementTeamEvent event) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/exception/JudgementTotalScoreExceededException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/exception/JudgementTotalScoreExceededException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.judge.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 심사 점수의 합계가 허용된 최대 점수(100점)를 초과할 때 발생하는 예외.
+ */
 public class JudgementTotalScoreExceededException extends GlobalException {
     public JudgementTotalScoreExceededException() {
         super(ErrorCode.JUDGEMENT_TOTAL_SCORE_EXCEEDED);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/mapper/JudgementMapper.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/mapper/JudgementMapper.java
@@ -5,6 +5,10 @@ import team.startup.gwangjutalentfestival.domain.judge.presentation.data.respons
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
 
+/**
+ * {@link JudgementEntity} 와 팀 정보를 응답 DTO로 변환하는 유틸리티 클래스.
+ * 심사 데이터가 없는 경우 기본 점수로 응답을 구성한다.
+ */
 public final class JudgementMapper {
 
     private static final int DEFAULT_EXPRESSION_COMMUNICATION_SCORE = 40;
@@ -13,6 +17,14 @@ public final class JudgementMapper {
     private static final int DEFAULT_STAGE_PRESENCE_PERFORMANCE_SCORE = 30;
     private static final int DEFAULT_TEAMWORK_STAGE_HARMONY_SCORE = 30;
 
+    /**
+     * 팀 엔티티와 심사 엔티티를 {@link GetJudgementResponse}로 변환한다.
+     * 심사 엔티티가 {@code null}인 경우 각 항목에 기본 점수가 설정된다.
+     *
+     * @param team 변환 대상 팀 엔티티
+     * @param jm   해당 팀에 대한 심사 엔티티 (없으면 {@code null})
+     * @return 심사 조회 응답 DTO
+     */
     public static GetJudgementResponse toResponse(TeamEntity team, JudgementEntity jm) {
         return new GetJudgementResponse(
                 jm != null ? jm.getId() : null,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/controller/JudgeController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/controller/JudgeController.java
@@ -20,6 +20,10 @@ import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgementScor
 
 import java.util.List;
 
+/**
+ * 심사 관련 API 엔드포인트를 제공하는 컨트롤러.
+ * SSE 연결, 점수 저장, 단일/전체 심사 조회 기능을 담당한다.
+ */
 @Tag(name = "Judge", description = "심사 API")
 @RestController
 @RequiredArgsConstructor
@@ -35,6 +39,11 @@ public class JudgeController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "SSE 연결 성공")
     })
+    /**
+     * 심사 이벤트 수신을 위한 SSE 연결을 맺는다.
+     *
+     * @return SSE 연결 객체
+     */
     @SecurityRequirement(name = "Authorization")
     @GetMapping(value = "/changes", produces = "text/event-stream")
     public SseEmitter connect() {
@@ -47,6 +56,13 @@ public class JudgeController {
             @ApiResponse(responseCode = "400", description = "잘못된 점수 입력"),
             @ApiResponse(responseCode = "404", description = "팀을 찾을 수 없음")
     })
+    /**
+     * 특정 팀에 대한 심사 점수를 저장하거나 수정한다.
+     *
+     * @param teamId  대상 팀 ID
+     * @param request 심사 점수 요청 데이터
+     * @return 204 No Content
+     */
     @SecurityRequirement(name = "Authorization")
     @PatchMapping("/{teamId}")
     public ResponseEntity<Void> saveJudgementScore(
@@ -60,6 +76,11 @@ public class JudgeController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
+    /**
+     * 현재 로그인한 심사위원의 전체 팀 심사 목록을 조회한다.
+     *
+     * @return 전체 팀 심사 응답 목록
+     */
     @SecurityRequirement(name = "Authorization")
     @GetMapping
     public ResponseEntity<List<GetJudgementResponse>> getAllJudgement() {
@@ -71,6 +92,12 @@ public class JudgeController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "팀을 찾을 수 없음")
     })
+    /**
+     * 현재 로그인한 심사위원의 특정 팀 심사를 조회한다.
+     *
+     * @param teamId 조회할 팀 ID
+     * @return 단일 팀 심사 응답
+     */
     @SecurityRequirement(name = "Authorization")
     @GetMapping("/{teamId}")
     public ResponseEntity<GetJudgementResponse> getJudgement(

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgementScoreRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgementScoreRequest.java
@@ -4,6 +4,15 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+/**
+ * 심사 점수 저장 요청 DTO.
+ *
+ * @param expressionCommunicationScore  표현·소통 점수 (0~40)
+ * @param technicalCompletenessScore    기술·완성도 점수 (0~40)
+ * @param creativityCompositionScore    창의·구성 점수 (0~30)
+ * @param stagePresencePerformanceScore 무대 장악력·퍼포먼스 점수 (0~30)
+ * @param teamworkStageHarmonyScore     팀워크·무대 조화 점수 (0~40)
+ */
 public record SaveJudgementScoreRequest(
         @NotNull @Min(0) @Max(40) Integer expressionCommunicationScore,
         @NotNull @Min(0) @Max(40) Integer technicalCompletenessScore,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/GetJudgementResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/GetJudgementResponse.java
@@ -1,5 +1,20 @@
 package team.startup.gwangjutalentfestival.domain.judge.presentation.data.response;
 
+/**
+ * 심사 조회 응답 DTO.
+ *
+ * @param judgementId                   심사 엔티티 ID (미심사 시 {@code null})
+ * @param teamId                        팀 ID
+ * @param teamName                      팀명
+ * @param expressionCommunicationScore  표현·소통 점수
+ * @param technicalCompletenessScore    기술·완성도 점수
+ * @param creativityCompositionScore    창의·구성 점수
+ * @param stagePresencePerformanceScore 무대 장악력·퍼포먼스 점수
+ * @param teamworkStageHarmonyScore     팀워크·무대 조화 점수
+ * @param totalScore                    팀의 전체 심사위원 합산 총점
+ * @param isPerformed                   공연 완료 여부
+ * @param isJudged                      현재 심사위원의 심사 완료 여부
+ */
 public record GetJudgementResponse(
         Long judgementId,
         Long teamId,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgementRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgementRepository.java
@@ -10,14 +10,37 @@ import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 심사 엔티티에 대한 데이터 접근 인터페이스.
+ */
 public interface JudgementRepository extends JpaRepository<JudgementEntity, Long> {
+
+    /**
+     * 팀과 심사위원으로 심사 엔티티를 조회한다.
+     *
+     * @param team 대상 팀 엔티티
+     * @param user 심사위원 사용자 엔티티
+     * @return 해당 팀·심사위원 조합의 심사 엔티티 (없으면 empty)
+     */
     Optional<JudgementEntity> findByTeamAndUser(TeamEntity team, UserEntity user);
 
+    /**
+     * 특정 팀에 대한 모든 심사위원의 점수 합계를 조회한다.
+     *
+     * @param team 집계 대상 팀 엔티티
+     * @return 팀의 총 심사 점수 합계 (심사 데이터가 없으면 {@code null})
+     */
     @Query("""
             SELECT SUM(j.expressionCommunicationScore + j.technicalCompletenessScore + j.creativityCompositionScore + j.stagePresencePerformanceScore + j.teamworkStageHarmonyScore)
             FROM JudgementEntity j
             WHERE j.team = :team""")
     Integer sumTotalScoreByTeam(@Param("team") TeamEntity team);
 
+    /**
+     * 특정 심사위원이 입력한 모든 심사 목록을 조회한다.
+     *
+     * @param user 심사위원 사용자 엔티티
+     * @return 해당 심사위원의 심사 목록
+     */
     List<JudgementEntity> findAllByUser(UserEntity user);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/ConnectSseJudgeEventService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/ConnectSseJudgeEventService.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.judge.service;
 
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+/**
+ * 심사 이벤트 SSE 연결을 처리하는 서비스 인터페이스.
+ */
 public interface ConnectSseJudgeEventService {
+
+    /**
+     * 현재 로그인한 심사위원에 대한 SSE 연결을 생성하고 반환한다.
+     *
+     * @return 생성된 {@link SseEmitter}
+     */
     SseEmitter execute();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/GetAllJudgementService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/GetAllJudgementService.java
@@ -4,6 +4,15 @@ import team.startup.gwangjutalentfestival.domain.judge.presentation.data.respons
 
 import java.util.List;
 
+/**
+ * 전체 팀에 대한 현재 심사위원의 심사 목록을 조회하는 서비스 인터페이스.
+ */
 public interface GetAllJudgementService {
+
+    /**
+     * 현재 로그인한 심사위원의 전체 팀 심사 목록을 반환한다.
+     *
+     * @return 전체 팀 심사 응답 목록
+     */
     List<GetJudgementResponse> execute();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgementService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgementService.java
@@ -2,6 +2,16 @@ package team.startup.gwangjutalentfestival.domain.judge.service;
 
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgementResponse;
 
+/**
+ * 특정 팀에 대한 현재 심사위원의 심사를 조회하는 서비스 인터페이스.
+ */
 public interface GetJudgementService {
+
+    /**
+     * 현재 로그인한 심사위원의 특정 팀 심사를 조회한다.
+     *
+     * @param teamId 조회할 팀 ID
+     * @return 단일 팀 심사 응답
+     */
     GetJudgementResponse execute(Long teamId);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreService.java
@@ -2,6 +2,16 @@ package team.startup.gwangjutalentfestival.domain.judge.service;
 
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgementScoreRequest;
 
+/**
+ * 팀에 대한 심사 점수를 저장하거나 수정하는 서비스 인터페이스.
+ */
 public interface SaveJudgementScoreService {
+
+    /**
+     * 현재 로그인한 심사위원의 특정 팀 심사 점수를 저장하거나 수정한다.
+     *
+     * @param request 심사 점수 요청 데이터
+     * @param teamId  대상 팀 ID
+     */
     void execute(SaveJudgementScoreRequest request, Long teamId);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeEventServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeEventServiceImpl.java
@@ -13,6 +13,10 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * {@link ConnectSseJudgeEventService} 구현체.
+ * SSE 연결 수립 후 최초 연결 이벤트를 전송하고, 주기적으로 heartbeat를 전송한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class ConnectSseJudgeEventServiceImpl implements ConnectSseJudgeEventService {
@@ -24,6 +28,12 @@ public class ConnectSseJudgeEventServiceImpl implements ConnectSseJudgeEventServ
     private final static String CONNECTED_DATA = "ok";
     private final static long HEARTBEAT_INTERVAL_SECONDS = 15;
 
+    /**
+     * 현재 로그인한 심사위원에 대한 SSE 연결을 생성하고,
+     * 초기 연결 이벤트 전송 및 heartbeat 스케줄러를 설정한 후 반환한다.
+     *
+     * @return 생성된 {@link SseEmitter}
+     */
     @Override
     public SseEmitter execute() {
         Long userId = userUtil.getCurrentUser().getId();

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetAllJudgementServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetAllJudgementServiceImpl.java
@@ -17,6 +17,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * {@link GetAllJudgementService} 구현체.
+ * 모든 팀 목록과 현재 심사위원의 심사 데이터를 결합하여 응답을 반환한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class GetAllJudgementServiceImpl implements GetAllJudgementService {
@@ -24,6 +28,12 @@ public class GetAllJudgementServiceImpl implements GetAllJudgementService {
     private final TeamRepository teamRepository;
     private final UserUtil userUtil;
 
+    /**
+     * 현재 로그인한 심사위원의 전체 팀 심사 목록을 반환한다.
+     * 심사 데이터가 없는 팀은 기본 점수로 응답을 구성한다.
+     *
+     * @return 전체 팀 심사 응답 목록
+     */
     @Override
     @Transactional(readOnly = true)
     public List<GetJudgementResponse> execute() {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgementServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgementServiceImpl.java
@@ -14,6 +14,10 @@ import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
+/**
+ * {@link GetJudgementService} 구현체.
+ * 특정 팀에 대한 현재 심사위원의 심사 데이터를 조회하여 반환한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class GetJudgementServiceImpl implements GetJudgementService {
@@ -21,6 +25,13 @@ public class GetJudgementServiceImpl implements GetJudgementService {
     private final TeamRepository teamRepository;
     private final JudgementRepository judgementRepository;
 
+    /**
+     * 현재 로그인한 심사위원의 특정 팀 심사를 조회한다.
+     * 심사 데이터가 없으면 기본 점수로 응답을 구성한다.
+     *
+     * @param teamId 조회할 팀 ID
+     * @return 단일 팀 심사 응답
+     */
     @Override
     @Transactional(readOnly = true)
     public GetJudgementResponse execute(Long teamId) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
@@ -16,6 +16,11 @@ import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
+/**
+ * {@link SaveJudgementScoreService} 구현체.
+ * 심사 점수를 저장 또는 수정하고, 팀 총점을 갱신한다.
+ * 점수 저장 후 팀 랭킹 캐시를 초기화한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService {
@@ -24,6 +29,14 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
     private final TeamRepository teamRepository;
     private final UserUtil userUtil;
 
+    /**
+     * 현재 로그인한 심사위원의 특정 팀 심사 점수를 저장하거나 수정한다.
+     * 기존 심사 데이터가 있으면 점수를 갱신하고, 없으면 새로 생성한다.
+     * 저장 후 팀 총점을 재계산하며, 총점이 100점을 초과하면 예외를 발생시킨다.
+     *
+     * @param request 심사 점수 요청 데이터
+     * @param teamId  대상 팀 ID
+     */
     @Override
     @Transactional
     @CacheEvict(cacheNames = CacheConfig.TEAM_RANKING, allEntries = true)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/entity/SeatBanEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/entity/SeatBanEntity.java
@@ -7,6 +7,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
+/**
+ * 관리자가 차단한 좌석 정보를 저장하는 엔티티.
+ * 동일한 구역과 번호의 조합은 유니크 제약으로 중복 차단을 방지한다.
+ */
 @Entity
 @Table(
         name = "seat_ban",

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/entity/SeatEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/entity/SeatEntity.java
@@ -9,6 +9,10 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
+/**
+ * 사용자의 좌석 예약 정보를 저장하는 엔티티.
+ * 동일한 구역과 번호의 조합은 유니크 제약으로 중복 예약을 방지한다.
+ */
 @Entity
 @Getter
 @NoArgsConstructor

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/event/SeatChangeEvent.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/event/SeatChangeEvent.java
@@ -1,5 +1,13 @@
 package team.startup.gwangjutalentfestival.domain.seat.event;
 
+/**
+ * 좌석 상태 변경 시 발행되는 이벤트.
+ * 예약 또는 차단 처리 후 SSE로 클라이언트에 변경 사항을 전달하는 데 사용된다.
+ *
+ * @param seatSection  변경된 좌석의 구역 (A~J)
+ * @param seatNumber   변경된 좌석 번호
+ * @param isAvailable  좌석 예약 가능 여부 (true: 예약 가능, false: 예약 불가)
+ */
 public record SeatChangeEvent(
         String seatSection,
         Integer seatNumber,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/event/handler/SeatChangeEventListener.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/event/handler/SeatChangeEventListener.java
@@ -10,6 +10,10 @@ import team.startup.gwangjutalentfestival.global.sse.AbstractSseEmitterManager;
 import team.startup.gwangjutalentfestival.global.sse.AbstractSseEventListener;
 import team.startup.gwangjutalentfestival.global.sse.SeatSseEmitterManager;
 
+/**
+ * 좌석 변경 이벤트를 수신하여 모든 SSE 구독 클라이언트에 알림을 전송하는 리스너.
+ * 트랜잭션 커밋 이후 비동기로 실행되며, "SEAT_CHANGE" 이름의 이벤트를 발행한다.
+ */
 @Component
 @RequiredArgsConstructor
 public class SeatChangeEventListener extends AbstractSseEventListener<SeatChangeEvent> {
@@ -26,6 +30,11 @@ public class SeatChangeEventListener extends AbstractSseEventListener<SeatChange
         return "SEAT_CHANGE";
     }
 
+    /**
+     * 트랜잭션 커밋 후 비동기로 모든 SSE 클라이언트에 좌석 변경 이벤트를 전송한다.
+     *
+     * @param event 전송할 좌석 변경 이벤트
+     */
     @Async("asyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void execute(SeatChangeEvent event) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/InvalidSeatSectionException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/InvalidSeatSectionException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.seat.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 유효하지 않은 좌석 구역(A~J 범위 외)이 입력되었을 때 발생하는 예외.
+ */
 public class InvalidSeatSectionException extends GlobalException {
     public InvalidSeatSectionException() {
         super(ErrorCode.INVALID_SEAT_SECTION);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatAlreadyBannedException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatAlreadyBannedException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.seat.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 이미 차단 처리된 좌석을 다시 차단하려 할 때 발생하는 예외.
+ */
 public class SeatAlreadyBannedException extends GlobalException {
     public SeatAlreadyBannedException() {
         super(ErrorCode.SEAT_ALREADY_BANNED);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatAlreadyReservedException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatAlreadyReservedException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.seat.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 이미 다른 사용자가 예약한 좌석을 예약하려 할 때 발생하는 예외.
+ */
 public class SeatAlreadyReservedException extends GlobalException {
     public SeatAlreadyReservedException() {
         super(ErrorCode.SEAT_ALREADY_RESERVED);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatBanNotFoundException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatBanNotFoundException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.seat.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 차단 취소 요청 시 해당 구역·번호의 차단 정보가 존재하지 않을 때 발생하는 예외.
+ */
 public class SeatBanNotFoundException extends GlobalException {
     public SeatBanNotFoundException() {
         super(ErrorCode.SEAT_BAN_NOT_FOUND);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatBannedException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatBannedException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.seat.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 관리자가 차단한 좌석을 예약하려 할 때 발생하는 예외.
+ */
 public class SeatBannedException extends GlobalException {
     public SeatBannedException() {
         super(ErrorCode.SEAT_BANNED);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatNotExistsInSectionException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatNotExistsInSectionException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.seat.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 요청한 좌석 번호가 해당 구역의 좌석 범위를 벗어날 때 발생하는 예외.
+ */
 public class SeatNotExistsInSectionException extends GlobalException {
     public SeatNotExistsInSectionException() {
         super(ErrorCode.SEAT_NOT_EXISTS_IN_SECTION);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatNotFoundException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatNotFoundException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.seat.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 조회 또는 취소 요청 시 해당 사용자의 예약 좌석이 존재하지 않을 때 발생하는 예외.
+ */
 public class SeatNotFoundException extends GlobalException {
     public SeatNotFoundException() {
         super(ErrorCode.SEAT_NOT_FOUND);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatReservationLimitExceededException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatReservationLimitExceededException.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.domain.seat.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 사용자가 예약 가능한 좌석 수 제한을 초과했을 때 발생하는 예외.
+ * 일반 사용자는 1석, 공연자는 3석까지 예약 가능하다.
+ */
 public class SeatReservationLimitExceededException extends GlobalException {
     public SeatReservationLimitExceededException() {
         super(ErrorCode.SEAT_RESERVATION_LIMIT_EXCEEDED);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatController.java
@@ -25,6 +25,9 @@ import team.startup.gwangjutalentfestival.domain.seat.service.admin.CancelSeatBa
 
 import java.util.List;
 
+/**
+ * 좌석 예약, 차단, 조회, SSE 연결 등 좌석 관련 기능을 제공하는 컨트롤러.
+ */
 @Tag(name = "Seat", description = "좌석 API")
 @RestController
 @RequestMapping("/seat")
@@ -42,6 +45,12 @@ public class SeatController {
     private final GetAllSeatsService getAllSeatsService;
     private final ConnectSseSeatEventService connectSseSeatEventService;
 
+    /**
+     * 좌석을 예약한다.
+     *
+     * @param reservationSeatRequest 예약할 좌석의 구역 및 번호 정보
+     * @return 201 Created
+     */
     @Operation(summary = "좌석 예약", description = "좌석을 예약합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -57,6 +66,12 @@ public class SeatController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    /**
+     * 관리자가 특정 좌석을 차단한다.
+     *
+     * @param banSeatRequest 차단할 좌석의 구역, 번호, 적용 역할 정보
+     * @return 201 Created
+     */
     @Operation(summary = "좌석 차단", description = "관리자가 특정 좌석을 차단합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -73,6 +88,11 @@ public class SeatController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    /**
+     * 현재 로그인한 사용자의 예약 좌석을 조회한다.
+     *
+     * @return 예약 좌석의 구역 및 번호
+     */
     @Operation(summary = "내 좌석 조회", description = "현재 로그인한 사용자의 예약 좌석을 조회합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -85,6 +105,11 @@ public class SeatController {
         return ResponseEntity.ok(getCurrentUserSeatService.execute());
     }
 
+    /**
+     * 현재 로그인한 공연자가 예약한 좌석 목록을 조회한다.
+     *
+     * @return 공연자의 예약 좌석 구역 및 번호 목록
+     */
     @Operation(summary = "공연자 예약 좌석 목록 조회", description = "현재 로그인한 공연자의 예약 좌석 목록을 조회합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -97,6 +122,12 @@ public class SeatController {
         return ResponseEntity.ok(getByCurrentPerformerSeatsService.execute());
     }
 
+    /**
+     * 특정 구역의 좌석 예약 가능 여부 목록을 조회한다.
+     *
+     * @param section 조회할 좌석 구역 (A~J)
+     * @return 해당 구역의 좌석별 예약 가능 여부 목록
+     */
     @Operation(summary = "구역별 좌석 현황 조회", description = "특정 구역의 좌석 예약 가능 여부 목록을 조회합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -110,6 +141,11 @@ public class SeatController {
         return ResponseEntity.ok(getSeatsBySectionService.execute(section));
     }
 
+    /**
+     * 전체 구역의 좌석 현황을 조회한다.
+     *
+     * @return 구역별 좌석 예약 가능 여부 맵
+     */
     @Operation(summary = "전체 좌석 조회", description = "전체 좌석 현황을 조회합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -122,6 +158,11 @@ public class SeatController {
         return ResponseEntity.ok(getAllSeatsService.execute());
     }
 
+    /**
+     * 좌석 실시간 이벤트를 수신하기 위한 SSE 연결을 생성한다.
+     *
+     * @return SSE 이미터 객체
+     */
     @Operation(summary = "좌석 SSE 연결", description = "좌석 실시간 이벤트를 수신하기 위한 SSE 연결을 맺습니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -133,6 +174,11 @@ public class SeatController {
         return connectSseSeatEventService.execute();
     }
 
+    /**
+     * 현재 로그인한 사용자의 좌석 예약을 취소한다.
+     *
+     * @return 204 No Content
+     */
     @Operation(summary = "좌석 예약 취소", description = "본인의 좌석 예약을 취소합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -146,6 +192,12 @@ public class SeatController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * 관리자가 특정 좌석의 차단을 해제한다.
+     *
+     * @param cancelSeatBanRequest 차단 해제할 좌석의 구역 및 번호 정보
+     * @return 204 No Content
+     */
     @Operation(summary = "좌석 차단 취소", description = "관리자가 특정 좌석의 차단을 취소합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({
@@ -161,6 +213,12 @@ public class SeatController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * 공연자가 본인이 예약한 특정 좌석을 취소한다.
+     *
+     * @param request 취소할 좌석의 구역 및 번호 정보
+     * @return 204 No Content
+     */
     @Operation(summary = "공연자 좌석 예약 취소", description = "공연자가 특정 사용자의 좌석 예약을 취소합니다.")
     @SecurityRequirement(name = "Authorization")
     @ApiResponses({

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/BanSeatRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/BanSeatRequest.java
@@ -6,6 +6,13 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
+/**
+ * 좌석 차단 요청 DTO.
+ *
+ * @param seatSection 차단할 좌석 구역 (A~J)
+ * @param seatNumber  차단할 좌석 번호 (1~154)
+ * @param role        차단을 적용할 사용자 역할
+ */
 public record BanSeatRequest(
         @Pattern(
                 regexp = "^[A-J]$",

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/CancelSeatBanRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/CancelSeatBanRequest.java
@@ -5,6 +5,12 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+/**
+ * 좌석 차단 취소 요청 DTO.
+ *
+ * @param seatSection 차단을 해제할 좌석 구역 (A~J)
+ * @param seatNumber  차단을 해제할 좌석 번호 (1~154)
+ */
 public record CancelSeatBanRequest(
         @Pattern(
                 regexp = "^[A-J]$",

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/PerformerCancelSeatReservationRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/PerformerCancelSeatReservationRequest.java
@@ -5,6 +5,12 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+/**
+ * 공연자의 좌석 예약 취소 요청 DTO.
+ *
+ * @param seatSection 취소할 좌석 구역 (A~J)
+ * @param seatNumber  취소할 좌석 번호 (1~154)
+ */
 public record PerformerCancelSeatReservationRequest(
         @Pattern(
                 regexp = "^[A-J]$",

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/ReservationSeatRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/ReservationSeatRequest.java
@@ -5,6 +5,12 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+/**
+ * 좌석 예약 요청 DTO.
+ *
+ * @param seatSection 예약할 좌석 구역 (A~J)
+ * @param seatNumber  예약할 좌석 번호 (1~154)
+ */
 public record ReservationSeatRequest(
         @Pattern(
                 regexp = "^[A-J]$",

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetAllSeatsResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetAllSeatsResponse.java
@@ -2,6 +2,11 @@ package team.startup.gwangjutalentfestival.domain.seat.presentation.data.respons
 
 import java.util.Map;
 
+/**
+ * 전체 구역 좌석 현황 응답 DTO.
+ *
+ * @param sections 구역 코드(A~J)를 키로, 해당 구역의 좌석 목록을 값으로 갖는 맵
+ */
 public record GetAllSeatsResponse(
     Map<String, GetSeatsBySectionResponse> sections
 ) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetSeatResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetSeatResponse.java
@@ -1,5 +1,11 @@
 package team.startup.gwangjutalentfestival.domain.seat.presentation.data.response;
 
+/**
+ * 단일 좌석 정보 응답 DTO.
+ *
+ * @param seatSection 좌석 구역 (A~J)
+ * @param seatNumber  좌석 번호
+ */
 public record GetSeatResponse(
         String seatSection,
         Integer seatNumber

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetSeatsBySectionResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetSeatsBySectionResponse.java
@@ -2,6 +2,11 @@ package team.startup.gwangjutalentfestival.domain.seat.presentation.data.respons
 
 import java.util.List;
 
+/**
+ * 특정 구역의 좌석 현황 응답 DTO.
+ *
+ * @param seats 좌석 번호 순서대로 예약 가능 여부(true: 예약 가능, false: 예약 불가)를 담은 목록
+ */
 public record GetSeatsBySectionResponse(
         List<Boolean> seats
 ) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/SectionSeatNumber.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/SectionSeatNumber.java
@@ -1,5 +1,12 @@
 package team.startup.gwangjutalentfestival.domain.seat.presentation.data.response;
 
+/**
+ * 구역과 좌석 번호를 묶어 전달하는 내부 DTO.
+ * QueryDSL 프로젝션 결과를 담는 데 사용된다.
+ *
+ * @param section    좌석 구역 (A~J)
+ * @param seatNumber 좌석 번호
+ */
 public record SectionSeatNumber(
         String section,
         Integer seatNumber

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatBanRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatBanRepository.java
@@ -5,8 +5,26 @@ import team.startup.gwangjutalentfestival.domain.seat.entity.SeatBanEntity;
 
 import java.util.Optional;
 
+/**
+ * 좌석 차단 정보에 대한 JPA 레포지토리.
+ */
 public interface SeatBanRepository extends JpaRepository<SeatBanEntity, Long> {
+
+    /**
+     * 특정 구역과 번호의 차단 정보가 존재하는지 확인한다.
+     *
+     * @param seatSection 좌석 구역
+     * @param seatNumber  좌석 번호
+     * @return 차단 정보 존재 여부
+     */
     boolean existsBySeatSectionAndSeatNumber(String seatSection, Integer seatNumber);
 
+    /**
+     * 특정 구역과 번호에 해당하는 차단 정보를 조회한다.
+     *
+     * @param seatSection 좌석 구역
+     * @param seatNumber  좌석 번호
+     * @return 차단 엔티티 (없으면 empty)
+     */
     Optional<SeatBanEntity> findBySeatSectionAndSeatNumber(String seatSection, Integer seatNumber);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatReservationRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatReservationRepository.java
@@ -9,22 +9,73 @@ import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 좌석 예약 정보에 대한 JPA 레포지토리.
+ */
 public interface SeatReservationRepository extends JpaRepository<SeatEntity, Long> {
+
+    /**
+     * 특정 구역과 번호의 예약 정보가 존재하는지 확인한다.
+     *
+     * @param seatSection 좌석 구역
+     * @param seatNumber  좌석 번호
+     * @return 예약 존재 여부
+     */
     boolean existsBySeatSectionAndSeatNumber(String seatSection, Integer seatNumber);
 
+    /**
+     * 특정 좌석의 예약 여부와 차단 여부를 비트 합산하여 반환한다.
+     * 반환값: 0=사용가능, 1=예약됨, 2=차단됨, 3=예약+차단
+     *
+     * @param seatSection 좌석 구역
+     * @param seatNumber  좌석 번호
+     * @return 가용성 비트 플래그
+     */
     @Query(value =
             "SELECT EXISTS(SELECT 1 FROM seat WHERE seat_section = :section AND seat_number = :number)" +
             " + EXISTS(SELECT 1 FROM seat_ban WHERE seat_section = :section AND seat_number = :number) * 2",
             nativeQuery = true)
     int checkAvailability(@Param("section") String seatSection, @Param("number") Integer seatNumber);
 
+    /**
+     * 특정 사용자의 예약 좌석 수를 조회한다.
+     *
+     * @param user 사용자 엔티티
+     * @return 예약 좌석 수
+     */
     long countByUser(UserEntity user);
 
+    /**
+     * 특정 사용자 ID의 예약 좌석 수를 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @return 예약 좌석 수
+     */
     long countByUserId(Long userId);
 
+    /**
+     * 특정 사용자의 예약 좌석을 조회한다.
+     *
+     * @param user 사용자 엔티티
+     * @return 예약 좌석 엔티티 (없으면 empty)
+     */
     Optional<SeatEntity> findByUser(UserEntity user);
 
+    /**
+     * 특정 구역·번호·사용자 조건에 해당하는 예약 좌석을 조회한다.
+     *
+     * @param seatSection 좌석 구역
+     * @param seatNumber  좌석 번호
+     * @param user        사용자 엔티티
+     * @return 예약 좌석 엔티티 (없으면 empty)
+     */
     Optional<SeatEntity> findBySeatSectionAndSeatNumberAndUser(String seatSection, Integer seatNumber, UserEntity user);
 
+    /**
+     * 특정 사용자 ID의 모든 예약 좌석을 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @return 예약 좌석 목록
+     */
     List<SeatEntity> findAllByUserId(Long userId);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/SeatBanCustomRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/SeatBanCustomRepository.java
@@ -6,7 +6,25 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * 좌석 차단 정보에 대한 QueryDSL 커스텀 레포지토리 인터페이스.
+ */
 public interface SeatBanCustomRepository {
+
+    /**
+     * 특정 역할에 적용된 모든 차단 좌석의 구역과 번호 목록을 조회한다.
+     *
+     * @param role 조회할 사용자 역할
+     * @return 차단된 좌석의 구역·번호 목록
+     */
     List<SectionSeatNumber> findSeatNumbersByRole(Role role);
+
+    /**
+     * 특정 구역에서 특정 역할에 적용된 차단 좌석 번호 집합을 조회한다.
+     *
+     * @param seatSection 좌석 구역
+     * @param role        사용자 역할
+     * @return 차단된 좌석 번호 집합
+     */
     Set<Integer> findSeatNumbersBySeatSectionAndRole(String seatSection, Role role);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/SeatReservationCustomRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/SeatReservationCustomRepository.java
@@ -5,7 +5,23 @@ import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response
 import java.util.List;
 import java.util.Set;
 
+/**
+ * 좌석 예약 정보에 대한 QueryDSL 커스텀 레포지토리 인터페이스.
+ */
 public interface SeatReservationCustomRepository {
+
+    /**
+     * 예약된 모든 좌석의 구역과 번호 목록을 조회한다.
+     *
+     * @return 예약된 좌석의 구역·번호 목록
+     */
     List<SectionSeatNumber> findAllSeatNumbers();
+
+    /**
+     * 특정 구역에서 예약된 좌석 번호 집합을 조회한다.
+     *
+     * @param seatSection 좌석 구역
+     * @return 예약된 좌석 번호 집합
+     */
     Set<Integer> findSeatNumbersBySeatSection(String seatSection);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/impl/SeatBanCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/impl/SeatBanCustomRepositoryImpl.java
@@ -13,6 +13,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * {@link SeatBanCustomRepository}의 QueryDSL 구현체.
+ */
 @Repository
 @RequiredArgsConstructor
 public class SeatBanCustomRepositoryImpl implements SeatBanCustomRepository {
@@ -21,6 +24,9 @@ public class SeatBanCustomRepositoryImpl implements SeatBanCustomRepository {
 
     private static final QSeatBanEntity seatBan = QSeatBanEntity.seatBanEntity;
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<SectionSeatNumber> findSeatNumbersByRole(Role role) {
         return queryFactory
@@ -34,6 +40,9 @@ public class SeatBanCustomRepositoryImpl implements SeatBanCustomRepository {
                 .fetch();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Set<Integer> findSeatNumbersBySeatSectionAndRole(String seatSection, Role role) {
         return new HashSet<>(queryFactory

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/impl/SeatReservationCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/impl/SeatReservationCustomRepositoryImpl.java
@@ -12,6 +12,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * {@link SeatReservationCustomRepository}의 QueryDSL 구현체.
+ */
 @Repository
 @RequiredArgsConstructor
 public class SeatReservationCustomRepositoryImpl implements SeatReservationCustomRepository {
@@ -20,6 +23,9 @@ public class SeatReservationCustomRepositoryImpl implements SeatReservationCusto
 
     private static final QSeatEntity seat = QSeatEntity.seatEntity;
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<SectionSeatNumber> findAllSeatNumbers() {
         return queryFactory
@@ -32,6 +38,9 @@ public class SeatReservationCustomRepositoryImpl implements SeatReservationCusto
                 .fetch();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Set<Integer> findSeatNumbersBySeatSection(String seatSection) {
         return new HashSet<>(queryFactory

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/CancelSeatReservationService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/CancelSeatReservationService.java
@@ -1,5 +1,12 @@
 package team.startup.gwangjutalentfestival.domain.seat.service;
 
+/**
+ * 현재 로그인한 사용자의 좌석 예약을 취소하는 서비스 인터페이스.
+ */
 public interface CancelSeatReservationService {
+
+    /**
+     * 현재 로그인한 사용자의 좌석 예약을 취소한다.
+     */
     void execute();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/ConnectSseSeatEventService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/ConnectSseSeatEventService.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.seat.service;
 
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+/**
+ * 좌석 실시간 변경 이벤트를 수신하기 위한 SSE 연결을 생성하는 서비스 인터페이스.
+ */
 public interface ConnectSseSeatEventService {
+
+    /**
+     * SSE 연결을 생성하고 이미터를 반환한다.
+     *
+     * @return 생성된 SSE 이미터
+     */
     SseEmitter execute();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetAllSeatsService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetAllSeatsService.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.seat.service;
 
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetAllSeatsResponse;
 
+/**
+ * 전체 구역의 좌석 현황을 조회하는 서비스 인터페이스.
+ */
 public interface GetAllSeatsService {
+
+    /**
+     * 현재 사용자 역할에 맞는 전체 구역 좌석 현황을 반환한다.
+     *
+     * @return 구역별 좌석 가용 여부 맵
+     */
     GetAllSeatsResponse execute();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetByCurrentPerformerSeatsService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetByCurrentPerformerSeatsService.java
@@ -4,6 +4,15 @@ import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response
 
 import java.util.List;
 
+/**
+ * 현재 로그인한 공연자가 예약한 좌석 목록을 조회하는 서비스 인터페이스.
+ */
 public interface GetByCurrentPerformerSeatsService {
+
+    /**
+     * 현재 로그인한 공연자의 예약 좌석 목록을 반환한다.
+     *
+     * @return 공연자의 예약 좌석 목록
+     */
     List<GetSeatResponse> execute();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetCurrentUserSeatService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetCurrentUserSeatService.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.seat.service;
 
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetSeatResponse;
 
+/**
+ * 현재 로그인한 사용자의 예약 좌석을 조회하는 서비스 인터페이스.
+ */
 public interface GetCurrentUserSeatService {
+
+    /**
+     * 현재 로그인한 사용자의 예약 좌석 정보를 반환한다.
+     *
+     * @return 예약 좌석 구역 및 번호
+     */
     GetSeatResponse execute();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetSeatsBySectionService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetSeatsBySectionService.java
@@ -2,6 +2,16 @@ package team.startup.gwangjutalentfestival.domain.seat.service;
 
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetSeatsBySectionResponse;
 
+/**
+ * 특정 구역의 좌석 현황을 조회하는 서비스 인터페이스.
+ */
 public interface GetSeatsBySectionService {
+
+    /**
+     * 현재 사용자 역할에 맞는 특정 구역의 좌석 가용 여부 목록을 반환한다.
+     *
+     * @param section 조회할 좌석 구역 (A~J)
+     * @return 해당 구역의 좌석별 예약 가능 여부 목록
+     */
     GetSeatsBySectionResponse execute(String section);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/PerformerCancelSeatReservationService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/PerformerCancelSeatReservationService.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.seat.service;
 
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.PerformerCancelSeatReservationRequest;
 
+/**
+ * 공연자가 본인의 특정 좌석 예약을 취소하는 서비스 인터페이스.
+ */
 public interface PerformerCancelSeatReservationService {
+
+    /**
+     * 공연자의 특정 좌석 예약을 취소한다.
+     *
+     * @param request 취소할 좌석의 구역 및 번호 정보
+     */
     void execute(PerformerCancelSeatReservationRequest request);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/ReservationSeatService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/ReservationSeatService.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.seat.service;
 
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.ReservationSeatRequest;
 
+/**
+ * 좌석 예약을 처리하는 서비스 인터페이스.
+ */
 public interface ReservationSeatService {
+
+    /**
+     * 요청한 좌석을 현재 로그인한 사용자에게 예약한다.
+     *
+     * @param request 예약할 좌석의 구역 및 번호 정보
+     */
     void execute(ReservationSeatRequest request);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/BanSeatService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/BanSeatService.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.seat.service.admin;
 
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.BanSeatRequest;
 
+/**
+ * 관리자가 특정 좌석을 차단하는 서비스 인터페이스.
+ */
 public interface BanSeatService {
+
+    /**
+     * 요청한 좌석을 특정 역할에 대해 차단 처리한다.
+     *
+     * @param request 차단할 좌석의 구역, 번호, 적용 역할 정보
+     */
     void execute(BanSeatRequest request);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/CancelSeatBanService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/CancelSeatBanService.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.seat.service.admin;
 
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.CancelSeatBanRequest;
 
+/**
+ * 관리자가 특정 좌석의 차단을 해제하는 서비스 인터페이스.
+ */
 public interface CancelSeatBanService {
+
+    /**
+     * 요청한 좌석의 차단을 해제한다.
+     *
+     * @param request 차단 해제할 좌석의 구역 및 번호 정보
+     */
     void execute(CancelSeatBanRequest request);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImpl.java
@@ -11,6 +11,10 @@ import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.admin.BanSeatService;
 
+/**
+ * {@link BanSeatService}의 구현체.
+ * 좌석 차단 후 SSE 이벤트를 발행하여 클라이언트에 변경 사항을 알린다.
+ */
 @Service
 @RequiredArgsConstructor
 public class BanSeatServiceImpl implements BanSeatService {
@@ -18,6 +22,12 @@ public class BanSeatServiceImpl implements BanSeatService {
     private final SeatBanRepository seatBanRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    /**
+     * 요청한 좌석을 차단 처리하고 SSE 이벤트를 발행한다.
+     *
+     * @param request 차단할 좌석의 구역, 번호, 적용 역할 정보
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyBannedException 이미 차단된 좌석일 때
+     */
     @Override
     @Transactional
     public void execute(BanSeatRequest request) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/CancelSeatBanServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/CancelSeatBanServiceImpl.java
@@ -11,6 +11,10 @@ import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.admin.CancelSeatBanService;
 
+/**
+ * {@link CancelSeatBanService}의 구현체.
+ * 좌석 차단 해제 후 SSE 이벤트를 발행하여 클라이언트에 변경 사항을 알린다.
+ */
 @Service
 @RequiredArgsConstructor
 public class CancelSeatBanServiceImpl implements CancelSeatBanService {
@@ -18,6 +22,12 @@ public class CancelSeatBanServiceImpl implements CancelSeatBanService {
     private final SeatBanRepository seatBanRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    /**
+     * 요청한 좌석의 차단을 해제하고 SSE 이벤트를 발행한다.
+     *
+     * @param request 차단 해제할 좌석의 구역 및 번호 정보
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatBanNotFoundException 해당 좌석의 차단 정보가 없을 때
+     */
     @Override
     @Transactional
     public void execute(CancelSeatBanRequest request) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImpl.java
@@ -15,6 +15,10 @@ import team.startup.gwangjutalentfestival.domain.seat.service.CancelSeatReservat
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
+/**
+ * {@link CancelSeatReservationService}의 구현체.
+ * 현재 로그인한 사용자의 예약을 삭제하고 SSE 이벤트를 발행하며, 관련 캐시를 무효화한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class CancelSeatReservationServiceImpl implements CancelSeatReservationService {
@@ -23,6 +27,11 @@ public class CancelSeatReservationServiceImpl implements CancelSeatReservationSe
     private final UserUtil userUtil;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    /**
+     * 현재 로그인한 사용자의 좌석 예약을 취소하고 SSE 이벤트를 발행한다.
+     *
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException 예약된 좌석이 없을 때
+     */
     @Override
     @Transactional
     @Caching(evict = {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ConnectSseSeatEventServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ConnectSseSeatEventServiceImpl.java
@@ -11,6 +11,10 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 import java.io.IOException;
 import java.time.Duration;
 
+/**
+ * {@link ConnectSseSeatEventService}의 구현체.
+ * SSE 이미터를 생성하고 초기 연결 이벤트를 전송하며, 15초 간격으로 하트비트를 전송한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class ConnectSseSeatEventServiceImpl implements ConnectSseSeatEventService {
@@ -22,6 +26,12 @@ public class ConnectSseSeatEventServiceImpl implements ConnectSseSeatEventServic
     private static final String CONNECTED_EVENT_NAME = "connected";
     private static final String HEARTBEAT_EVENT_NAME = "heartbeat";
 
+    /**
+     * SSE 연결을 생성하고 초기 연결 이벤트를 전송한 뒤 이미터를 반환한다.
+     * 연결 완료·타임아웃·에러 시 하트비트 스케줄러를 취소한다.
+     *
+     * @return 생성된 SSE 이미터
+     */
     @Override
     public SseEmitter execute() {
         String phoneNumber = userUtil.getCurrentUser().getPhoneNumber();

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
@@ -19,6 +19,10 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+/**
+ * {@link GetAllSeatsService}의 구현체.
+ * 현재 사용자 역할을 기준으로 전체 구역 좌석 현황을 조회하며, Redis 캐시를 활용한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class GetAllSeatsServiceImpl implements GetAllSeatsService {
@@ -28,6 +32,12 @@ public class GetAllSeatsServiceImpl implements GetAllSeatsService {
     private final SeatBanCustomRepository seatBanCustomRepository;
     private final SeatReservationCustomRepository seatReservationCustomRepository;
 
+    /**
+     * 현재 사용자 역할에 맞는 전체 구역 좌석 현황을 반환한다.
+     * 역할별로 캐시가 분리되어 적용된다.
+     *
+     * @return 구역별 좌석 가용 여부 맵
+     */
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.SEATS_ALL, key = "@userUtil.currentUserRole()")
@@ -60,6 +70,14 @@ public class GetAllSeatsServiceImpl implements GetAllSeatsService {
         return new GetAllSeatsResponse(responseMap);
     }
 
+    /**
+     * 특정 구역의 차단·예약 정보를 기반으로 좌석 가용 여부 목록을 생성한다.
+     *
+     * @param section      좌석 구역
+     * @param bans         차단된 좌석 번호 집합
+     * @param reservations 예약된 좌석 번호 집합
+     * @return 좌석별 예약 가능 여부 목록
+     */
     private GetSeatsBySectionResponse getSeatResponse(
             String section, Set<Integer> bans, Set<Integer> reservations) {
         Integer seatLastNumber = seatUtil.getMaxSeats(section);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetByCurrentPerformerSeatsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetByCurrentPerformerSeatsServiceImpl.java
@@ -11,6 +11,10 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.util.List;
 
+/**
+ * {@link GetByCurrentPerformerSeatsService}의 구현체.
+ * 현재 로그인한 공연자의 ID로 예약된 모든 좌석을 조회한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class GetByCurrentPerformerSeatsServiceImpl implements GetByCurrentPerformerSeatsService {
@@ -18,6 +22,11 @@ public class GetByCurrentPerformerSeatsServiceImpl implements GetByCurrentPerfor
     private final SeatReservationRepository seatReservationRepository;
     private final UserUtil userUtil;
 
+    /**
+     * 현재 로그인한 공연자의 예약 좌석 목록을 반환한다.
+     *
+     * @return 공연자의 예약 좌석 목록
+     */
     @Override
     @Transactional(readOnly = true)
     public List<GetSeatResponse> execute() {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetCurrentUserSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetCurrentUserSeatServiceImpl.java
@@ -11,6 +11,10 @@ import team.startup.gwangjutalentfestival.domain.seat.service.GetCurrentUserSeat
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
+/**
+ * {@link GetCurrentUserSeatService}의 구현체.
+ * 현재 로그인한 사용자의 예약 좌석을 조회한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class GetCurrentUserSeatServiceImpl implements GetCurrentUserSeatService {
@@ -18,6 +22,12 @@ public class GetCurrentUserSeatServiceImpl implements GetCurrentUserSeatService 
     private final SeatReservationRepository seatReservationRepository;
     private final UserUtil userUtil;
 
+    /**
+     * 현재 로그인한 사용자의 예약 좌석 정보를 반환한다.
+     *
+     * @return 예약 좌석 구역 및 번호
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException 예약된 좌석이 없을 때
+     */
     @Override
     @Transactional(readOnly = true)
     public GetSeatResponse execute() {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
@@ -17,6 +17,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+/**
+ * {@link GetSeatsBySectionService}의 구현체.
+ * 현재 사용자 역할을 기준으로 특정 구역의 좌석 가용 여부를 조회하며, Redis 캐시를 활용한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class GetSeatsBySectionServiceImpl implements GetSeatsBySectionService {
@@ -26,6 +30,13 @@ public class GetSeatsBySectionServiceImpl implements GetSeatsBySectionService {
     private final SeatReservationCustomRepository seatReservationCustomRepository;
     private final SeatBanCustomRepository seatBanCustomRepository;
 
+    /**
+     * 현재 사용자 역할에 맞는 특정 구역의 좌석 가용 여부 목록을 반환한다.
+     * 구역·역할 조합으로 캐시가 분리되어 적용된다.
+     *
+     * @param section 조회할 좌석 구역 (A~J)
+     * @return 해당 구역의 좌석별 예약 가능 여부 목록
+     */
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.SEATS_SECTION, key = "#section + ':' + @userUtil.currentUserRole()")

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImpl.java
@@ -16,6 +16,10 @@ import team.startup.gwangjutalentfestival.domain.seat.service.PerformerCancelSea
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
+/**
+ * {@link PerformerCancelSeatReservationService}의 구현체.
+ * 공연자 본인의 특정 좌석 예약을 취소하고 SSE 이벤트를 발행하며, 관련 캐시를 무효화한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class PerformerCancelSeatReservationServiceImpl implements PerformerCancelSeatReservationService {
@@ -24,6 +28,12 @@ public class PerformerCancelSeatReservationServiceImpl implements PerformerCance
     private final UserUtil userUtil;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    /**
+     * 공연자의 특정 좌석 예약을 취소하고 SSE 이벤트를 발행한다.
+     *
+     * @param request 취소할 좌석의 구역 및 번호 정보
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException 해당 좌석의 예약 정보가 없을 때
+     */
     @Override
     @Transactional
     @Caching(evict = {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -22,6 +22,11 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import static team.startup.gwangjutalentfestival.domain.user.enums.Role.PERFORMER;
 
+/**
+ * {@link ReservationSeatService}의 구현체.
+ * 좌석 유효성, 예약·차단 여부, 예약 한도를 검증한 후 좌석을 예약하고 SSE 이벤트를 발행한다.
+ * 동시 요청 충돌은 DB 유니크 제약을 통해 처리하며, 관련 캐시를 무효화한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class ReservationSeatServiceImpl implements ReservationSeatService {
@@ -36,6 +41,15 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
     private static final int RESERVED = 1;
     private static final int BANNED = 2;
 
+    /**
+     * 요청한 좌석을 현재 로그인한 사용자에게 예약한다.
+     *
+     * @param request 예약할 좌석의 구역 및 번호 정보
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotExistsInSectionException 좌석 번호가 구역 범위를 벗어날 때
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException 이미 예약된 좌석일 때
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatBannedException 차단된 좌석일 때
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationLimitExceededException 예약 한도를 초과했을 때
+     */
     @Override
     @Transactional
     @Caching(evict = {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/entity/SloganEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/entity/SloganEntity.java
@@ -7,6 +7,10 @@ import team.startup.gwangjutalentfestival.global.constant.TimeConstants;
 
 import java.time.LocalDateTime;
 
+/**
+ * 슬로건 제출 데이터를 저장하는 엔티티.
+ * Google Sheets 동기화 상태와 재시도 정보를 함께 관리한다.
+ */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -56,15 +60,29 @@ public class SloganEntity {
     @Column(name = "sheet_sync_status", nullable = false)
     private SheetSyncStatus sheetSyncStatus;
 
+    /**
+     * 시트 동기화 상태를 {@link SheetSyncStatus#PROCESSING}으로 변경한다.
+     */
     public void processSheetSyncStatus() {
         this.sheetSyncStatus = SheetSyncStatus.PROCESSING;
     }
 
+    /**
+     * 시트 동기화 성공 처리를 수행한다.
+     * 상태를 {@link SheetSyncStatus#COMPLETED}로 변경하고 동기화 시각을 기록한다.
+     */
     public void markDone() {
         this.sheetSyncStatus = SheetSyncStatus.COMPLETED;
         this.syncedAt = LocalDateTime.now(TimeConstants.SEOUL_ZONE_ID);
     }
 
+    /**
+     * 시트 동기화 실패 처리를 수행한다.
+     * 상태를 {@link SheetSyncStatus#REJECTED}로 변경하고 재시도 예정 시각과 오류 메시지를 기록한다.
+     *
+     * @param nextRetryAt 다음 재시도 예정 시각
+     * @param lastError   마지막 오류 메시지
+     */
     public void markFailed(LocalDateTime nextRetryAt, String lastError) {
         this.sheetSyncStatus = SheetSyncStatus.REJECTED;
         this.nextRetryAt = nextRetryAt;
@@ -72,6 +90,10 @@ public class SloganEntity {
         this.retryCount += 1;
     }
 
+    /**
+     * 최대 재시도 횟수 초과로 인해 동기화를 포기 처리한다.
+     * 상태를 {@link SheetSyncStatus#EXHAUSTED}로 변경한다.
+     */
     public void markExhausted() {
         this.sheetSyncStatus = SheetSyncStatus.EXHAUSTED;
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/enums/SheetSyncStatus.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/enums/SheetSyncStatus.java
@@ -1,5 +1,16 @@
 package team.startup.gwangjutalentfestival.domain.slogan.enums;
 
+/**
+ * 슬로건의 Google Sheets 동기화 상태를 나타내는 열거형.
+ *
+ * <ul>
+ *   <li>{@link #PENDING} - 동기화 대기 중</li>
+ *   <li>{@link #PROCESSING} - 동기화 진행 중</li>
+ *   <li>{@link #REJECTED} - 동기화 실패 (재시도 예정)</li>
+ *   <li>{@link #COMPLETED} - 동기화 완료</li>
+ *   <li>{@link #EXHAUSTED} - 최대 재시도 횟수 초과로 동기화 포기</li>
+ * </ul>
+ */
 public enum SheetSyncStatus {
     PENDING,
     PROCESSING,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/exception/SloganSubmissionPeriodException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/exception/SloganSubmissionPeriodException.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.domain.slogan.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 슬로건 접수 기간이 아닐 때 발생하는 예외.
+ * 현재 시각이 설정된 접수 시작일 이전이거나 종료일 이후인 경우 발생한다.
+ */
 public class SloganSubmissionPeriodException extends GlobalException {
     public SloganSubmissionPeriodException() {
         super(ErrorCode.SLOGAN_SUBMISSION_PERIOD_INVALID);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/controller/SloganController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/controller/SloganController.java
@@ -15,6 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 import team.startup.gwangjutalentfestival.domain.slogan.presentation.data.request.CreateSloganRequest;
 import team.startup.gwangjutalentfestival.domain.slogan.service.CreateSloganService;
 
+/**
+ * 슬로건 관련 API 엔드포인트를 제공하는 컨트롤러.
+ */
 @Tag(name = "Slogan", description = "슬로건 API")
 @RestController
 @RequestMapping("/slogan")
@@ -27,6 +30,12 @@ public class SloganController {
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "슬로건 등록 성공")
     })
+    /**
+     * 슬로건을 등록한다.
+     *
+     * @param request 슬로건 등록 요청 데이터
+     * @return 201 Created
+     */
     @PostMapping
     public ResponseEntity<Void> createSlogan(@Valid @RequestBody CreateSloganRequest request) {
         createSloganService.execute(request);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/SloganSheetRowData.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/SloganSheetRowData.java
@@ -1,5 +1,16 @@
 package team.startup.gwangjutalentfestival.domain.slogan.presentation.data;
 
+/**
+ * Google Sheets에 슬로건 데이터를 추가할 때 사용하는 행 데이터 DTO.
+ *
+ * @param slogan      슬로건 문구
+ * @param description 슬로건 설명
+ * @param school      학교명
+ * @param name        제출자 이름
+ * @param grade       학년
+ * @param classNum    반 번호
+ * @param phoneNumber 전화번호
+ */
 public record SloganSheetRowData(
         String slogan,
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/request/CreateSloganRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/request/CreateSloganRequest.java
@@ -2,6 +2,17 @@ package team.startup.gwangjutalentfestival.domain.slogan.presentation.data.reque
 
 import jakarta.validation.constraints.*;
 
+/**
+ * 슬로건 등록 요청 DTO.
+ *
+ * @param slogan      슬로건 문구 (필수)
+ * @param description 슬로건 설명 (필수)
+ * @param school      학교명 (필수)
+ * @param name        제출자 이름 (필수)
+ * @param grade       학년 (1~6)
+ * @param classNum    반 번호 (양수)
+ * @param phoneNumber 전화번호 (010으로 시작하는 11자리 숫자)
+ */
 public record CreateSloganRequest(
         @NotBlank
         String slogan,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/properties/SloganSubmissionProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/properties/SloganSubmissionProperties.java
@@ -4,6 +4,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.LocalDateTime;
 
+/**
+ * 슬로건 접수 기간 설정 프로퍼티.
+ * {@code slogan.submission} 접두사로 외부 설정에서 주입된다.
+ *
+ * @param startAt 접수 시작 일시
+ * @param endAt   접수 종료 일시
+ */
 @ConfigurationProperties(prefix = "slogan.submission")
 public record SloganSubmissionProperties(
         LocalDateTime startAt,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/repository/SloganRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/repository/SloganRepository.java
@@ -7,10 +7,29 @@ import team.startup.gwangjutalentfestival.domain.slogan.enums.SheetSyncStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * 슬로건 엔티티에 대한 데이터 접근 인터페이스.
+ */
 public interface SloganRepository extends JpaRepository<SloganEntity, Long> {
+
+    /**
+     * 동일한 전화번호로 제출된 슬로건이 존재하는지 확인한다.
+     *
+     * @param phoneNumber 확인할 전화번호
+     * @return 동일 전화번호 슬로건 존재 여부
+     */
     boolean existsByPhoneNumber(String phoneNumber);
 
+    /**
+     * 지정된 동기화 상태에 해당하며 다음 재시도 시각이 현재 시각 이전인 슬로건을
+     * ID 오름차순으로 최대 50건 조회한다.
+     *
+     * @param statuses 조회할 동기화 상태 목록
+     * @param now      기준 현재 시각
+     * @return 처리 대상 슬로건 목록 (최대 50건)
+     */
     List<SloganEntity> findTop50BySheetSyncStatusInAndNextRetryAtBeforeOrderByIdAsc(
             List<SheetSyncStatus> statuses,
             LocalDateTime now
-    );}
+    );
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/scheduler/SloganSheetSyncScheduler.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/scheduler/SloganSheetSyncScheduler.java
@@ -15,6 +15,11 @@ import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.Googl
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * 슬로건 데이터를 Google Sheets에 주기적으로 동기화하는 스케줄러.
+ * 10초 간격으로 실행되며, 대기 중이거나 재시도 대상인 슬로건을 최대 50건씩 처리한다.
+ * 동기화 실패 시 재시도 횟수를 증가시키며, 최대 재시도 횟수 초과 시 포기 처리한다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -27,6 +32,10 @@ public class SloganSheetSyncScheduler {
     private final GoogleSheetsAdapter googleSheetsAdapter;
     private final TransactionTemplate transactionTemplate;
 
+    /**
+     * 10초 간격으로 실행되어 대기 또는 재시도 대상 슬로건을 Google Sheets에 동기화한다.
+     * 처리할 데이터가 없으면 즉시 반환한다.
+     */
     @Scheduled(fixedDelay = 10000)
     public void execute() {
         List<SloganEntity> slogans = transactionTemplate.execute(status -> {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/CreateSloganService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/CreateSloganService.java
@@ -2,6 +2,16 @@ package team.startup.gwangjutalentfestival.domain.slogan.service;
 
 import team.startup.gwangjutalentfestival.domain.slogan.presentation.data.request.CreateSloganRequest;
 
+/**
+ * 슬로건을 등록하는 서비스 인터페이스.
+ */
 public interface CreateSloganService {
+
+    /**
+     * 슬로건을 등록한다.
+     * 접수 기간 및 전화번호 중복 여부를 검증한 후 저장한다.
+     *
+     * @param request 슬로건 등록 요청 데이터
+     */
     void execute(CreateSloganRequest request);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
@@ -15,6 +15,11 @@ import team.startup.gwangjutalentfestival.global.constant.TimeConstants;
 
 import java.time.LocalDateTime;
 
+/**
+ * {@link CreateSloganService} 구현체.
+ * 접수 기간 유효성 및 전화번호 중복을 검증한 후 슬로건을 저장한다.
+ * 저장된 슬로건은 Google Sheets 동기화 대기 상태({@link SheetSyncStatus#PENDING})로 설정된다.
+ */
 @Service
 @RequiredArgsConstructor
 public class CreateSloganServiceImpl implements CreateSloganService {
@@ -22,6 +27,13 @@ public class CreateSloganServiceImpl implements CreateSloganService {
     private final SloganRepository sloganRepository;
     private final SloganSubmissionProperties sloganSubmissionProperties;
 
+    /**
+     * 슬로건을 등록한다.
+     * 접수 기간이 아니면 {@link SloganSubmissionPeriodException},
+     * 동일 전화번호가 이미 존재하면 {@code DuplicatePhoneNumberException}이 발생한다.
+     *
+     * @param request 슬로건 등록 요청 데이터
+     */
     @Override
     @Transactional
     public void execute(CreateSloganRequest request) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/entity/TeamEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/entity/TeamEntity.java
@@ -8,6 +8,10 @@ import lombok.NoArgsConstructor;
 import team.startup.gwangjutalentfestival.domain.team.enums.TeamGenre;
 import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
 
+/**
+ * 공연 팀 엔티티.
+ * 팀 이름, 학교, 공연 상태, 장르, 공연 순서, 총점 정보를 관리한다.
+ */
 @Entity
 @Getter
 @NoArgsConstructor
@@ -39,14 +43,29 @@ public class TeamEntity {
     @Column(name = "total_score", nullable = false)
     private Integer totalScore;
 
+    /**
+     * 팀의 공연 상태를 변경한다.
+     *
+     * @param teamStatus 변경할 공연 상태
+     */
     public void updateStatus(TeamStatus teamStatus) {
         this.teamStatus = teamStatus;
     }
 
+    /**
+     * 팀의 공연 순서를 변경한다.
+     *
+     * @param order 변경할 공연 순서
+     */
     public void updateOrder(Integer order) {
         this.performOrder = order;
     }
 
+    /**
+     * 팀의 총점을 변경한다.
+     *
+     * @param totalScore 변경할 총점
+     */
     public void updateTotalScore(Integer totalScore) {
         this.totalScore = totalScore;
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/enums/TeamGenre.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/enums/TeamGenre.java
@@ -1,5 +1,15 @@
 package team.startup.gwangjutalentfestival.domain.team.enums;
 
+/**
+ * 팀의 공연 장르를 정의하는 열거형.
+ * <ul>
+ *   <li>{@code ALL} - 전체</li>
+ *   <li>{@code GUGAK} - 국악</li>
+ *   <li>{@code PLAY} - 연주</li>
+ *   <li>{@code DANCE} - 춤</li>
+ *   <li>{@code SING} - 노래</li>
+ * </ul>
+ */
 public enum TeamGenre {
     ALL, // 전체
     GUGAK, // 국악

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/enums/TeamStatus.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/enums/TeamStatus.java
@@ -2,9 +2,23 @@ package team.startup.gwangjutalentfestival.domain.team.enums;
 
 import team.startup.gwangjutalentfestival.domain.team.exception.TeamAlreadyFinishedException;
 
+/**
+ * 팀의 공연 진행 상태를 정의하는 열거형.
+ * <ul>
+ *   <li>{@code PENDING} - 공연 대기 중</li>
+ *   <li>{@code ONGOING} - 공연 진행 중</li>
+ *   <li>{@code FINISHED} - 공연 완료</li>
+ * </ul>
+ */
 public enum TeamStatus {
     PENDING, ONGOING, FINISHED;
 
+    /**
+     * 현재 상태에서 다음 상태로 전환한다.
+     * {@code FINISHED} 상태에서 호출하면 {@link team.startup.gwangjutalentfestival.domain.team.exception.TeamAlreadyFinishedException}이 발생한다.
+     *
+     * @return 다음 공연 상태
+     */
     public TeamStatus next() {
         return switch (this) {
             case PENDING -> ONGOING;

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/event/TeamOrderChangedEvent.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/event/TeamOrderChangedEvent.java
@@ -7,6 +7,10 @@ import team.startup.gwangjutalentfestival.domain.team.presentation.data.TeamOrde
 
 import java.util.List;
 
+/**
+ * 팀 공연 순서가 변경되었을 때 발행되는 이벤트.
+ * 변경된 팀 순서 목록을 담아 이벤트 리스너에 전달한다.
+ */
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/event/handler/TeamOrderChangedEventListener.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/event/handler/TeamOrderChangedEventListener.java
@@ -10,22 +10,42 @@ import team.startup.gwangjutalentfestival.global.sse.AbstractSseEmitterManager;
 import team.startup.gwangjutalentfestival.global.sse.AbstractSseEventListener;
 import team.startup.gwangjutalentfestival.global.sse.JudgeSseEmitterManager;
 
+/**
+ * 팀 공연 순서 변경 이벤트 리스너.
+ * 트랜잭션 커밋 이후 비동기로 실행되며, 연결된 모든 심사위원 SSE 클라이언트에 순서 변경 이벤트를 전송한다.
+ */
 @Component
 @RequiredArgsConstructor
 public class TeamOrderChangedEventListener extends AbstractSseEventListener<TeamOrderChangedEvent> {
 
     private final JudgeSseEmitterManager judgeSseEmitterManager;
 
+    /**
+     * SSE Emitter 관리자를 반환한다.
+     *
+     * @return 심사위원용 SSE Emitter 관리자
+     */
     @Override
     protected AbstractSseEmitterManager<?> getEmitterManager() {
         return judgeSseEmitterManager;
     }
 
+    /**
+     * SSE 이벤트 이름을 반환한다.
+     *
+     * @return 이벤트 이름 {@code "TEAM_ORDER_CHANGE"}
+     */
     @Override
     protected String getEventName() {
         return "TEAM_ORDER_CHANGE";
     }
 
+    /**
+     * 팀 공연 순서 변경 이벤트를 수신하여 모든 SSE 클라이언트에 전송한다.
+     * 트랜잭션 커밋 후 비동기로 실행된다.
+     *
+     * @param event 팀 공연 순서 변경 이벤트
+     */
     @Async("asyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void execute(TeamOrderChangedEvent event) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/exception/TeamAlreadyFinishedException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/exception/TeamAlreadyFinishedException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.team.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 이미 공연이 완료된 팀의 상태를 변경하려 할 때 발생하는 예외.
+ */
 public class TeamAlreadyFinishedException extends GlobalException {
     public TeamAlreadyFinishedException() {
         super(ErrorCode.TEAM_ALREADY_FINISHED);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/exception/TeamAlreadyOngoingException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/exception/TeamAlreadyOngoingException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.team.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 이미 공연 진행 중인 팀에 중복 처리를 시도할 때 발생하는 예외.
+ */
 public class TeamAlreadyOngoingException extends GlobalException {
     public TeamAlreadyOngoingException() {
         super(ErrorCode.TEAM_ALREADY_ONGOING);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/exception/TeamNotFoundException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/exception/TeamNotFoundException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.team.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 요청한 팀이 존재하지 않을 때 발생하는 예외.
+ */
 public class TeamNotFoundException extends GlobalException {
     public TeamNotFoundException() {
         super(ErrorCode.TEAM_NOT_FOUND);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/controller/TeamController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/controller/TeamController.java
@@ -18,6 +18,10 @@ import team.startup.gwangjutalentfestival.domain.team.service.UpdateTeamPerforma
 
 import java.util.List;
 
+/**
+ * 팀 관련 REST API 컨트롤러.
+ * 팀 조회, 랭킹 조회, 공연 상태 변경, 공연 순서 변경 엔드포인트를 제공한다.
+ */
 @Tag(name = "Team", description = "팀 API")
 @RestController
 @RequestMapping("/team")
@@ -29,6 +33,11 @@ public class TeamController {
     private final UpdateTeamPerformanceService updateTeamPerformanceService;
     private final UpdateTeamOrderService updateTeamOrderService;
 
+    /**
+     * 등록된 모든 팀을 공연 순서 오름차순으로 조회한다.
+     *
+     * @return 전체 팀 목록
+     */
     @Operation(summary = "전체 팀 조회", description = "등록된 모든 팀의 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "전체 팀 조회 성공")
@@ -38,6 +47,11 @@ public class TeamController {
         return ResponseEntity.ok(getAllTeamService.execute());
     }
 
+    /**
+     * 총점 기준으로 팀 랭킹을 조회한다.
+     *
+     * @return 랭킹 순서로 정렬된 팀 목록
+     */
     @Operation(summary = "팀 랭킹 조회", description = "팀의 랭킹 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "팀 랭킹 조회 성공")
@@ -47,6 +61,12 @@ public class TeamController {
         return ResponseEntity.ok(getTeamRankingService.execute());
     }
 
+    /**
+     * 특정 팀의 공연 상태를 다음 단계로 변경한다.
+     *
+     * @param teamId 상태를 변경할 팀 ID
+     * @return 204 No Content
+     */
     @Operation(summary = "팀 공연 상태 변경", description = "팀의 공연 상태를 변경합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "공연 상태 변경 성공"),
@@ -60,6 +80,12 @@ public class TeamController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * 여러 팀의 공연 순서를 일괄 변경한다.
+     *
+     * @param request 팀별 변경할 공연 순서 목록
+     * @return 204 No Content
+     */
     @Operation(summary = "팀 공연 순서 변경", description = "팀의 공연 순서를 변경합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "공연 순서 변경 성공"),

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/TeamOrderItem.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/TeamOrderItem.java
@@ -1,5 +1,11 @@
 package team.startup.gwangjutalentfestival.domain.team.presentation.data;
 
+/**
+ * 팀 공연 순서 변경을 위한 단일 항목.
+ *
+ * @param teamId 순서를 변경할 팀 ID
+ * @param order  변경할 공연 순서 번호
+ */
 public record TeamOrderItem(
         Long teamId,
         Integer order

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/request/UpdateTeamOrderRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/request/UpdateTeamOrderRequest.java
@@ -4,6 +4,11 @@ import team.startup.gwangjutalentfestival.domain.team.presentation.data.TeamOrde
 
 import java.util.List;
 
+/**
+ * 팀 공연 순서 일괄 변경 요청 DTO.
+ *
+ * @param orderItems 변경할 팀 순서 항목 목록
+ */
 public record UpdateTeamOrderRequest(
     List<TeamOrderItem> orderItems
 ) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/response/GetTeamRankingResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/response/GetTeamRankingResponse.java
@@ -1,5 +1,11 @@
 package team.startup.gwangjutalentfestival.domain.team.presentation.data.response;
 
+/**
+ * 팀 랭킹 조회 응답 DTO.
+ *
+ * @param ranking  팀의 순위
+ * @param teamName 팀 이름
+ */
 public record GetTeamRankingResponse(
         Integer ranking,
         String teamName

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/response/GetTeamResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/response/GetTeamResponse.java
@@ -2,6 +2,15 @@ package team.startup.gwangjutalentfestival.domain.team.presentation.data.respons
 
 import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
 
+/**
+ * 팀 정보 조회 응답 DTO.
+ *
+ * @param teamId       팀 ID
+ * @param teamName     팀 이름
+ * @param school       소속 학교
+ * @param performOrder 공연 순서
+ * @param status       현재 공연 상태
+ */
 public record GetTeamResponse(
         Long teamId,
         String teamName,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepository.java
@@ -7,8 +7,24 @@ import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * 팀 엔티티에 대한 데이터 접근 레이어.
+ */
 @Repository
 public interface TeamRepository extends JpaRepository<TeamEntity, Long>, TeamRepositoryCustom {
+
+    /**
+     * 주어진 ID 목록에 해당하는 팀들을 조회한다.
+     *
+     * @param ids 조회할 팀 ID 컬렉션
+     * @return 해당 ID를 가진 팀 컬렉션
+     */
     Collection<TeamEntity> findAllByIdIn(Collection<Long> ids);
+
+    /**
+     * 모든 팀을 공연 순서 오름차순으로 조회한다.
+     *
+     * @return 공연 순서로 정렬된 팀 목록
+     */
     List<TeamEntity> findAllByOrderByPerformOrderAsc();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepositoryCustom.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepositoryCustom.java
@@ -4,6 +4,15 @@ import team.startup.gwangjutalentfestival.domain.team.presentation.data.response
 
 import java.util.List;
 
+/**
+ * QueryDSL을 활용한 팀 커스텀 쿼리 인터페이스.
+ */
 public interface TeamRepositoryCustom {
+
+    /**
+     * 총점 및 세부 심사 점수 기준으로 팀 랭킹을 조회한다.
+     *
+     * @return 순위가 포함된 팀 랭킹 목록
+     */
     List<GetTeamRankingResponse> getRanking();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepositoryCustomImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepositoryCustomImpl.java
@@ -10,6 +10,10 @@ import team.startup.gwangjutalentfestival.domain.team.presentation.data.response
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * {@link TeamRepositoryCustom}의 QueryDSL 구현체.
+ * 총점 및 세부 심사 점수를 기준으로 팀 랭킹을 계산한다.
+ */
 @Repository
 @RequiredArgsConstructor
 public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
@@ -19,6 +23,12 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
     private static final QTeamEntity team = QTeamEntity.teamEntity;
     private static final QJudgementEntity judgement = QJudgementEntity.judgementEntity;
 
+    /**
+     * 총점 내림차순, 세부 심사 점수 평균 순으로 팀 랭킹을 조회한다.
+     * 동점일 경우 표현/소통 점수, 창의성/구성 점수, 무대 매너/퍼포먼스 점수, ID 오름차순으로 순위를 결정한다.
+     *
+     * @return 순위가 부여된 팀 랭킹 목록
+     */
     @Override
     public List<GetTeamRankingResponse> getRanking() {
         List<String> teamNames = queryFactory

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/GetAllTeamService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/GetAllTeamService.java
@@ -4,6 +4,15 @@ import team.startup.gwangjutalentfestival.domain.team.presentation.data.response
 
 import java.util.List;
 
+/**
+ * 전체 팀 조회 서비스 인터페이스.
+ */
 public interface GetAllTeamService {
+
+    /**
+     * 공연 순서 오름차순으로 전체 팀 목록을 반환한다.
+     *
+     * @return 전체 팀 응답 목록
+     */
     List<GetTeamResponse> execute();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/GetTeamRankingService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/GetTeamRankingService.java
@@ -4,6 +4,15 @@ import team.startup.gwangjutalentfestival.domain.team.presentation.data.response
 
 import java.util.List;
 
+/**
+ * 팀 랭킹 조회 서비스 인터페이스.
+ */
 public interface GetTeamRankingService {
+
+    /**
+     * 총점 기준으로 팀 랭킹 목록을 반환한다.
+     *
+     * @return 순위가 포함된 팀 랭킹 응답 목록
+     */
     List<GetTeamRankingResponse> execute();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/UpdateTeamOrderService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/UpdateTeamOrderService.java
@@ -4,6 +4,15 @@ import team.startup.gwangjutalentfestival.domain.team.presentation.data.TeamOrde
 
 import java.util.List;
 
+/**
+ * 팀 공연 순서 변경 서비스 인터페이스.
+ */
 public interface UpdateTeamOrderService {
+
+    /**
+     * 여러 팀의 공연 순서를 일괄 변경한다.
+     *
+     * @param orders 변경할 팀 순서 항목 목록
+     */
     void execute(List<TeamOrderItem> orders);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/UpdateTeamPerformanceService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/UpdateTeamPerformanceService.java
@@ -1,5 +1,14 @@
 package team.startup.gwangjutalentfestival.domain.team.service;
 
+/**
+ * 팀 공연 상태 변경 서비스 인터페이스.
+ */
 public interface UpdateTeamPerformanceService {
+
+    /**
+     * 특정 팀의 공연 상태를 다음 단계로 변경한다.
+     *
+     * @param teamId 상태를 변경할 팀 ID
+     */
     void execute(Long teamId);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetAllTeamServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetAllTeamServiceImpl.java
@@ -11,11 +11,21 @@ import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 
 import java.util.List;
 
+/**
+ * {@link GetAllTeamService} 구현체.
+ * 결과가 비어있지 않은 경우 캐싱하여 반복 조회 성능을 최적화한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class GetAllTeamServiceImpl implements GetAllTeamService {
     private final TeamRepository teamRepository;
 
+    /**
+     * 공연 순서 오름차순으로 전체 팀 목록을 조회한다.
+     * 결과가 비어있지 않으면 캐시에 저장된다.
+     *
+     * @return 전체 팀 응답 목록
+     */
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.TEAM_ALL, unless = "#result.isEmpty()")

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetTeamRankingServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetTeamRankingServiceImpl.java
@@ -11,11 +11,21 @@ import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 
 import java.util.List;
 
+/**
+ * {@link GetTeamRankingService} 구현체.
+ * 결과가 비어있지 않은 경우 캐싱하여 반복 조회 성능을 최적화한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class GetTeamRankingServiceImpl implements GetTeamRankingService {
     private final TeamRepository teamRepository;
 
+    /**
+     * 총점 기준으로 팀 랭킹을 조회한다.
+     * 결과가 비어있지 않으면 캐시에 저장된다.
+     *
+     * @return 순위가 포함된 팀 랭킹 응답 목록
+     */
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.TEAM_RANKING, unless = "#result.isEmpty()")

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/UpdateTeamOrderServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/UpdateTeamOrderServiceImpl.java
@@ -17,12 +17,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * {@link UpdateTeamOrderService} 구현체.
+ * 팀 순서 변경 후 캐시를 초기화하고 SSE 이벤트를 발행한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class UpdateTeamOrderServiceImpl implements UpdateTeamOrderService {
     private final TeamRepository teamRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    /**
+     * 여러 팀의 공연 순서를 일괄 변경한다.
+     * 존재하지 않는 팀 ID가 포함된 경우 {@link team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundException}이 발생한다.
+     * 변경 완료 후 전체 팀 캐시를 초기화하고 {@link team.startup.gwangjutalentfestival.domain.team.event.TeamOrderChangedEvent}를 발행한다.
+     *
+     * @param orders 변경할 팀 순서 항목 목록
+     */
     @Override
     @Transactional
     @CacheEvict(cacheNames = CacheConfig.TEAM_ALL, allEntries = true)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/UpdateTeamPerformanceServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/UpdateTeamPerformanceServiceImpl.java
@@ -13,12 +13,24 @@ import team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundExce
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.team.service.UpdateTeamPerformanceService;
 
+/**
+ * {@link UpdateTeamPerformanceService} 구현체.
+ * 팀 상태 변경 후 전체 팀 및 랭킹 캐시를 초기화하고 심사 이벤트를 발행한다.
+ */
 @Service
 @RequiredArgsConstructor
 public class UpdateTeamPerformanceServiceImpl implements UpdateTeamPerformanceService {
     private final TeamRepository teamRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    /**
+     * 특정 팀의 공연 상태를 다음 단계로 변경한다.
+     * 팀이 존재하지 않으면 {@link team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundException}이 발생한다.
+     * 이미 완료된 팀이면 {@link team.startup.gwangjutalentfestival.domain.team.exception.TeamAlreadyFinishedException}이 발생한다.
+     * 상태 변경 후 전체 팀 및 랭킹 캐시를 초기화하고 심사 이벤트를 발행한다.
+     *
+     * @param teamId 상태를 변경할 팀 ID
+     */
     @Override
     @Transactional
     @Caching(evict = {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/user/entity/PerformerUser.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/user/entity/PerformerUser.java
@@ -4,6 +4,10 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 공연자 사용자 엔티티.
+ * 공연팀에 속한 사용자의 전화번호와 비밀번호를 관리한다.
+ */
 @Getter
 @Entity
 @NoArgsConstructor

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/user/entity/UserEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/user/entity/UserEntity.java
@@ -4,6 +4,10 @@ import jakarta.persistence.*;
 import lombok.*;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
+/**
+ * 일반 사용자 엔티티.
+ * 전화번호, 비밀번호, 역할(Role)을 포함한 사용자 정보를 관리한다.
+ */
 @Entity
 @Getter
 @Builder

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/user/enums/Role.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/user/enums/Role.java
@@ -1,5 +1,13 @@
 package team.startup.gwangjutalentfestival.domain.user.enums;
 
+/**
+ * 사용자 역할을 정의하는 열거형.
+ * <ul>
+ *   <li>{@code USER} - 일반 관람객</li>
+ *   <li>{@code ADMIN} - 관리자</li>
+ *   <li>{@code PERFORMER} - 공연자</li>
+ * </ul>
+ */
 public enum Role {
     USER,
     ADMIN,

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/user/exception/UserNotFoundException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.domain.user.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * 요청한 사용자가 존재하지 않을 때 발생하는 예외.
+ */
 public class UserNotFoundException extends GlobalException {
     public UserNotFoundException() {
         super(ErrorCode.USER_NOT_FOUND);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/user/repository/UserRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/user/repository/UserRepository.java
@@ -5,8 +5,24 @@ import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
 import java.util.Optional;
 
+/**
+ * 사용자 엔티티에 대한 데이터 접근 레이어.
+ */
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
+
+    /**
+     * 전화번호로 사용자를 조회한다.
+     *
+     * @param phoneNumber 조회할 전화번호
+     * @return 해당 전화번호의 사용자 (없으면 빈 Optional)
+     */
     Optional<UserEntity> findByPhoneNumber(String phoneNumber);
 
+    /**
+     * 전화번호로 사용자 존재 여부를 확인한다.
+     *
+     * @param phoneNumber 확인할 전화번호
+     * @return 사용자가 존재하면 {@code true}
+     */
     boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/auth/CustomUserDetails.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/auth/CustomUserDetails.java
@@ -10,6 +10,10 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Spring Security에서 사용하는 커스텀 사용자 정보 클래스.
+ * <p>{@link UserEntity}나 JWT 클레임으로부터 생성되며, 사용자 ID와 역할 정보를 보유한다.</p>
+ */
 public class CustomUserDetails implements UserDetails {
     @Getter
     private final Long userId;
@@ -25,10 +29,24 @@ public class CustomUserDetails implements UserDetails {
         this.role = role;
     }
 
+    /**
+     * {@link UserEntity}로부터 {@link CustomUserDetails}를 생성한다.
+     *
+     * @param user 사용자 엔티티
+     * @return 사용자 정보 객체
+     */
     public static CustomUserDetails from(UserEntity user) {
         return new CustomUserDetails(user.getId(), user.getPhoneNumber(), user.getPassword(), user.getRole());
     }
 
+    /**
+     * JWT 토큰 클레임으로부터 {@link CustomUserDetails}를 생성한다.
+     * <p>전화번호와 비밀번호는 null로 설정된다.</p>
+     *
+     * @param userId 사용자 ID
+     * @param role   사용자 역할
+     * @return 사용자 정보 객체
+     */
     public static CustomUserDetails fromToken(Long userId, Role role) {
         return new CustomUserDetails(userId, null, null, role);
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/auth/CustomUserDetailsService.java
@@ -6,12 +6,23 @@ import org.springframework.stereotype.Service;
 import team.startup.gwangjutalentfestival.domain.user.exception.UserNotFoundException;
 import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 
+/**
+ * 사용자 ID 기반으로 {@link CustomUserDetails}를 로드하는 서비스.
+ * <p>JWT 인증 흐름에서 데이터베이스로부터 사용자 정보를 조회할 때 사용된다.</p>
+ */
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService {
 
     private final UserRepository userRepository;
 
+    /**
+     * 사용자 ID로 사용자 정보를 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @return 사용자 정보 객체
+     * @throws team.startup.gwangjutalentfestival.domain.user.exception.UserNotFoundException 사용자가 존재하지 않을 경우
+     */
     public CustomUserDetails loadUserByUsername(Long userId) {
         return userRepository.findById(userId)
                 .map(CustomUserDetails::from)

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/AsyncConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/AsyncConfig.java
@@ -7,10 +7,19 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
 
+/**
+ * 비동기 처리를 위한 스레드 풀 설정.
+ * <p>코어 5개, 최대 10개의 스레드와 큐 용량 100을 갖는 {@code asyncExecutor} 빈을 등록한다.</p>
+ */
 @Configuration
 @EnableAsync
 public class AsyncConfig {
 
+    /**
+     * 비동기 작업 전용 스레드 풀 Executor를 생성한다.
+     *
+     * @return 설정된 {@link Executor} 빈
+     */
     @Bean(name = "asyncExecutor")
     public Executor asyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/CacheConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/CacheConfig.java
@@ -11,6 +11,10 @@ import org.springframework.context.annotation.Configuration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Caffeine 기반 인메모리 캐시 설정.
+ * <p>팀 목록, 팀 랭킹, 좌석 전체/구역별 조회에 대한 캐시를 구성한다.</p>
+ */
 @EnableCaching
 @Configuration
 public class CacheConfig {
@@ -20,6 +24,11 @@ public class CacheConfig {
     public static final String SEATS_ALL     = "seats:all";
     public static final String SEATS_SECTION = "seats:section";
 
+    /**
+     * Caffeine 캐시 매니저를 생성한다.
+     *
+     * @return 설정된 {@link CacheManager} 빈
+     */
     @Bean
     public CacheManager cacheManager() {
         SimpleCacheManager cacheManager = new SimpleCacheManager();

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/FeignConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/FeignConfig.java
@@ -5,12 +5,21 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * OpenFeign 클라이언트 전역 설정.
+ * <p>프로퍼티({@code feign.log-level})를 통해 Feign 로그 레벨을 동적으로 설정한다. 기본값은 {@code BASIC}이다.</p>
+ */
 @Configuration
 public class FeignConfig {
 
     @Value("${feign.log-level:BASIC}")
     private String logLevel;
 
+    /**
+     * Feign 클라이언트 로그 레벨을 설정한다.
+     *
+     * @return {@link feign.Logger.Level} 빈
+     */
     @Bean
     public Logger.Level feignLoggerLevel() {
         return Logger.Level.valueOf(logLevel);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/QuerydslConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/QuerydslConfig.java
@@ -6,12 +6,20 @@ import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * QueryDSL 사용을 위한 {@link JPAQueryFactory} 빈 설정.
+ */
 @Configuration
 public class QuerydslConfig {
 
     @PersistenceContext
     private EntityManager entityManager;
 
+    /**
+     * {@link JPAQueryFactory} 빈을 생성한다.
+     *
+     * @return {@link JPAQueryFactory} 빈
+     */
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
         return new JPAQueryFactory(entityManager);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/RestClientConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/RestClientConfig.java
@@ -7,12 +7,21 @@ import org.springframework.web.client.RestClient;
 
 import java.time.Duration;
 
+/**
+ * Spring {@link RestClient} 빈 설정.
+ * <p>연결 타임아웃 5초, 읽기 타임아웃 10초를 적용한다.</p>
+ */
 @Configuration
 public class RestClientConfig {
 
     private static final int CONNECT_TIMEOUT_MS = 5_000;
     private static final int READ_TIMEOUT_MS = 10_000;
 
+    /**
+     * 타임아웃이 설정된 {@link RestClient} 빈을 생성한다.
+     *
+     * @return {@link RestClient} 빈
+     */
     @Bean
     public RestClient restClient() {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
@@ -5,9 +5,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
+/**
+ * SSE 하트비트 전송에 사용되는 {@link TaskScheduler} 빈 설정.
+ * <p>스레드 풀 크기 4로 구성된 스케줄러를 등록한다.</p>
+ */
 @Configuration
 public class SchedulerConfig {
 
+    /**
+     * SSE 하트비트 전용 스레드 풀 스케줄러를 생성한다.
+     *
+     * @return {@link TaskScheduler} 빈
+     */
     @Bean
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/SwaggerConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/SwaggerConfig.java
@@ -6,6 +6,10 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Swagger(springdoc-openapi) 문서 설정.
+ * <p>API 문서 제목, 버전 정보와 JWT Bearer 보안 스키마를 정의한다.</p>
+ */
 @OpenAPIDefinition(
         info = @Info(
                 title = "광주 탤런트 페스티벌 API",

--- a/src/main/java/team/startup/gwangjutalentfestival/global/constant/TimeConstants.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/constant/TimeConstants.java
@@ -2,8 +2,13 @@ package team.startup.gwangjutalentfestival.global.constant;
 
 import java.time.ZoneId;
 
+/**
+ * 시간 관련 전역 상수 클래스.
+ * <p>서울(KST) 타임존 등 애플리케이션 전반에서 공통으로 사용하는 시간 상수를 정의한다.</p>
+ */
 public final class TimeConstants {
 
+    /** 서울(Asia/Seoul, KST) 타임존 ID */
     public static final ZoneId SEOUL_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private TimeConstants() {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.global.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * 애플리케이션 전반에서 사용하는 에러 코드 열거형.
+ * <p>각 항목은 HTTP 상태 코드와 사용자 메시지를 포함한다.</p>
+ */
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorResponse.java
@@ -1,5 +1,12 @@
 package team.startup.gwangjutalentfestival.global.exception;
 
+/**
+ * API 에러 응답 DTO.
+ * <p>HTTP 상태 코드와 에러 메시지를 담아 클라이언트에 반환한다.</p>
+ *
+ * @param status  HTTP 상태 코드
+ * @param message 에러 메시지
+ */
 public record ErrorResponse(
         int status,
         String message

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/GlobalException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/GlobalException.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.global.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 애플리케이션 전역 비즈니스 예외 기반 클래스.
+ * <p>모든 도메인별 예외는 이 클래스를 상속하며, {@link ErrorCode}를 통해 에러 정보를 전달한다.</p>
+ */
 @Getter
 @RequiredArgsConstructor
 public class GlobalException extends RuntimeException {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/HttpExceptionHandler.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/HttpExceptionHandler.java
@@ -8,10 +8,21 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+/**
+ * 전역 예외 핸들러.
+ * <p>{@link GlobalException}, {@link MethodArgumentNotValidException}, 그 외 미처리 예외를 처리하여
+ * 일관된 {@link ErrorResponse} 형태로 응답한다.</p>
+ */
 @Slf4j
 @RestControllerAdvice
 public class HttpExceptionHandler {
 
+    /**
+     * {@link GlobalException} 발생 시 해당 에러 코드에 맞는 응답을 반환한다.
+     *
+     * @param e 발생한 {@link GlobalException}
+     * @return 에러 코드에 맞는 {@link ErrorResponse}
+     */
     @ExceptionHandler(GlobalException.class)
     public ResponseEntity<ErrorResponse> globalException(GlobalException e) {
         ErrorCode errorCode = e.getErrorCode();
@@ -20,6 +31,12 @@ public class HttpExceptionHandler {
                 .body(new ErrorResponse(errorCode.getStatus(), errorCode.getMessage()));
     }
 
+    /**
+     * {@link MethodArgumentNotValidException} 발생 시 첫 번째 필드 오류 메시지를 반환한다.
+     *
+     * @param e 발생한 {@link MethodArgumentNotValidException}
+     * @return 400 Bad Request {@link ErrorResponse}
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> methodArgumentNotValidException(MethodArgumentNotValidException e) {
         String reason = e.getBindingResult()
@@ -33,6 +50,12 @@ public class HttpExceptionHandler {
                 .body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), reason));
     }
 
+    /**
+     * 예상치 못한 모든 예외를 처리하여 500 Internal Server Error를 반환한다.
+     *
+     * @param e 발생한 예외
+     * @return 500 {@link ErrorResponse}
+     */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> exception(Exception e) {
         log.error("[예상치 못한 예외 발생] message: {}", e.getMessage(), e);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/jwt/JwtProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/jwt/JwtProperties.java
@@ -5,6 +5,10 @@ import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 
+/**
+ * JWT 설정 프로퍼티.
+ * <p>시크릿 키, 액세스 토큰 만료 시간, 리프레시 토큰 만료 시간을 {@code jwt.*} 프로퍼티로 바인딩한다.</p>
+ */
 @Getter
 @AllArgsConstructor
 @ConfigurationProperties(prefix = "jwt")

--- a/src/main/java/team/startup/gwangjutalentfestival/global/jwt/JwtProvider.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/jwt/JwtProvider.java
@@ -18,6 +18,10 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.UUID;
 
+/**
+ * JWT 토큰 생성, 검증, 파싱을 담당하는 컴포넌트.
+ * <p>액세스 토큰과 리프레시 토큰 발급, 클레임 추출, 블랙리스트 확인 전 토큰 유효성 검사를 수행한다.</p>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -38,6 +42,13 @@ public class JwtProvider {
         this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
     }
 
+    /**
+     * 액세스 토큰과 리프레시 토큰을 함께 발급한다.
+     *
+     * @param userId 사용자 ID
+     * @param role   사용자 역할
+     * @return 발급된 토큰 정보 응답
+     */
     public TokenResponse receiveToken(Long userId, Role role) {
         Date accessExpiryDate = calculateExpiryDate(jwtProperties.getAccessTokenExpiration());
         Date refreshExpiryDate = calculateExpiryDate(jwtProperties.getRefreshTokenExpiration());
@@ -54,11 +65,25 @@ public class JwtProvider {
         );
     }
 
+    /**
+     * 액세스 토큰을 단독으로 발급한다.
+     *
+     * @param userId 사용자 ID
+     * @param role   사용자 역할
+     * @return 액세스 토큰 문자열
+     */
     public String generateAccessToken(Long userId, Role role) {
         Date expiryDate = calculateExpiryDate(jwtProperties.getAccessTokenExpiration());
         return createToken(userId, role, ACCESS_TOKEN, expiryDate);
     }
 
+    /**
+     * 리프레시 토큰을 단독으로 발급한다.
+     *
+     * @param userId 사용자 ID
+     * @param role   사용자 역할
+     * @return 리프레시 토큰 문자열
+     */
     public String generateRefreshToken(Long userId, Role role) {
         Date expiryDate = calculateExpiryDate(jwtProperties.getRefreshTokenExpiration());
         return createToken(userId, role, REFRESH_TOKEN, expiryDate);
@@ -76,6 +101,12 @@ public class JwtProvider {
                 .compact();
     }
 
+    /**
+     * JWT 토큰의 서명과 만료 여부를 검증한다.
+     *
+     * @param token 검증할 JWT 문자열
+     * @return 유효하면 {@code true}, 그렇지 않으면 {@code false}
+     */
     public boolean validateToken(String token) {
         try {
             Jwts.parser()
@@ -95,6 +126,12 @@ public class JwtProvider {
         return false;
     }
 
+    /**
+     * JWT 토큰에서 클레임을 추출한다.
+     *
+     * @param token JWT 문자열
+     * @return 파싱된 {@link Claims}
+     */
     public Claims getClaims(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
@@ -103,22 +140,52 @@ public class JwtProvider {
                 .getPayload();
     }
 
+    /**
+     * 클레임의 토큰 타입이 액세스 토큰인지 확인한다.
+     *
+     * @param claims JWT 클레임
+     * @return 액세스 토큰이면 {@code true}
+     */
     public boolean isAccessToken(Claims claims) {
         return ACCESS_TOKEN.equals(claims.get(TOKEN_TYPE, String.class));
     }
 
+    /**
+     * 클레임의 토큰 타입이 리프레시 토큰인지 확인한다.
+     *
+     * @param claims JWT 클레임
+     * @return 리프레시 토큰이면 {@code true}
+     */
     public boolean isRefreshToken(Claims claims) {
         return REFRESH_TOKEN.equals(claims.get(TOKEN_TYPE, String.class));
     }
 
+    /**
+     * 클레임에서 사용자 ID를 추출한다.
+     *
+     * @param claims JWT 클레임
+     * @return 사용자 ID
+     */
     public Long getUserId(Claims claims) {
         return Long.parseLong(claims.getSubject());
     }
 
+    /**
+     * 클레임에서 사용자 역할 문자열을 추출한다.
+     *
+     * @param claims JWT 클레임
+     * @return 역할 문자열 (예: "ADMIN", "USER")
+     */
     public String getRole(Claims claims) {
         return claims.get("role", String.class);
     }
 
+    /**
+     * HTTP 요청의 Authorization 헤더에서 Bearer 토큰을 추출한다.
+     *
+     * @param request HTTP 서블릿 요청
+     * @return 토큰 문자열, 헤더가 없거나 형식이 맞지 않으면 {@code null}
+     */
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
@@ -127,10 +194,23 @@ public class JwtProvider {
         return null;
     }
 
+    /**
+     * 토큰의 남은 만료 시간을 밀리초로 반환한다.
+     *
+     * @param claims JWT 클레임
+     * @return 남은 만료 시간 (밀리초)
+     */
     public long getRemainingExpireTime(Claims claims) {
         return claims.getExpiration().getTime() - System.currentTimeMillis();
     }
 
+    /**
+     * 만료된 토큰에서도 클레임을 추출한다.
+     * <p>리프레시 토큰 재발급 등 만료 이후에도 클레임이 필요한 경우에 사용한다.</p>
+     *
+     * @param token JWT 문자열 (만료 여부 무관)
+     * @return 파싱된 {@link Claims}
+     */
     public Claims getClaimsAllowExpired(String token) {
         try {
             return Jwts.parser()

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/EncoderConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/EncoderConfig.java
@@ -5,9 +5,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+/**
+ * 비밀번호 암호화를 위한 {@link PasswordEncoder} 빈 설정.
+ * <p>BCrypt strength 12를 사용한다.</p>
+ */
 @Configuration
 public class EncoderConfig {
 
+    /**
+     * BCrypt 기반 {@link PasswordEncoder} 빈을 생성한다.
+     *
+     * @return {@link PasswordEncoder} 빈
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder(12);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
@@ -24,6 +24,10 @@ import team.startup.gwangjutalentfestival.global.security.properties.CorsPropert
 
 import java.util.List;
 
+/**
+ * Spring Security 보안 설정.
+ * <p>JWT 필터 등록, URL별 접근 권한, CORS, CSRF, 세션 정책을 구성한다.</p>
+ */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -43,6 +47,13 @@ public class SecurityConfig {
             "/error"
     };
 
+    /**
+     * HTTP 보안 필터 체인을 구성한다.
+     *
+     * @param http {@link HttpSecurity} 객체
+     * @return 구성된 {@link SecurityFilterChain}
+     * @throws Exception 보안 설정 중 예외 발생 시
+     */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
@@ -92,6 +103,12 @@ public class SecurityConfig {
                 .build();
     }
 
+    /**
+     * CORS 설정 소스를 구성한다.
+     * <p>허용 출처는 {@link CorsProperties}에서 읽어온다.</p>
+     *
+     * @return {@link CorsConfigurationSource} 빈
+     */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/filter/JwtFilter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/filter/JwtFilter.java
@@ -23,6 +23,11 @@ import team.startup.gwangjutalentfestival.global.jwt.JwtProvider;
 
 import java.io.IOException;
 
+/**
+ * 요청당 한 번 실행되는 JWT 인증 필터.
+ * <p>Authorization 헤더에서 액세스 토큰을 추출하여 유효성 검증 후 {@link org.springframework.security.core.context.SecurityContext}에 인증 정보를 등록한다.
+ * 블랙리스트에 등록된 토큰은 거부한다.</p>
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/handler/JwtAccessDeniedHandler.java
@@ -13,6 +13,10 @@ import team.startup.gwangjutalentfestival.global.exception.ErrorResponse;
 
 import java.io.IOException;
 
+/**
+ * 인가 실패(403 Forbidden) 처리 핸들러.
+ * <p>인증은 되었으나 접근 권한이 없는 경우 JSON 형태의 에러 응답을 반환한다.</p>
+ */
 @RequiredArgsConstructor
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -13,6 +13,10 @@ import team.startup.gwangjutalentfestival.global.exception.ErrorResponse;
 
 import java.io.IOException;
 
+/**
+ * 인증 실패(401 Unauthorized) 처리 핸들러.
+ * <p>미인증 사용자가 보호된 리소스에 접근할 때 JSON 형태의 에러 응답을 반환한다.</p>
+ */
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/properties/CorsProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/properties/CorsProperties.java
@@ -6,6 +6,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
 
+/**
+ * CORS 허용 출처 설정 프로퍼티.
+ * <p>{@code cors.allowed-origins} 프로퍼티로 허용할 출처 목록을 바인딩한다.</p>
+ */
 @Getter
 @ConfigurationProperties(prefix = "cors")
 @Setter

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sms/adapter/SmsAdapter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sms/adapter/SmsAdapter.java
@@ -13,6 +13,10 @@ import team.startup.gwangjutalentfestival.global.sms.exception.SmsEmptyResponseE
 import team.startup.gwangjutalentfestival.global.sms.exception.SmsSendFailedException;
 import team.startup.gwangjutalentfestival.global.sms.properties.SolapiProperties;
 
+/**
+ * Solapi(nurigo SDK)를 이용한 SMS 전송 어댑터.
+ * <p>애플리케이션 시작 시 {@code DefaultMessageService}를 초기화하고, 인증번호 SMS 발송을 처리한다.</p>
+ */
 @Component
 @RequiredArgsConstructor
 public class SmsAdapter {
@@ -31,6 +35,14 @@ public class SmsAdapter {
         );
     }
 
+    /**
+     * 지정된 수신 번호로 인증번호 SMS를 발송한다.
+     *
+     * @param to   수신자 전화번호
+     * @param code 전송할 인증 코드
+     * @throws SmsSendFailedException     SMS 전송에 실패한 경우
+     * @throws SmsEmptyResponseException  SMS 응답이 없는 경우
+     */
     public void sendSms(String to, String code) {
         Message message = new Message();
         message.setFrom(solapiProperties.getSmsPhoneNumber());

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sms/exception/SmsEmptyResponseException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sms/exception/SmsEmptyResponseException.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.global.sms.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * SMS 전송 시 응답이 비어 있을 때 발생하는 예외.
+ * <p>Solapi API가 빈 응답을 반환하는 경우 발생한다.</p>
+ */
 public class SmsEmptyResponseException extends GlobalException {
     public SmsEmptyResponseException() {
         super(ErrorCode.SMS_EMPTY_RESPONSE);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sms/exception/SmsSendFailedException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sms/exception/SmsSendFailedException.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.global.sms.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * SMS 전송에 실패했을 때 발생하는 예외.
+ * <p>Solapi API 호출 중 전송 오류 또는 알 수 없는 오류가 발생한 경우 발생한다.</p>
+ */
 public class SmsSendFailedException extends GlobalException {
     public SmsSendFailedException() {
         super(ErrorCode.SMS_SEND_FAILED);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sms/properties/SmsVerifyProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sms/properties/SmsVerifyProperties.java
@@ -4,6 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * SMS 인증 관련 설정 프로퍼티.
+ * <p>최대 발송 횟수, 인증 코드/횟수 TTL, Redis 키 프리픽스를 {@code sms.verify.*}로 바인딩한다.</p>
+ */
 @Getter
 @AllArgsConstructor
 @ConfigurationProperties(prefix = "sms.verify")
@@ -13,6 +17,12 @@ public class SmsVerifyProperties {
     private long verifyCountTtl;
     private String verifyCountKeyPrefix;
 
+    /**
+     * 전화번호에 해당하는 인증 횟수 Redis 키를 반환한다.
+     *
+     * @param phoneNumber 전화번호
+     * @return Redis 키 문자열
+     */
     public String getVerifyCountKey(String phoneNumber) {
         return verifyCountKeyPrefix + phoneNumber;
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sms/properties/SolapiProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sms/properties/SolapiProperties.java
@@ -4,6 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * Solapi SMS API 연동 설정 프로퍼티.
+ * <p>API 키, 시크릿, 발신 번호, API URL을 {@code solapi.*}로 바인딩한다.</p>
+ */
 @Getter
 @AllArgsConstructor
 @ConfigurationProperties(prefix = "solapi")

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
@@ -7,12 +7,27 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * SSE Emitter를 관리하는 추상 기반 클래스.
+ * <p>키 타입({@code K}) 별로 {@link SseEmitter}를 {@link java.util.concurrent.ConcurrentHashMap}으로 저장하며,
+ * 연결 완료·타임아웃·에러 발생 시 자동으로 제거한다.
+ * 동일 키로 재연결 시 기존 Emitter를 완료 처리하여 리소스 누수를 방지한다.</p>
+ *
+ * @param <K> Emitter를 식별하는 키 타입
+ */
 public abstract class AbstractSseEmitterManager<K> {
 
     private static final long SSE_TIMEOUT_MILLIS = 60 * 60 * 1000L;
 
     private final Map<K, SseEmitter> emitters = new ConcurrentHashMap<>();
 
+    /**
+     * 새 {@link SseEmitter}를 생성하고 등록한다.
+     * <p>동일 키에 기존 Emitter가 있으면 완료 처리 후 교체한다.</p>
+     *
+     * @param key Emitter를 식별하는 키
+     * @return 생성된 {@link SseEmitter}
+     */
     public SseEmitter addEmitter(K key) {
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
 
@@ -28,10 +43,21 @@ public abstract class AbstractSseEmitterManager<K> {
         return emitter;
     }
 
+    /**
+     * 키에 해당하는 {@link SseEmitter}를 조회한다.
+     *
+     * @param key 조회할 키
+     * @return {@link SseEmitter}를 감싼 {@link Optional}, 없으면 empty
+     */
     public Optional<SseEmitter> getEmitter(K key) {
         return Optional.ofNullable(emitters.get(key));
     }
 
+    /**
+     * 현재 등록된 모든 {@link SseEmitter}를 반환한다.
+     *
+     * @return 등록된 Emitter 컬렉션
+     */
     public Collection<SseEmitter> getAllEmitters() {
         return emitters.values();
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
@@ -4,13 +4,38 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 
+/**
+ * SSE 이벤트를 전체 구독자에게 전송하는 추상 리스너.
+ * <p>구체 클래스는 {@link #getEmitterManager()}와 {@link #getEventName()}을 구현하여
+ * 도메인별 Emitter 관리자와 이벤트 이름을 제공한다.
+ * {@link #sendToAll(Object)}를 호출하면 연결된 모든 SSE 클라이언트에 이벤트가 전송된다.</p>
+ *
+ * @param <E> 전송할 이벤트 데이터 타입
+ */
 @Slf4j
 public abstract class AbstractSseEventListener<E> {
 
+    /**
+     * 이벤트를 전송할 {@link AbstractSseEmitterManager}를 반환한다.
+     *
+     * @return 도메인별 Emitter 관리자
+     */
     protected abstract AbstractSseEmitterManager<?> getEmitterManager();
 
+    /**
+     * SSE 이벤트 이름을 반환한다.
+     *
+     * @return 이벤트 이름 문자열
+     */
     protected abstract String getEventName();
 
+    /**
+     * 연결된 모든 SSE 클라이언트에 이벤트를 전송한다.
+     * <p>각 Emitter에 동기화(synchronized)하여 스레드 안전성을 보장하며,
+     * 전송 실패 시 해당 Emitter를 오류 완료 처리한다.</p>
+     *
+     * @param event 전송할 이벤트 데이터
+     */
     protected void sendToAll(E event) {
         for (SseEmitter emitter : getEmitterManager().getAllEmitters()) {
             synchronized (emitter) {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/JudgeSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/JudgeSseEmitterManager.java
@@ -2,6 +2,10 @@ package team.startup.gwangjutalentfestival.global.sse;
 
 import org.springframework.stereotype.Component;
 
+/**
+ * 심사(Judge) 도메인의 SSE Emitter 관리자.
+ * <p>사용자 ID({@link Long})를 키로 사용하여 심사 관련 SSE 연결을 관리한다.</p>
+ */
 @Component
 public class JudgeSseEmitterManager extends AbstractSseEmitterManager<Long> {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/SeatSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/SeatSseEmitterManager.java
@@ -2,6 +2,10 @@ package team.startup.gwangjutalentfestival.global.sse;
 
 import org.springframework.stereotype.Component;
 
+/**
+ * 좌석(Seat) 도메인의 SSE Emitter 관리자.
+ * <p>좌석 구역 문자열({@link String})을 키로 사용하여 좌석 변경 SSE 연결을 관리한다.</p>
+ */
 @Component
 public class SeatSseEmitterManager extends AbstractSseEmitterManager<String> {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapter.java
@@ -15,6 +15,11 @@ import com.google.api.services.sheets.v4.model.ValueRange;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Google Sheets API 연동 어댑터.
+ * <p>슬로건 데이터를 Google Sheets에 행(row) 단위로 추가하는 기능을 제공한다.
+ * API 오류, IO 오류, 예상치 못한 오류를 각각 도메인 예외로 변환하여 던진다.</p>
+ */
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -23,6 +28,14 @@ public class GoogleSheetsAdapter {
     private final Sheets sheets;
     private final GoogleSheetsProperties properties;
 
+    /**
+     * 슬로건 데이터 목록을 Google Sheets에 추가한다.
+     *
+     * @param data 추가할 슬로건 행 데이터 목록
+     * @throws GoogleSheetsApiException Google Sheets API 오류 발생 시
+     * @throws GoogleSheetsIoException  네트워크/IO 오류 발생 시
+     * @throws GoogleSheetsException    그 외 예기치 못한 오류 발생 시
+     */
     public void appendSlogan(List<SloganSheetRowData> data) {
         List<List<Object>> rows = getList(data);
         String sheetId = properties.sheetId();

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/config/GoogleSheetsConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/config/GoogleSheetsConfig.java
@@ -19,11 +19,23 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.List;
 
+/**
+ * Google Sheets API 클라이언트 빈 설정.
+ * <p>서비스 계정 자격증명을 통해 인증된 {@link Sheets} 빈을 생성하여 등록한다.
+ * 초기화 실패 시 {@link GoogleSheetsInitException}을 던진다.</p>
+ */
 @Slf4j
 @Configuration
 @EnableConfigurationProperties(GoogleSheetsProperties.class)
 public class GoogleSheetsConfig {
 
+    /**
+     * Google Sheets API 클라이언트를 생성한다.
+     *
+     * @param properties Google Sheets 설정 프로퍼티
+     * @return 인증된 {@link Sheets} 빈
+     * @throws GoogleSheetsInitException 인증 파일 읽기 실패 또는 TLS 초기화 실패 시
+     */
     @Bean
     public Sheets sheets(GoogleSheetsProperties properties) {
         try {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/exception/GoogleSheetsApiException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/exception/GoogleSheetsApiException.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.global.thirdparty.google.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * Google Sheets API 호출 중 API 오류가 발생했을 때 던지는 예외.
+ * <p>{@link com.google.api.client.googleapis.json.GoogleJsonResponseException} 발생 시 변환된다.</p>
+ */
 public class GoogleSheetsApiException extends GlobalException {
     public GoogleSheetsApiException() {
         super(ErrorCode.GOOGLE_SHEETS_API_ERROR);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/exception/GoogleSheetsException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/exception/GoogleSheetsException.java
@@ -3,6 +3,9 @@ package team.startup.gwangjutalentfestival.global.thirdparty.google.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * Google Sheets 연동 중 예상치 못한 오류가 발생했을 때 던지는 예외.
+ */
 public class GoogleSheetsException extends GlobalException {
     public GoogleSheetsException() {
         super(ErrorCode.GOOGLE_SHEETS);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/exception/GoogleSheetsInitException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/exception/GoogleSheetsInitException.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.global.thirdparty.google.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * Google Sheets 클라이언트 초기화에 실패했을 때 던지는 예외.
+ * <p>인증 파일 읽기 실패 또는 TLS 초기화 실패 시 발생한다.</p>
+ */
 public class GoogleSheetsInitException extends GlobalException {
     public GoogleSheetsInitException() {
         super(ErrorCode.GOOGLE_SHEETS_INIT_ERROR);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/exception/GoogleSheetsIoException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/exception/GoogleSheetsIoException.java
@@ -3,6 +3,10 @@ package team.startup.gwangjutalentfestival.global.thirdparty.google.exception;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
+/**
+ * Google Sheets 서버와 통신 중 IO 오류가 발생했을 때 던지는 예외.
+ * <p>네트워크 장애 등 {@link java.io.IOException} 발생 시 변환된다.</p>
+ */
 public class GoogleSheetsIoException extends GlobalException {
     public GoogleSheetsIoException() {
         super(ErrorCode.GOOGLE_SHEETS_IO_ERROR);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/properties/GoogleSheetsProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/properties/GoogleSheetsProperties.java
@@ -2,6 +2,14 @@ package team.startup.gwangjutalentfestival.global.thirdparty.google.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * Google Sheets 연동 설정 프로퍼티.
+ * <p>{@code google.sheets.*} 프로퍼티로 서비스 계정 자격증명, 스프레드시트 ID, 시트 페이지를 바인딩한다.</p>
+ *
+ * @param accountCredential 서비스 계정 JSON 자격증명 문자열
+ * @param sheetId           Google 스프레드시트 ID
+ * @param sheetPage         데이터를 기록할 시트 페이지 이름
+ */
 @ConfigurationProperties(prefix = "google.sheets")
 public record GoogleSheetsProperties(
         String accountCredential,

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/RandomUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/RandomUtil.java
@@ -4,10 +4,20 @@ import org.springframework.stereotype.Component;
 
 import java.security.SecureRandom;
 
+/**
+ * 보안 난수 기반 코드 생성 유틸리티.
+ * <p>{@link SecureRandom}을 사용하여 예측 불가능한 숫자 코드를 생성한다.</p>
+ */
 @Component
 public class RandomUtil {
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
+    /**
+     * 지정된 길이의 숫자 랜덤 코드를 생성한다.
+     *
+     * @param length 생성할 코드 길이
+     * @return 숫자로만 이루어진 랜덤 코드 문자열
+     */
     public String createRandomCode(int length) {
         String digits = "0123456789";
         StringBuilder sb = new StringBuilder(length);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
@@ -6,6 +6,10 @@ import team.startup.gwangjutalentfestival.domain.seat.exception.InvalidSeatSecti
 import java.util.List;
 import java.util.Map;
 
+/**
+ * 좌석 구역 및 최대 좌석 수 관리 유틸리티.
+ * <p>구역별 최대 좌석 수를 내부 맵으로 관리하며, 유효하지 않은 구역 조회 시 예외를 던진다.</p>
+ */
 @Component
 public class SeatUtil {
     private static final Map<String, Integer> SEAT_MAP = Map.of(
@@ -13,10 +17,22 @@ public class SeatUtil {
             "F", 54, "G", 100, "H", 119, "I", 100, "J", 54
     );
 
+    /**
+     * 전체 좌석 구역 목록을 알파벳 오름차순으로 반환한다.
+     *
+     * @return 정렬된 구역 문자열 목록
+     */
     public List<String> getSections() {
         return SEAT_MAP.keySet().stream().sorted().toList();
     }
 
+    /**
+     * 지정된 구역의 최대 좌석 수를 반환한다.
+     *
+     * @param section 구역 문자 (예: "A", "B")
+     * @return 해당 구역의 최대 좌석 수
+     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.InvalidSeatSectionException 유효하지 않은 구역인 경우
+     */
     public Integer getMaxSeats(String section) {
         if (!SEAT_MAP.containsKey(section)) {
             throw new InvalidSeatSectionException();

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/UserUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/UserUtil.java
@@ -9,12 +9,22 @@ import team.startup.gwangjutalentfestival.domain.user.exception.UserNotFoundExce
 import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 import team.startup.gwangjutalentfestival.global.auth.CustomUserDetails;
 
+/**
+ * 현재 인증된 사용자 정보를 조회하는 유틸리티.
+ * <p>{@link org.springframework.security.core.context.SecurityContext}에서 사용자 ID와 역할을 추출하거나,
+ * DB에서 사용자 엔티티를 조회하는 편의 메서드를 제공한다.</p>
+ */
 @Component
 @RequiredArgsConstructor
 public class UserUtil {
 
     private final UserRepository userRepository;
 
+    /**
+     * 현재 인증된 사용자의 ID를 반환한다.
+     *
+     * @return 현재 사용자 ID
+     */
     public static Long getCurrentUserId() {
         return ((CustomUserDetails) SecurityContextHolder.getContext()
                 .getAuthentication()
@@ -22,6 +32,11 @@ public class UserUtil {
                 .getUserId();
     }
 
+    /**
+     * 현재 인증된 사용자의 역할을 반환한다.
+     *
+     * @return 현재 사용자 역할
+     */
     public static Role getCurrentUserRole() {
         return ((CustomUserDetails) SecurityContextHolder.getContext()
                 .getAuthentication()
@@ -29,19 +44,41 @@ public class UserUtil {
                 .getRole();
     }
 
+    /**
+     * 현재 인증된 사용자의 엔티티를 DB에서 조회한다.
+     *
+     * @return 현재 사용자 엔티티
+     * @throws team.startup.gwangjutalentfestival.domain.user.exception.UserNotFoundException 사용자가 존재하지 않을 경우
+     */
     public UserEntity getCurrentUser() {
         return userRepository.findById(getCurrentUserId())
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    /**
+     * 현재 인증된 사용자의 프록시 참조(Lazy 로딩)를 반환한다.
+     * <p>실제 DB 조회 없이 참조만 필요한 경우 사용한다.</p>
+     *
+     * @return 현재 사용자 엔티티 프록시 참조
+     */
     public UserEntity getCurrentUserRef() {
         return userRepository.getReferenceById(getCurrentUserId());
     }
 
+    /**
+     * 현재 인증된 사용자의 ID를 반환한다. {@link #getCurrentUserId()}의 인스턴스 메서드 래퍼.
+     *
+     * @return 현재 사용자 ID
+     */
     public Long currentUserId() {
         return getCurrentUserId();
     }
 
+    /**
+     * 현재 인증된 사용자의 역할을 반환한다. {@link #getCurrentUserRole()}의 인스턴스 메서드 래퍼.
+     *
+     * @return 현재 사용자 역할
+     */
     public Role currentUserRole() {
         return getCurrentUserRole();
     }


### PR DESCRIPTION
## ✨ 작업 내용
> auth, judge, seat, slogan, team, user, global 전체 도메인의 클래스, 메서드, 필드에 JavaDoc을 추가하였습니다.


---

## 🔍 리뷰 시 참고사항
- 174개 파일에 걸쳐 JavaDoc이 추가되었습니다.
- 기존 로직 변경 없이 문서화 작업만 진행되었습니다.
- Controller, Service, Repository, Entity, DTO, Exception 등 전 계층에 적용되었습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #60
