### PR TITLE
slogan 요청 DTO의 유효성 검증 오류 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/request/CreateSloganRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/request/CreateSloganRequest.java
@@ -26,6 +26,7 @@ public record CreateSloganRequest(
         @NotBlank
         String phoneNumber,
 
+        @NotNull
         SchoolStatus schoolStatus,
 
         @NotBlank

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/request/CreateSloganRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/presentation/data/request/CreateSloganRequest.java
@@ -26,7 +26,6 @@ public record CreateSloganRequest(
         @NotBlank
         String phoneNumber,
 
-        @NotBlank
         SchoolStatus schoolStatus,
 
         @NotBlank


### PR DESCRIPTION
## ✨ 작업 내용
`CreateSloganRequest`의 `schoolStatus` 필드에 잘못 적용된 `@NotBlank` 어노테이션을 제거하였습니다.

`@NotBlank`는 `String` 타입에만 적용 가능한 제약 조건으로, `SchoolStatus` enum 필드에 사용할 경우 유효성 검증 오류가 발생하였습니다. 해당 어노테이션을 제거하여 정상적으로 동작하도록 수정하였습니다.

---

## 🔍 리뷰 시 참고사항
- `@NotBlank`는 `CharSequence` 타입에만 적용 가능하며, enum 타입인 `SchoolStatus`에는 사용할 수 없습니다.
- enum 필드의 null 검증이 필요한 경우 `@NotNull`을 사용해야 합니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #
