### PR TITLE
Swagger 경로 허용 및 springdoc 버전 업그레이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     // API Documentation
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
     // SMS
     implementation 'net.nurigo:sdk:4.3.0'

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
@@ -44,7 +44,9 @@ public class SecurityConfig {
             "/health/**",
             "/excel/**",
             "/vote/{teamId}",
-            "/error"
+            "/error",
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
     };
 
     /**


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

Spring Security의 `PUBLIC_URLS`에 Swagger UI 접근 경로가 누락되어 인증 없이 API 문서에 접근할 수 없던 문제를 해결하였습니다.
또한 Spring Boot 3.5.x와의 호환성을 위해 `springdoc-openapi` 버전을 `2.5.0`에서 `2.8.8`로 업그레이드하였습니다.

- `SecurityConfig`: `/swagger-ui/**`, `/v3/api-docs/**` 경로를 인증 없이 접근 가능하도록 허용하였습니다.
- `build.gradle`: `springdoc-openapi-starter-webmvc-ui` 버전을 `2.8.8`로 업그레이드하였습니다.

---

## 🔍 리뷰 시 참고사항
- Swagger UI는 개발 환경에서 API 명세 확인 용도로 사용되므로 인증 없이 접근 가능하도록 설정하였습니다.
- `springdoc-openapi 2.5.0`은 Spring Boot 3.5.x 환경에서 일부 호환 문제가 발생할 수 있어 최신 버전으로 업그레이드하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #66
