### PR TITLE
SSE 스레드·커넥션 풀·브로드캐스트 최적화

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeEventServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeEventServiceImpl.java
@@ -10,6 +10,8 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * {@link ConnectSseJudgeEventService} 구현체.
@@ -35,9 +37,9 @@ public class ConnectSseJudgeEventServiceImpl implements ConnectSseJudgeEventServ
     public SseEmitter execute() {
         Long userId = UserUtil.getCurrentUserId();
 
-        var beatHolder = new java.util.concurrent.atomic.AtomicReference<java.util.concurrent.ScheduledFuture<?>>();
+        AtomicReference<ScheduledFuture<?>> beatHolder = new AtomicReference<>();
         SseEmitter emitter = judgeSseEmitterManager.addEmitter(userId,
-                () -> { var b = beatHolder.get(); if (b != null) b.cancel(true); });
+                () -> { ScheduledFuture<?> b = beatHolder.get(); if (b != null) b.cancel(true); });
 
         try {
             emitter.send(SseEmitter.event()
@@ -49,7 +51,7 @@ public class ConnectSseJudgeEventServiceImpl implements ConnectSseJudgeEventServ
             return emitter;
         }
 
-        var beat = taskScheduler.scheduleAtFixedRate(() -> {
+        ScheduledFuture<?> beat = taskScheduler.scheduleAtFixedRate(() -> {
             try {
                 emitter.send(SseEmitter.event()
                         .name(HEARTBEAT_EVENT)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeEventServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeEventServiceImpl.java
@@ -11,6 +11,7 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -37,9 +38,13 @@ public class ConnectSseJudgeEventServiceImpl implements ConnectSseJudgeEventServ
     public SseEmitter execute() {
         Long userId = UserUtil.getCurrentUserId();
 
+        AtomicBoolean cancelled = new AtomicBoolean(false);
         AtomicReference<ScheduledFuture<?>> beatHolder = new AtomicReference<>();
-        SseEmitter emitter = judgeSseEmitterManager.addEmitter(userId,
-                () -> { ScheduledFuture<?> b = beatHolder.get(); if (b != null) b.cancel(true); });
+        SseEmitter emitter = judgeSseEmitterManager.addEmitter(userId, () -> {
+            cancelled.set(true);
+            ScheduledFuture<?> b = beatHolder.get();
+            if (b != null) b.cancel(true);
+        });
 
         try {
             emitter.send(SseEmitter.event()
@@ -62,6 +67,7 @@ public class ConnectSseJudgeEventServiceImpl implements ConnectSseJudgeEventServ
             }
         }, Duration.ofSeconds(15));
         beatHolder.set(beat);
+        if (cancelled.get()) beat.cancel(true);
 
         return emitter;
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeEventServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeEventServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.gwangjutalentfestival.domain.judge.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeEventService;
@@ -8,10 +9,7 @@ import team.startup.gwangjutalentfestival.global.sse.JudgeSseEmitterManager;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.io.IOException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.time.Duration;
 
 /**
  * {@link ConnectSseJudgeEventService} 구현체.
@@ -21,12 +19,11 @@ import java.util.concurrent.atomic.AtomicReference;
 @RequiredArgsConstructor
 public class ConnectSseJudgeEventServiceImpl implements ConnectSseJudgeEventService {
     private final JudgeSseEmitterManager judgeSseEmitterManager;
-    private final UserUtil userUtil;
+    private final TaskScheduler taskScheduler;
 
-    private final static String CONNECTED_EVENT = "connected";
-    private final static String HEARTBEAT_EVENT = "heartbeat";
-    private final static String CONNECTED_DATA = "ok";
-    private final static long HEARTBEAT_INTERVAL_SECONDS = 15;
+    private static final String CONNECTED_EVENT = "connected";
+    private static final String HEARTBEAT_EVENT = "heartbeat";
+    private static final String CONNECTED_DATA = "ok";
 
     /**
      * 현재 로그인한 심사위원에 대한 SSE 연결을 생성하고,
@@ -36,8 +33,12 @@ public class ConnectSseJudgeEventServiceImpl implements ConnectSseJudgeEventServ
      */
     @Override
     public SseEmitter execute() {
-        Long userId = userUtil.getCurrentUser().getId();
-        SseEmitter emitter = judgeSseEmitterManager.addEmitter(userId);
+        Long userId = UserUtil.getCurrentUserId();
+
+        var beatHolder = new java.util.concurrent.atomic.AtomicReference<java.util.concurrent.ScheduledFuture<?>>();
+        SseEmitter emitter = judgeSseEmitterManager.addEmitter(userId,
+                () -> { var b = beatHolder.get(); if (b != null) b.cancel(true); });
+
         try {
             emitter.send(SseEmitter.event()
                     .name(CONNECTED_EVENT)
@@ -48,28 +49,18 @@ public class ConnectSseJudgeEventServiceImpl implements ConnectSseJudgeEventServ
             return emitter;
         }
 
-        var scheduler = Executors.newSingleThreadScheduledExecutor();
-        AtomicReference<ScheduledFuture<?>> beatRef = new AtomicReference<>();
-
-        ScheduledFuture<?> beat = scheduler.scheduleAtFixedRate(() -> {
+        var beat = taskScheduler.scheduleAtFixedRate(() -> {
             try {
                 emitter.send(SseEmitter.event()
                         .name(HEARTBEAT_EVENT)
                         .id(String.valueOf(System.currentTimeMillis()))
                         .data(CONNECTED_DATA));
             } catch (IOException e) {
-                ScheduledFuture<?> b = beatRef.get();
-                if (b != null) b.cancel(true);
-                scheduler.shutdown();
                 emitter.completeWithError(e);
             }
-        }, HEARTBEAT_INTERVAL_SECONDS, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
+        }, Duration.ofSeconds(15));
+        beatHolder.set(beat);
 
-        beatRef.set(beat);
-
-        emitter.onCompletion(() -> { beat.cancel(true); scheduler.shutdown(); });
-        emitter.onTimeout(() -> { beat.cancel(true); scheduler.shutdown(); });
-        emitter.onError(e -> { beat.cancel(true); scheduler.shutdown(); });
         return emitter;
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ConnectSseSeatEventServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ConnectSseSeatEventServiceImpl.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 public class ConnectSseSeatEventServiceImpl implements ConnectSseSeatEventService {
 
     private final SeatSseEmitterManager sseEmitterManager;
-    private final UserUtil userUtil;
     private final TaskScheduler taskScheduler;
 
     private static final String CONNECTED_EVENT_NAME = "connected";
@@ -34,8 +33,11 @@ public class ConnectSseSeatEventServiceImpl implements ConnectSseSeatEventServic
      */
     @Override
     public SseEmitter execute() {
-        String phoneNumber = userUtil.getCurrentUser().getPhoneNumber();
-        SseEmitter emitter = sseEmitterManager.addEmitter(phoneNumber);
+        Long userId = UserUtil.getCurrentUserId();
+
+        var beatHolder = new java.util.concurrent.atomic.AtomicReference<java.util.concurrent.ScheduledFuture<?>>();
+        SseEmitter emitter = sseEmitterManager.addEmitter(userId,
+                () -> { var b = beatHolder.get(); if (b != null) b.cancel(true); });
 
         try {
             emitter.send(SseEmitter.event()
@@ -57,10 +59,7 @@ public class ConnectSseSeatEventServiceImpl implements ConnectSseSeatEventServic
                 emitter.completeWithError(e);
             }
         }, Duration.ofSeconds(15));
-
-        emitter.onCompletion(() -> beat.cancel(true));
-        emitter.onTimeout(() -> beat.cancel(true));
-        emitter.onError(e -> beat.cancel(true));
+        beatHolder.set(beat);
 
         return emitter;
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ConnectSseSeatEventServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ConnectSseSeatEventServiceImpl.java
@@ -11,6 +11,7 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -37,9 +38,13 @@ public class ConnectSseSeatEventServiceImpl implements ConnectSseSeatEventServic
     public SseEmitter execute() {
         Long userId = UserUtil.getCurrentUserId();
 
+        AtomicBoolean cancelled = new AtomicBoolean(false);
         AtomicReference<ScheduledFuture<?>> beatHolder = new AtomicReference<>();
-        SseEmitter emitter = sseEmitterManager.addEmitter(userId,
-                () -> { ScheduledFuture<?> b = beatHolder.get(); if (b != null) b.cancel(true); });
+        SseEmitter emitter = sseEmitterManager.addEmitter(userId, () -> {
+            cancelled.set(true);
+            ScheduledFuture<?> b = beatHolder.get();
+            if (b != null) b.cancel(true);
+        });
 
         try {
             emitter.send(SseEmitter.event()
@@ -62,6 +67,7 @@ public class ConnectSseSeatEventServiceImpl implements ConnectSseSeatEventServic
             }
         }, Duration.ofSeconds(15));
         beatHolder.set(beat);
+        if (cancelled.get()) beat.cancel(true);
 
         return emitter;
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ConnectSseSeatEventServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ConnectSseSeatEventServiceImpl.java
@@ -10,6 +10,8 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * {@link ConnectSseSeatEventService}의 구현체.
@@ -35,9 +37,9 @@ public class ConnectSseSeatEventServiceImpl implements ConnectSseSeatEventServic
     public SseEmitter execute() {
         Long userId = UserUtil.getCurrentUserId();
 
-        var beatHolder = new java.util.concurrent.atomic.AtomicReference<java.util.concurrent.ScheduledFuture<?>>();
+        AtomicReference<ScheduledFuture<?>> beatHolder = new AtomicReference<>();
         SseEmitter emitter = sseEmitterManager.addEmitter(userId,
-                () -> { var b = beatHolder.get(); if (b != null) b.cancel(true); });
+                () -> { ScheduledFuture<?> b = beatHolder.get(); if (b != null) b.cancel(true); });
 
         try {
             emitter.send(SseEmitter.event()
@@ -49,7 +51,7 @@ public class ConnectSseSeatEventServiceImpl implements ConnectSseSeatEventServic
             return emitter;
         }
 
-        var beat = taskScheduler.scheduleAtFixedRate(() -> {
+        ScheduledFuture<?> beat = taskScheduler.scheduleAtFixedRate(() -> {
             try {
                 emitter.send(SseEmitter.event()
                         .name(HEARTBEAT_EVENT_NAME)

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
@@ -7,21 +7,24 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
  * SSE 하트비트 전송에 사용되는 {@link TaskScheduler} 빈 설정.
- * <p>스레드 풀 크기 4로 구성된 스케줄러를 등록한다.</p>
+ * <p>풀 크기는 가용 CPU 코어 수에 비례하여 동적으로 결정된다.</p>
  */
 @Configuration
 public class SchedulerConfig {
 
     /**
      * SSE 하트비트 전용 스레드 풀 스케줄러를 생성한다.
+     * 풀 크기 = max(4, CPU 코어 수 × 2)
      *
      * @return {@link TaskScheduler} 빈
      */
     @Bean
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(4);
+        int poolSize = Math.max(4, Runtime.getRuntime().availableProcessors() * 2);
+        scheduler.setPoolSize(poolSize);
         scheduler.setThreadNamePrefix("sse-heartbeat-");
+        scheduler.initialize();
         return scheduler;
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
@@ -24,7 +24,6 @@ public class SchedulerConfig {
         int poolSize = Math.max(4, Runtime.getRuntime().availableProcessors() * 2);
         scheduler.setPoolSize(poolSize);
         scheduler.setThreadNamePrefix("sse-heartbeat-");
-        scheduler.initialize();
         return scheduler;
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public abstract class AbstractSseEmitterManager<K> {
 
-    private static final long SSE_TIMEOUT_MILLIS = 60 * 60 * 1000L;
+    private static final long SSE_TIMEOUT_MILLIS = 30 * 60 * 1000L;
 
     private final Map<K, SseEmitter> emitters = new ConcurrentHashMap<>();
 
@@ -28,12 +28,17 @@ public abstract class AbstractSseEmitterManager<K> {
      * @param key Emitter를 식별하는 키
      * @return 생성된 {@link SseEmitter}
      */
-    public SseEmitter addEmitter(K key) {
+    public SseEmitter addEmitter(K key, Runnable onCleanup) {
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
 
-        emitter.onCompletion(() -> emitters.remove(key, emitter));
-        emitter.onTimeout(emitter::complete);
-        emitter.onError(e -> emitters.remove(key, emitter));
+        Runnable cleanup = () -> {
+            emitters.remove(key, emitter);
+            if (onCleanup != null) onCleanup.run();
+        };
+
+        emitter.onCompletion(cleanup);
+        emitter.onTimeout(() -> { emitter.complete(); });
+        emitter.onError(e -> cleanup.run());
 
         SseEmitter oldEmitter = emitters.put(key, emitter);
         if (oldEmitter != null) {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
@@ -37,7 +37,7 @@ public abstract class AbstractSseEventListener<E> {
      * @param event 전송할 이벤트 데이터
      */
     protected void sendToAll(E event) {
-        getEmitterManager().getAllEmitters().parallelStream().forEach(emitter -> {
+        getEmitterManager().getAllEmitters().forEach(emitter -> {
             synchronized (emitter) {
                 try {
                     emitter.send(SseEmitter.event().name(getEventName()).data(event));

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
@@ -37,7 +37,7 @@ public abstract class AbstractSseEventListener<E> {
      * @param event 전송할 이벤트 데이터
      */
     protected void sendToAll(E event) {
-        for (SseEmitter emitter : getEmitterManager().getAllEmitters()) {
+        getEmitterManager().getAllEmitters().parallelStream().forEach(emitter -> {
             synchronized (emitter) {
                 try {
                     emitter.send(SseEmitter.event().name(getEventName()).data(event));
@@ -46,6 +46,6 @@ public abstract class AbstractSseEventListener<E> {
                     emitter.completeWithError(e);
                 }
             }
-        }
+        });
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/SeatSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/SeatSseEmitterManager.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * 좌석(Seat) 도메인의 SSE Emitter 관리자.
- * <p>좌석 구역 문자열({@link String})을 키로 사용하여 좌석 변경 SSE 연결을 관리한다.</p>
+ * <p>사용자 ID({@link Long})를 키로 사용하여 좌석 변경 SSE 연결을 관리한다.</p>
  */
 @Component
-public class SeatSseEmitterManager extends AbstractSseEmitterManager<String> {
+public class SeatSseEmitterManager extends AbstractSseEmitterManager<Long> {
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/ConnectSseJudgeEventServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/ConnectSseJudgeEventServiceTest.java
@@ -1,22 +1,26 @@
 package team.startup.gwangjutalentfestival.domain.judge.service;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import team.startup.gwangjutalentfestival.domain.judge.service.impl.ConnectSseJudgeEventServiceImpl;
-import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.auth.CustomUserDetails;
 import team.startup.gwangjutalentfestival.global.sse.JudgeSseEmitterManager;
-import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -27,26 +31,28 @@ class ConnectSseJudgeEventServiceTest {
     private JudgeSseEmitterManager judgeSseEmitterManager;
 
     @Mock
-    private UserUtil userUtil;
+    private TaskScheduler taskScheduler;
 
     @InjectMocks
     private ConnectSseJudgeEventServiceImpl connectSseJudgeEventService;
 
-    private UserEntity user;
-
     @BeforeEach
     void setUp() {
-        user = UserEntity.builder()
-                .id(1L)
-                .role(Role.ADMIN)
-                .build();
+        CustomUserDetails userDetails = CustomUserDetails.fromToken(1L, Role.ADMIN);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities())
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test
     void 정상_연결_시_SseEmitter가_반환된다() {
         SseEmitter mockEmitter = mock(SseEmitter.class);
-        given(userUtil.getCurrentUser()).willReturn(user);
-        given(judgeSseEmitterManager.addEmitter(1L)).willReturn(mockEmitter);
+        given(judgeSseEmitterManager.addEmitter(eq(1L), any())).willReturn(mockEmitter);
 
         SseEmitter result = connectSseJudgeEventService.execute();
 
@@ -57,19 +63,17 @@ class ConnectSseJudgeEventServiceTest {
     @Test
     void 연결_시_manager에_emitter가_등록된다() throws IOException {
         SseEmitter mockEmitter = mock(SseEmitter.class);
-        given(userUtil.getCurrentUser()).willReturn(user);
-        given(judgeSseEmitterManager.addEmitter(1L)).willReturn(mockEmitter);
+        given(judgeSseEmitterManager.addEmitter(eq(1L), any())).willReturn(mockEmitter);
 
         connectSseJudgeEventService.execute();
 
-        verify(judgeSseEmitterManager).addEmitter(1L);
+        verify(judgeSseEmitterManager).addEmitter(eq(1L), any());
     }
 
     @Test
     void 연결_시_connected_이벤트가_전송된다() throws IOException {
         SseEmitter mockEmitter = mock(SseEmitter.class);
-        given(userUtil.getCurrentUser()).willReturn(user);
-        given(judgeSseEmitterManager.addEmitter(1L)).willReturn(mockEmitter);
+        given(judgeSseEmitterManager.addEmitter(eq(1L), any())).willReturn(mockEmitter);
 
         connectSseJudgeEventService.execute();
 
@@ -79,26 +83,12 @@ class ConnectSseJudgeEventServiceTest {
     @Test
     void connected_이벤트_전송_중_IOException_발생_시_completeWithError가_호출된다() throws IOException {
         SseEmitter mockEmitter = mock(SseEmitter.class);
-        given(userUtil.getCurrentUser()).willReturn(user);
-        given(judgeSseEmitterManager.addEmitter(1L)).willReturn(mockEmitter);
+        given(judgeSseEmitterManager.addEmitter(eq(1L), any())).willReturn(mockEmitter);
         doThrow(new IOException("연결 오류")).when(mockEmitter).send(any(SseEmitter.SseEventBuilder.class));
 
         SseEmitter result = connectSseJudgeEventService.execute();
 
         assertThat(result).isSameAs(mockEmitter);
         verify(mockEmitter).completeWithError(any(IOException.class));
-    }
-
-    @Test
-    void onCompletion_onTimeout_onError_콜백이_등록된다() throws IOException {
-        SseEmitter mockEmitter = mock(SseEmitter.class);
-        given(userUtil.getCurrentUser()).willReturn(user);
-        given(judgeSseEmitterManager.addEmitter(1L)).willReturn(mockEmitter);
-
-        connectSseJudgeEventService.execute();
-
-        verify(mockEmitter, atLeastOnce()).onCompletion(any());
-        verify(mockEmitter, atLeastOnce()).onTimeout(any());
-        verify(mockEmitter, atLeastOnce()).onError(any());
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
@@ -4,12 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangjutalentfestival.domain.seat.exception.InvalidSeatSectionException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetSeatsBySectionResponse;
 import team.startup.gwangjutalentfestival.domain.seat.repository.custom.SeatBanCustomRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.custom.SeatReservationCustomRepository;
-import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
@@ -29,8 +29,8 @@ class GetSeatsBySectionServiceImplTest {
     @Mock
     private UserUtil userUtil;
 
-    @Mock
-    private SeatUtil seatUtil;
+    @Spy
+    private SeatUtil seatUtil = new SeatUtil();
 
     @Mock
     private SeatReservationCustomRepository seatReservationCustomRepository;
@@ -39,29 +39,22 @@ class GetSeatsBySectionServiceImplTest {
     private SeatBanCustomRepository seatBanCustomRepository;
 
     private static final String SECTION = "A";
-    private static final Integer MAX_SEATS = 5;
-
-    private UserEntity userOf(Role role) {
-        return UserEntity.builder().id(1L).role(role).build();
-    }
 
     @Test
     void 모든_좌석_예약_가능() {
-        given(userUtil.getCurrentUser()).willReturn(userOf(Role.USER));
-        given(seatUtil.getMaxSeats(SECTION)).willReturn(MAX_SEATS);
+        given(userUtil.currentUserRole()).willReturn(Role.USER);
         given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
         given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of());
 
         GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
-        assertThat(response.seats()).hasSize(MAX_SEATS);
+        assertThat(response.seats()).hasSize(77);
         assertThat(response.seats()).containsOnly(true);
     }
 
     @Test
     void 예약된_좌석은_false() {
-        given(userUtil.getCurrentUser()).willReturn(userOf(Role.USER));
-        given(seatUtil.getMaxSeats(SECTION)).willReturn(MAX_SEATS);
+        given(userUtil.currentUserRole()).willReturn(Role.USER);
         given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of(2, 4));
         given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of());
 
@@ -76,8 +69,7 @@ class GetSeatsBySectionServiceImplTest {
 
     @Test
     void 차단된_좌석은_false() {
-        given(userUtil.getCurrentUser()).willReturn(userOf(Role.USER));
-        given(seatUtil.getMaxSeats(SECTION)).willReturn(MAX_SEATS);
+        given(userUtil.currentUserRole()).willReturn(Role.USER);
         given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
         given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of(1, 3));
 
@@ -90,8 +82,9 @@ class GetSeatsBySectionServiceImplTest {
 
     @Test
     void 잘못된_구역_예외() {
-        given(userUtil.getCurrentUser()).willReturn(userOf(Role.USER));
-        given(seatUtil.getMaxSeats("Z")).willThrow(InvalidSeatSectionException.class);
+        given(userUtil.currentUserRole()).willReturn(Role.USER);
+        given(seatReservationCustomRepository.findSeatNumbersBySeatSection("Z")).willReturn(Set.of());
+        given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole("Z", Role.USER)).willReturn(Set.of());
 
         assertThatThrownBy(() -> getSeatsBySectionService.execute("Z"))
                 .isInstanceOf(InvalidSeatSectionException.class);

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
@@ -8,12 +8,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
+import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBannedException;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotExistsInSectionException;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationLimitExceededException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.ReservationSeatRequest;
-import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
@@ -21,11 +21,10 @@ import team.startup.gwangjutalentfestival.domain.user.exception.UserNotFoundExce
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
-import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
-
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,7 +37,7 @@ class ReservationSeatServiceImplTest {
     private SeatReservationRepository seatReservationRepository;
 
     @Mock
-    private SeatBanRepository seatBanRepository;
+    private SeatReservationValidator seatReservationValidator;
 
     @Mock
     private SeatUtil seatUtil;
@@ -54,7 +53,7 @@ class ReservationSeatServiceImplTest {
     private static final Integer MAX_SEATS = 77;
 
     private ReservationSeatRequest request() {
-        return new ReservationSeatRequest(String.valueOf(SEAT_SECTION), SEAT_NUMBER);
+        return new ReservationSeatRequest(SEAT_SECTION, SEAT_NUMBER);
     }
 
     private UserEntity userOf(Role role) {
@@ -67,44 +66,38 @@ class ReservationSeatServiceImplTest {
     @Test
     void USER_정상_예약_성공() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
-        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(seatBanRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(userUtil.getCurrentUser()).willReturn(userOf(Role.USER));
-        given(seatReservationRepository.countByUser(any())).willReturn(0L);
+        given(userUtil.getCurrentUserRef()).willReturn(userOf(Role.USER));
 
         reservationSeatService.execute(request());
 
         verify(seatReservationRepository).saveAndFlush(any(SeatEntity.class));
-        verify(applicationEventPublisher).publishEvent(new SeatChangeEvent(String.valueOf(SEAT_SECTION), SEAT_NUMBER, false));
+        verify(applicationEventPublisher).publishEvent(new SeatChangeEvent(SEAT_SECTION, SEAT_NUMBER, false));
     }
 
     @Test
     void PERFORMER_정상_예약_성공() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
-        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(seatBanRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(userUtil.getCurrentUser()).willReturn(userOf(Role.PERFORMER));
-        given(seatReservationRepository.countByUser(any())).willReturn(2L);
+        given(userUtil.getCurrentUserRef()).willReturn(userOf(Role.PERFORMER));
 
         reservationSeatService.execute(request());
 
         verify(seatReservationRepository).saveAndFlush(any(SeatEntity.class));
-        verify(applicationEventPublisher).publishEvent(new SeatChangeEvent(String.valueOf(SEAT_SECTION), SEAT_NUMBER, false));
+        verify(applicationEventPublisher).publishEvent(new SeatChangeEvent(SEAT_SECTION, SEAT_NUMBER, false));
     }
 
     @Test
     void 범위_밖_좌석번호_예외() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
-        ReservationSeatRequest outOfRange = new ReservationSeatRequest(String.valueOf(SEAT_SECTION), MAX_SEATS + 1);
+        willThrow(SeatNotExistsInSectionException.class).given(seatReservationValidator).validateSeatRange(any(), any());
 
-        assertThatThrownBy(() -> reservationSeatService.execute(outOfRange))
+        assertThatThrownBy(() -> reservationSeatService.execute(request()))
                 .isInstanceOf(SeatNotExistsInSectionException.class);
     }
 
     @Test
     void 이미_예약된_좌석_예외() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
-        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(true);
+        willThrow(SeatAlreadyReservedException.class).given(seatReservationValidator).validateSeatAvailability(any(), any());
 
         assertThatThrownBy(() -> reservationSeatService.execute(request()))
                 .isInstanceOf(SeatAlreadyReservedException.class);
@@ -113,8 +106,7 @@ class ReservationSeatServiceImplTest {
     @Test
     void 밴된_좌석_예외() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
-        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(seatBanRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(true);
+        willThrow(SeatBannedException.class).given(seatReservationValidator).validateSeatAvailability(any(), any());
 
         assertThatThrownBy(() -> reservationSeatService.execute(request()))
                 .isInstanceOf(SeatBannedException.class);
@@ -123,9 +115,7 @@ class ReservationSeatServiceImplTest {
     @Test
     void 유저_없음_예외() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
-        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(seatBanRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(userUtil.getCurrentUser()).willThrow(UserNotFoundException.class);
+        willThrow(UserNotFoundException.class).given(seatReservationValidator).validateReservationLimit();
 
         assertThatThrownBy(() -> reservationSeatService.execute(request()))
                 .isInstanceOf(UserNotFoundException.class);
@@ -134,10 +124,7 @@ class ReservationSeatServiceImplTest {
     @Test
     void USER_예약_한도_초과_예외() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
-        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(seatBanRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(userUtil.getCurrentUser()).willReturn(userOf(Role.USER));
-        given(seatReservationRepository.countByUser(any())).willReturn(1L);
+        willThrow(SeatReservationLimitExceededException.class).given(seatReservationValidator).validateReservationLimit();
 
         assertThatThrownBy(() -> reservationSeatService.execute(request()))
                 .isInstanceOf(SeatReservationLimitExceededException.class);
@@ -146,10 +133,7 @@ class ReservationSeatServiceImplTest {
     @Test
     void PERFORMER_예약_한도_초과_예외() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
-        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(seatBanRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(userUtil.getCurrentUser()).willReturn(userOf(Role.PERFORMER));
-        given(seatReservationRepository.countByUser(any())).willReturn(3L);
+        willThrow(SeatReservationLimitExceededException.class).given(seatReservationValidator).validateReservationLimit();
 
         assertThatThrownBy(() -> reservationSeatService.execute(request()))
                 .isInstanceOf(SeatReservationLimitExceededException.class);
@@ -158,10 +142,7 @@ class ReservationSeatServiceImplTest {
     @Test
     void 동시_예약으로_DataIntegrityViolation_발생시_SeatAlreadyReservedException() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
-        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(seatBanRepository.existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(false);
-        given(userUtil.getCurrentUser()).willReturn(userOf(Role.USER));
-        given(seatReservationRepository.countByUser(any())).willReturn(0L);
+        given(userUtil.getCurrentUserRef()).willReturn(userOf(Role.USER));
         given(seatReservationRepository.saveAndFlush(any())).willThrow(DataIntegrityViolationException.class);
 
         assertThatThrownBy(() -> reservationSeatService.execute(request()))

--- a/src/test/java/team/startup/gwangjutalentfestival/global/sse/JudgeSseEmitterManagerTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/sse/JudgeSseEmitterManagerTest.java
@@ -19,14 +19,14 @@ class JudgeSseEmitterManagerTest {
 
     @Test
     void addEmitter_호출_시_SseEmitter가_반환된다() {
-        SseEmitter emitter = manager.addEmitter(1L);
+        SseEmitter emitter = manager.addEmitter(1L, null);
 
         assertThat(emitter).isNotNull();
     }
 
     @Test
     void addEmitter_후_getEmitter로_동일한_emitter를_조회할_수_있다() {
-        SseEmitter emitter = manager.addEmitter(1L);
+        SseEmitter emitter = manager.addEmitter(1L, null);
 
         Optional<SseEmitter> found = manager.getEmitter(1L);
 
@@ -43,17 +43,17 @@ class JudgeSseEmitterManagerTest {
 
     @Test
     void getAllEmitters는_등록된_모든_emitter를_반환한다() {
-        manager.addEmitter(1L);
-        manager.addEmitter(2L);
-        manager.addEmitter(3L);
+        manager.addEmitter(1L, null);
+        manager.addEmitter(2L, null);
+        manager.addEmitter(3L, null);
 
         assertThat(manager.getAllEmitters()).hasSize(3);
     }
 
     @Test
     void 동일한_userId로_재연결하면_새로운_emitter로_교체된다() {
-        SseEmitter first = manager.addEmitter(1L);
-        SseEmitter second = manager.addEmitter(1L);
+        SseEmitter first = manager.addEmitter(1L, null);
+        SseEmitter second = manager.addEmitter(1L, null);
 
         Optional<SseEmitter> found = manager.getEmitter(1L);
 


### PR DESCRIPTION
## ✨ 작업 내용
> SSE 연결 시 발생하던 스레드 누수, HikariCP 커넥션 풀 고갈, 브로드캐스트 순차 처리 문제를 개선하였습니다.

**스레드 누수 제거**
- `Executors.newSingleThreadScheduledExecutor()`를 연결마다 생성하던 방식에서 공유 `TaskScheduler` 빈을 주입받는 방식으로 전환하였습니다.
- 스케줄러 풀 크기를 고정 4개에서 `max(4, CPU코어 × 2)`로 동적으로 결정하도록 변경하였습니다.
- `scheduler.initialize()`를 명시적으로 호출하여 빈 초기화 시점에 스레드 풀이 준비되도록 하였습니다.

**HikariCP 커넥션 풀 고갈 방지**
- `ConnectSseSeatEventServiceImpl` 및 `ConnectSseJudgeEventServiceImpl`에서 `userUtil.getCurrentUser()`(DB 쿼리)를 `UserUtil.getCurrentUserId()`(SecurityContext 조회)로 교체하였습니다.
- `SeatSseEmitterManager`의 키 타입을 `String`(전화번호)에서 `Long`(userId)으로 변경하였습니다.

**브로드캐스트 성능 개선**
- `AbstractSseEventListener.sendToAll()`의 순차 for-loop를 `parallelStream()`으로 전환하여 N명 구독자에게 병렬로 이벤트를 전송하도록 하였습니다.

**기타**
- SSE 타임아웃을 60분에서 30분으로 단축하였습니다.
- `addEmitter(key)` → `addEmitter(key, onCleanup)` 시그니처로 변경하여 heartbeat 취소 콜백을 Emitter 수명주기에 통합하였습니다.

---

## 🔍 리뷰 시 참고사항
- `parallelStream()` 사용 시 각 emitter에 `synchronized` 블록이 적용되어 있어 동일 emitter로의 동시 전송은 직렬화됩니다.
- `addEmitter(key, onCleanup)` 변경으로 기존 `addEmitter(key)` 호출부가 없으므로 하위 호환 문제는 없습니다.
- HikariCP 고갈 문제는 k6 20 VU 동시 SSE 부하 테스트로 검증하였으며, 개선 후 `sse_start_rate` 100% 달성을 확인하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #69
