### PR TITLE
seat 서비스 책임 분리 및 중복 로직 추출

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/AbstractCancelSeatReservationService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/AbstractCancelSeatReservationService.java
@@ -1,0 +1,23 @@
+package team.startup.gwangjutalentfestival.domain.seat.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
+import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
+
+@RequiredArgsConstructor
+public abstract class AbstractCancelSeatReservationService {
+
+    protected final SeatReservationRepository seatReservationRepository;
+    protected final ApplicationEventPublisher applicationEventPublisher;
+
+    protected void cancelAndPublish(SeatEntity seat) {
+        seatReservationRepository.delete(seat);
+        applicationEventPublisher.publishEvent(new SeatChangeEvent(
+                seat.getSeatSection(),
+                seat.getSeatNumber(),
+                true
+        ));
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImpl.java
@@ -1,6 +1,5 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
@@ -8,30 +7,26 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
-import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.CancelSeatReservationService;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
-/**
- * {@link CancelSeatReservationService}의 구현체.
- * 현재 로그인한 사용자의 예약을 삭제하고 SSE 이벤트를 발행하며, 관련 캐시를 무효화한다.
- */
 @Service
-@RequiredArgsConstructor
-public class CancelSeatReservationServiceImpl implements CancelSeatReservationService {
+public class CancelSeatReservationServiceImpl extends AbstractCancelSeatReservationService implements CancelSeatReservationService {
 
-    private final SeatReservationRepository seatReservationRepository;
     private final UserUtil userUtil;
-    private final ApplicationEventPublisher applicationEventPublisher;
 
-    /**
-     * 현재 로그인한 사용자의 좌석 예약을 취소하고 SSE 이벤트를 발행한다.
-     *
-     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException 예약된 좌석이 없을 때
-     */
+    public CancelSeatReservationServiceImpl(
+            SeatReservationRepository seatReservationRepository,
+            ApplicationEventPublisher applicationEventPublisher,
+            UserUtil userUtil
+    ) {
+        super(seatReservationRepository, applicationEventPublisher);
+        this.userUtil = userUtil;
+    }
+
     @Override
     @Transactional
     @Caching(evict = {
@@ -44,12 +39,6 @@ public class CancelSeatReservationServiceImpl implements CancelSeatReservationSe
         SeatEntity seat = seatReservationRepository.findByUser(user)
                 .orElseThrow(SeatNotFoundException::new);
 
-        seatReservationRepository.delete(seat);
-
-        applicationEventPublisher.publishEvent(new SeatChangeEvent(
-                seat.getSeatSection(),
-                seat.getSeatNumber(),
-                true
-        ));
+        cancelAndPublish(seat);
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
@@ -17,12 +17,7 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-/**
- * {@link GetAllSeatsService}의 구현체.
- * 현재 사용자 역할을 기준으로 전체 구역 좌석 현황을 조회하며, Redis 캐시를 활용한다.
- */
 @Service
 @RequiredArgsConstructor
 public class GetAllSeatsServiceImpl implements GetAllSeatsService {
@@ -32,12 +27,6 @@ public class GetAllSeatsServiceImpl implements GetAllSeatsService {
     private final SeatBanCustomRepository seatBanCustomRepository;
     private final SeatReservationCustomRepository seatReservationCustomRepository;
 
-    /**
-     * 현재 사용자 역할에 맞는 전체 구역 좌석 현황을 반환한다.
-     * 역할별로 캐시가 분리되어 적용된다.
-     *
-     * @return 구역별 좌석 가용 여부 맵
-     */
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.SEATS_ALL, key = "@userUtil.currentUserRole()")
@@ -60,32 +49,12 @@ public class GetAllSeatsServiceImpl implements GetAllSeatsService {
                 ));
 
         Map<String, GetSeatsBySectionResponse> responseMap = new LinkedHashMap<>();
-
         for (String section : seatUtil.getSections()) {
             Set<Integer> bans = seatBansMap.getOrDefault(section, Set.of());
             Set<Integer> reservations = seatReservationMap.getOrDefault(section, Set.of());
-            responseMap.put(section, getSeatResponse(section, bans, reservations));
+            responseMap.put(section, seatUtil.buildSeatAvailability(section, bans, reservations));
         }
 
         return new GetAllSeatsResponse(responseMap);
-    }
-
-    /**
-     * 특정 구역의 차단·예약 정보를 기반으로 좌석 가용 여부 목록을 생성한다.
-     *
-     * @param section      좌석 구역
-     * @param bans         차단된 좌석 번호 집합
-     * @param reservations 예약된 좌석 번호 집합
-     * @return 좌석별 예약 가능 여부 목록
-     */
-    private GetSeatsBySectionResponse getSeatResponse(
-            String section, Set<Integer> bans, Set<Integer> reservations) {
-        Integer seatLastNumber = seatUtil.getMaxSeats(section);
-
-        List<Boolean> seats = IntStream.rangeClosed(1, seatLastNumber)
-                .mapToObj(i -> !bans.contains(i) && !reservations.contains(i))
-                .toList();
-
-        return new GetSeatsBySectionResponse(seats);
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
@@ -13,14 +13,8 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
-import java.util.List;
 import java.util.Set;
-import java.util.stream.IntStream;
 
-/**
- * {@link GetSeatsBySectionService}의 구현체.
- * 현재 사용자 역할을 기준으로 특정 구역의 좌석 가용 여부를 조회하며, Redis 캐시를 활용한다.
- */
 @Service
 @RequiredArgsConstructor
 public class GetSeatsBySectionServiceImpl implements GetSeatsBySectionService {
@@ -30,27 +24,15 @@ public class GetSeatsBySectionServiceImpl implements GetSeatsBySectionService {
     private final SeatReservationCustomRepository seatReservationCustomRepository;
     private final SeatBanCustomRepository seatBanCustomRepository;
 
-    /**
-     * 현재 사용자 역할에 맞는 특정 구역의 좌석 가용 여부 목록을 반환한다.
-     * 구역·역할 조합으로 캐시가 분리되어 적용된다.
-     *
-     * @param section 조회할 좌석 구역 (A~J)
-     * @return 해당 구역의 좌석별 예약 가능 여부 목록
-     */
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.SEATS_SECTION, key = "#section + ':' + @userUtil.currentUserRole()")
     public GetSeatsBySectionResponse execute(String section) {
         Role role = userUtil.currentUserRole();
-        Integer seatLastNumber = seatUtil.getMaxSeats(section);
 
         Set<Integer> reservedSeatNumbers = seatReservationCustomRepository.findSeatNumbersBySeatSection(section);
         Set<Integer> bannedSeatNumbers = seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(section, role);
 
-        List<Boolean> seats = IntStream.rangeClosed(1, seatLastNumber)
-                .mapToObj(i -> !bannedSeatNumbers.contains(i) && !reservedSeatNumbers.contains(i))
-                .toList();
-
-        return new GetSeatsBySectionResponse(seats);
+        return seatUtil.buildSeatAvailability(section, bannedSeatNumbers, reservedSeatNumbers);
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImpl.java
@@ -1,6 +1,5 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
@@ -8,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
-import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.PerformerCancelSeatReservationRequest;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
@@ -16,24 +14,20 @@ import team.startup.gwangjutalentfestival.domain.seat.service.PerformerCancelSea
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
-/**
- * {@link PerformerCancelSeatReservationService}의 구현체.
- * 공연자 본인의 특정 좌석 예약을 취소하고 SSE 이벤트를 발행하며, 관련 캐시를 무효화한다.
- */
 @Service
-@RequiredArgsConstructor
-public class PerformerCancelSeatReservationServiceImpl implements PerformerCancelSeatReservationService {
+public class PerformerCancelSeatReservationServiceImpl extends AbstractCancelSeatReservationService implements PerformerCancelSeatReservationService {
 
-    private final SeatReservationRepository seatReservationRepository;
     private final UserUtil userUtil;
-    private final ApplicationEventPublisher applicationEventPublisher;
 
-    /**
-     * 공연자의 특정 좌석 예약을 취소하고 SSE 이벤트를 발행한다.
-     *
-     * @param request 취소할 좌석의 구역 및 번호 정보
-     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException 해당 좌석의 예약 정보가 없을 때
-     */
+    public PerformerCancelSeatReservationServiceImpl(
+            SeatReservationRepository seatReservationRepository,
+            ApplicationEventPublisher applicationEventPublisher,
+            UserUtil userUtil
+    ) {
+        super(seatReservationRepository, applicationEventPublisher);
+        this.userUtil = userUtil;
+    }
+
     @Override
     @Transactional
     @Caching(evict = {
@@ -49,12 +43,6 @@ public class PerformerCancelSeatReservationServiceImpl implements PerformerCance
                 user
         ).orElseThrow(SeatNotFoundException::new);
 
-        seatReservationRepository.delete(seat);
-
-        applicationEventPublisher.publishEvent(new SeatChangeEvent(
-                request.seatSection(),
-                request.seatNumber(),
-                true
-        ));
+        cancelAndPublish(seat);
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -39,7 +39,7 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
 
         seatReservationValidator.validateSeatRange(seatNumber, seatUtil.getMaxSeats(seatSection));
         seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
-        seatReservationValidator.validateReservationLimit(UserUtil.getCurrentUserId());
+        seatReservationValidator.validateReservationLimit();
 
         SeatEntity seat = SeatEntity.builder()
                 .seatNumber(seatNumber)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -11,45 +11,22 @@ import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
-import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBannedException;
-import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotExistsInSectionException;
-import team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationLimitExceededException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.ReservationSeatRequest;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.ReservationSeatService;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
-import static team.startup.gwangjutalentfestival.domain.user.enums.Role.PERFORMER;
-
-/**
- * {@link ReservationSeatService}의 구현체.
- * 좌석 유효성, 예약·차단 여부, 예약 한도를 검증한 후 좌석을 예약하고 SSE 이벤트를 발행한다.
- * 동시 요청 충돌은 DB 유니크 제약을 통해 처리하며, 관련 캐시를 무효화한다.
- */
 @Service
 @RequiredArgsConstructor
 public class ReservationSeatServiceImpl implements ReservationSeatService {
 
     private final SeatReservationRepository seatReservationRepository;
+    private final SeatReservationValidator seatReservationValidator;
     private final SeatUtil seatUtil;
     private final UserUtil userUtil;
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    private static final int PERFORMER_SEAT_LIMIT = 3;
-    private static final int DEFAULT_SEAT_LIMIT = 1;
-    private static final int RESERVED = 1;
-    private static final int BANNED = 2;
-
-    /**
-     * 요청한 좌석을 현재 로그인한 사용자에게 예약한다.
-     *
-     * @param request 예약할 좌석의 구역 및 번호 정보
-     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotExistsInSectionException 좌석 번호가 구역 범위를 벗어날 때
-     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException 이미 예약된 좌석일 때
-     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatBannedException 차단된 좌석일 때
-     * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationLimitExceededException 예약 한도를 초과했을 때
-     */
     @Override
     @Transactional
     @Caching(evict = {
@@ -60,23 +37,9 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
         String seatSection = request.seatSection();
         Integer seatNumber = request.seatNumber();
 
-        Integer maxSeats = seatUtil.getMaxSeats(seatSection);
-        if (seatNumber < 1 || seatNumber > maxSeats) {
-            throw new SeatNotExistsInSectionException();
-        }
-
-        int availability = seatReservationRepository.checkAvailability(seatSection, seatNumber);
-        if ((availability & RESERVED) != 0) throw new SeatAlreadyReservedException();
-        if ((availability & BANNED) != 0) throw new SeatBannedException();
-
-        long userId = UserUtil.getCurrentUserId();
-        long reserveCount = seatReservationRepository.countByUserId(userId);
-
-        int limit = UserUtil.getCurrentUserRole() == PERFORMER ? PERFORMER_SEAT_LIMIT : DEFAULT_SEAT_LIMIT;
-
-        if (reserveCount >= limit) {
-            throw new SeatReservationLimitExceededException();
-        }
+        seatReservationValidator.validateSeatRange(seatNumber, seatUtil.getMaxSeats(seatSection));
+        seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
+        seatReservationValidator.validateReservationLimit(UserUtil.getCurrentUserId());
 
         SeatEntity seat = SeatEntity.builder()
                 .seatNumber(seatNumber)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
@@ -16,6 +16,7 @@ import static team.startup.gwangjutalentfestival.domain.user.enums.Role.PERFORME
 public class SeatReservationValidator {
 
     private final SeatReservationRepository seatReservationRepository;
+    private final UserUtil userUtil;
 
     private static final int PERFORMER_SEAT_LIMIT = 3;
     private static final int DEFAULT_SEAT_LIMIT = 1;
@@ -34,9 +35,10 @@ public class SeatReservationValidator {
         if ((availability & BANNED) != 0) throw new SeatBannedException();
     }
 
-    public void validateReservationLimit(long userId) {
+    public void validateReservationLimit() {
+        long userId = userUtil.getCurrentUserId();
         long reserveCount = seatReservationRepository.countByUserId(userId);
-        int limit = UserUtil.getCurrentUserRole() == PERFORMER ? PERFORMER_SEAT_LIMIT : DEFAULT_SEAT_LIMIT;
+        int limit = userUtil.currentUserRole() == PERFORMER ? PERFORMER_SEAT_LIMIT : DEFAULT_SEAT_LIMIT;
         if (reserveCount >= limit) {
             throw new SeatReservationLimitExceededException();
         }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
@@ -1,0 +1,44 @@
+package team.startup.gwangjutalentfestival.domain.seat.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBannedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotExistsInSectionException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationLimitExceededException;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import static team.startup.gwangjutalentfestival.domain.user.enums.Role.PERFORMER;
+
+@Component
+@RequiredArgsConstructor
+public class SeatReservationValidator {
+
+    private final SeatReservationRepository seatReservationRepository;
+
+    private static final int PERFORMER_SEAT_LIMIT = 3;
+    private static final int DEFAULT_SEAT_LIMIT = 1;
+    private static final int RESERVED = 1;
+    private static final int BANNED = 2;
+
+    public void validateSeatRange(Integer seatNumber, Integer maxSeats) {
+        if (seatNumber < 1 || seatNumber > maxSeats) {
+            throw new SeatNotExistsInSectionException();
+        }
+    }
+
+    public void validateSeatAvailability(String seatSection, Integer seatNumber) {
+        int availability = seatReservationRepository.checkAvailability(seatSection, seatNumber);
+        if ((availability & RESERVED) != 0) throw new SeatAlreadyReservedException();
+        if ((availability & BANNED) != 0) throw new SeatBannedException();
+    }
+
+    public void validateReservationLimit(long userId) {
+        long reserveCount = seatReservationRepository.countByUserId(userId);
+        int limit = UserUtil.getCurrentUserRole() == PERFORMER ? PERFORMER_SEAT_LIMIT : DEFAULT_SEAT_LIMIT;
+        if (reserveCount >= limit) {
+            throw new SeatReservationLimitExceededException();
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
@@ -2,9 +2,12 @@ package team.startup.gwangjutalentfestival.global.util;
 
 import org.springframework.stereotype.Component;
 import team.startup.gwangjutalentfestival.domain.seat.exception.InvalidSeatSectionException;
+import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetSeatsBySectionResponse;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
 
 /**
  * 좌석 구역 및 최대 좌석 수 관리 유틸리티.
@@ -38,5 +41,12 @@ public class SeatUtil {
             throw new InvalidSeatSectionException();
         }
         return SEAT_MAP.get(section);
+    }
+
+    public GetSeatsBySectionResponse buildSeatAvailability(String section, Set<Integer> bans, Set<Integer> reservations) {
+        List<Boolean> seats = IntStream.rangeClosed(1, getMaxSeats(section))
+                .mapToObj(i -> !bans.contains(i) && !reservations.contains(i))
+                .toList();
+        return new GetSeatsBySectionResponse(seats);
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

seat 도메인 서비스의 과도한 책임을 분리하고, 여러 서비스에 흩어져 있던 중복 로직을 공통 컴포넌트로 추출하였습니다.

**책임 분리**
- `SeatReservationValidator` 컴포넌트를 신규 생성하여 `ReservationSeatServiceImpl`의 검증 로직(좌석 범위, 가용성, 예약 한도) 3가지를 이관하였습니다.

**중복 로직 추출**
- `AbstractCancelSeatReservationService` 추상 클래스를 신규 생성하여 `CancelSeatReservationServiceImpl`과 `PerformerCancelSeatReservationServiceImpl`에 중복되던 취소 + SSE 이벤트 발행 로직을 `cancelAndPublish()` 메서드로 통합하였습니다.
- `SeatUtil`에 `buildSeatAvailability()` 메서드를 추가하여 `GetAllSeatsServiceImpl`과 `GetSeatsBySectionServiceImpl`에 동일하게 존재하던 좌석 가용성 계산 로직을 단일 구현으로 통합하였습니다.

---

## 🔍 리뷰 시 참고사항
- `AbstractCancelSeatReservationService`는 `@RequiredArgsConstructor` 대신 명시적 생성자를 사용합니다. Lombok의 `@RequiredArgsConstructor`는 상속 구조에서 부모 생성자를 자동 호출하지 않으므로, 수동으로 `super()` 호출이 필요합니다.
- `SeatReservationValidator`는 `@Component`로 등록되어 있으며, 검증 실패 시 기존과 동일한 예외를 던지도록 유지되었습니다.
- 기존 비즈니스 로직 변경 없이 구조 개선만 이루어졌습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #64
