### PR TITLE
Virtual Thread 도입으로 I/O 처리 성능 개선

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/AsyncConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/AsyncConfig.java
@@ -7,10 +7,19 @@ import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.concurrent.Executor;
 
+/**
+ * 비동기 처리를 위한 Executor 설정.
+ * <p>가상 스레드 기반 {@link VirtualThreadTaskExecutor}를 {@code asyncExecutor} 빈으로 등록한다.</p>
+ */
 @Configuration
 @EnableAsync
 public class AsyncConfig {
 
+    /**
+     * 비동기 작업 전용 가상 스레드 Executor를 생성한다.
+     *
+     * @return {@link Executor} 빈
+     */
     @Bean(name = "asyncExecutor")
     public Executor asyncExecutor() {
         return new VirtualThreadTaskExecutor("async-executor-");

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/AsyncConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/AsyncConfig.java
@@ -2,32 +2,17 @@ package team.startup.gwangjutalentfestival.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.VirtualThreadTaskExecutor;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
 
-/**
- * 비동기 처리를 위한 스레드 풀 설정.
- * <p>코어 5개, 최대 10개의 스레드와 큐 용량 100을 갖는 {@code asyncExecutor} 빈을 등록한다.</p>
- */
 @Configuration
 @EnableAsync
 public class AsyncConfig {
 
-    /**
-     * 비동기 작업 전용 스레드 풀 Executor를 생성한다.
-     *
-     * @return 설정된 {@link Executor} 빈
-     */
     @Bean(name = "asyncExecutor")
     public Executor asyncExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(5);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(100);
-        executor.setThreadNamePrefix("async-executor-");
-        executor.initialize();
-        return executor;
+        return new VirtualThreadTaskExecutor("async-executor-");
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
@@ -3,26 +3,15 @@ package team.startup.gwangjutalentfestival.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
-/**
- * SSE 하트비트 전송에 사용되는 {@link TaskScheduler} 빈 설정.
- * <p>풀 크기는 가용 CPU 코어 수에 비례하여 동적으로 결정된다.</p>
- */
 @Configuration
 public class SchedulerConfig {
 
-    /**
-     * SSE 하트비트 전용 스레드 풀 스케줄러를 생성한다.
-     * 풀 크기 = max(4, CPU 코어 수 × 2)
-     *
-     * @return {@link TaskScheduler} 빈
-     */
     @Bean
     public TaskScheduler taskScheduler() {
-        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        int poolSize = Math.max(4, Runtime.getRuntime().availableProcessors() * 2);
-        scheduler.setPoolSize(poolSize);
+        SimpleAsyncTaskScheduler scheduler = new SimpleAsyncTaskScheduler();
+        scheduler.setVirtualThreads(true);
         scheduler.setThreadNamePrefix("sse-heartbeat-");
         return scheduler;
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/SchedulerConfig.java
@@ -5,9 +5,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
+/**
+ * SSE 하트비트 전송에 사용되는 {@link TaskScheduler} 빈 설정.
+ * <p>가상 스레드 기반 {@link SimpleAsyncTaskScheduler}를 사용해 스레드 상한 없이 스케줄링한다.</p>
+ */
 @Configuration
 public class SchedulerConfig {
 
+    /**
+     * SSE 하트비트 전용 가상 스레드 스케줄러를 생성한다.
+     *
+     * @return {@link TaskScheduler} 빈
+     */
     @Bean
     public TaskScheduler taskScheduler() {
         SimpleAsyncTaskScheduler scheduler = new SimpleAsyncTaskScheduler();

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
@@ -39,6 +39,19 @@ public abstract class AbstractSseEmitterManager<K> {
         return emitter;
     }
 
+    public void executeSafe(K key, Consumer<SseEmitter> action) {
+        SseEmitter emitter = emitters.get(key);
+        if (emitter == null) return;
+        ReentrantLock lock = locks.get(emitter);
+        if (lock == null) return;
+        lock.lock();
+        try {
+            action.accept(emitter);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     public void forEachEmitterSafe(Consumer<SseEmitter> action) {
         emitters.values().forEach(emitter -> {
             ReentrantLock lock = locks.get(emitter);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
@@ -6,63 +6,56 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
-/**
- * SSE Emitter를 관리하는 추상 기반 클래스.
- * <p>키 타입({@code K}) 별로 {@link SseEmitter}를 {@link java.util.concurrent.ConcurrentHashMap}으로 저장하며,
- * 연결 완료·타임아웃·에러 발생 시 자동으로 제거한다.
- * 동일 키로 재연결 시 기존 Emitter를 완료 처리하여 리소스 누수를 방지한다.</p>
- *
- * @param <K> Emitter를 식별하는 키 타입
- */
 public abstract class AbstractSseEmitterManager<K> {
 
     private static final long SSE_TIMEOUT_MILLIS = 30 * 60 * 1000L;
 
     private final Map<K, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<SseEmitter, ReentrantLock> locks = new ConcurrentHashMap<>();
 
-    /**
-     * 새 {@link SseEmitter}를 생성하고 등록한다.
-     * <p>동일 키에 기존 Emitter가 있으면 완료 처리 후 교체한다.</p>
-     *
-     * @param key Emitter를 식별하는 키
-     * @return 생성된 {@link SseEmitter}
-     */
     public SseEmitter addEmitter(K key, Runnable onCleanup) {
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
+        locks.put(emitter, new ReentrantLock());
 
         Runnable cleanup = () -> {
             emitters.remove(key, emitter);
+            locks.remove(emitter);
             if (onCleanup != null) onCleanup.run();
         };
 
         emitter.onCompletion(cleanup);
-        emitter.onTimeout(() -> { emitter.complete(); });
+        emitter.onTimeout(() -> emitter.complete());
         emitter.onError(e -> cleanup.run());
 
         SseEmitter oldEmitter = emitters.put(key, emitter);
         if (oldEmitter != null) {
+            locks.remove(oldEmitter);
             oldEmitter.complete();
         }
 
         return emitter;
     }
 
-    /**
-     * 키에 해당하는 {@link SseEmitter}를 조회한다.
-     *
-     * @param key 조회할 키
-     * @return {@link SseEmitter}를 감싼 {@link Optional}, 없으면 empty
-     */
+    public void forEachEmitterSafe(Consumer<SseEmitter> action) {
+        emitters.values().forEach(emitter -> {
+            ReentrantLock lock = locks.get(emitter);
+            if (lock == null) return;
+            lock.lock();
+            try {
+                action.accept(emitter);
+            } finally {
+                lock.unlock();
+            }
+        });
+    }
+
     public Optional<SseEmitter> getEmitter(K key) {
         return Optional.ofNullable(emitters.get(key));
     }
 
-    /**
-     * 현재 등록된 모든 {@link SseEmitter}를 반환한다.
-     *
-     * @return 등록된 Emitter 컬렉션
-     */
     public Collection<SseEmitter> getAllEmitters() {
         return emitters.values();
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
@@ -9,6 +9,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
+/**
+ * SSE Emitter를 관리하는 추상 기반 클래스.
+ * <p>키 타입({@code K}) 별로 {@link SseEmitter}를 {@link ConcurrentHashMap}으로 저장하며,
+ * 연결 완료·타임아웃·에러 발생 시 자동으로 제거한다.
+ * 동일 키로 재연결 시 기존 Emitter를 완료 처리하여 리소스 누수를 방지한다.
+ * 가상 스레드 환경에서 carrier thread pinning 없이 안전한 전송을 위해
+ * {@link ReentrantLock}을 Emitter별로 관리한다.</p>
+ *
+ * @param <K> Emitter를 식별하는 키 타입
+ */
 public abstract class AbstractSseEmitterManager<K> {
 
     private static final long SSE_TIMEOUT_MILLIS = 30 * 60 * 1000L;
@@ -16,6 +26,14 @@ public abstract class AbstractSseEmitterManager<K> {
     private final Map<K, SseEmitter> emitters = new ConcurrentHashMap<>();
     private final Map<SseEmitter, ReentrantLock> locks = new ConcurrentHashMap<>();
 
+    /**
+     * 새 {@link SseEmitter}를 생성하고 등록한다.
+     * <p>동일 키에 기존 Emitter가 있으면 완료 처리 후 교체한다.</p>
+     *
+     * @param key       Emitter를 식별하는 키
+     * @param onCleanup 연결 종료 시 실행할 콜백
+     * @return 생성된 {@link SseEmitter}
+     */
     public SseEmitter addEmitter(K key, Runnable onCleanup) {
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
         locks.put(emitter, new ReentrantLock());
@@ -39,6 +57,12 @@ public abstract class AbstractSseEmitterManager<K> {
         return emitter;
     }
 
+    /**
+     * 키에 해당하는 Emitter를 락을 획득한 상태로 안전하게 실행한다.
+     *
+     * @param key    조회할 키
+     * @param action Emitter에 수행할 작업
+     */
     public void executeSafe(K key, Consumer<SseEmitter> action) {
         SseEmitter emitter = emitters.get(key);
         if (emitter == null) return;
@@ -52,6 +76,11 @@ public abstract class AbstractSseEmitterManager<K> {
         }
     }
 
+    /**
+     * 등록된 모든 Emitter에 대해 락을 획득한 상태로 안전하게 실행한다.
+     *
+     * @param action 각 Emitter에 수행할 작업
+     */
     public void forEachEmitterSafe(Consumer<SseEmitter> action) {
         emitters.values().forEach(emitter -> {
             ReentrantLock lock = locks.get(emitter);
@@ -65,10 +94,21 @@ public abstract class AbstractSseEmitterManager<K> {
         });
     }
 
+    /**
+     * 키에 해당하는 {@link SseEmitter}를 조회한다.
+     *
+     * @param key 조회할 키
+     * @return {@link SseEmitter}를 감싼 {@link Optional}, 없으면 empty
+     */
     public Optional<SseEmitter> getEmitter(K key) {
         return Optional.ofNullable(emitters.get(key));
     }
 
+    /**
+     * 현재 등록된 모든 {@link SseEmitter}를 반환한다.
+     *
+     * @return 등록된 Emitter 컬렉션
+     */
     public Collection<SseEmitter> getAllEmitters() {
         return emitters.values();
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
@@ -3,13 +3,37 @@ package team.startup.gwangjutalentfestival.global.sse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+/**
+ * SSE 이벤트를 전체 구독자에게 전송하는 추상 리스너.
+ * <p>구체 클래스는 {@link #getEmitterManager()}와 {@link #getEventName()}을 구현하여
+ * 도메인별 Emitter 관리자와 이벤트 이름을 제공한다.
+ * {@link #sendToAll(Object)}를 호출하면 {@link AbstractSseEmitterManager#forEachEmitterSafe}를 통해
+ * 락을 보유한 상태로 모든 SSE 클라이언트에 이벤트가 전송된다.</p>
+ *
+ * @param <E> 전송할 이벤트 데이터 타입
+ */
 @Slf4j
 public abstract class AbstractSseEventListener<E> {
 
+    /**
+     * 이벤트를 전송할 {@link AbstractSseEmitterManager}를 반환한다.
+     *
+     * @return 도메인별 Emitter 관리자
+     */
     protected abstract AbstractSseEmitterManager<?> getEmitterManager();
 
+    /**
+     * 전송할 SSE 이벤트 이름을 반환한다.
+     *
+     * @return 이벤트 이름
+     */
     protected abstract String getEventName();
 
+    /**
+     * 현재 연결된 모든 SSE 클라이언트에 이벤트를 전송한다.
+     *
+     * @param event 전송할 이벤트 데이터
+     */
     protected void sendToAll(E event) {
         getEmitterManager().forEachEmitterSafe(emitter -> {
             try {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEventListener.java
@@ -3,48 +3,20 @@ package team.startup.gwangjutalentfestival.global.sse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-
-/**
- * SSE 이벤트를 전체 구독자에게 전송하는 추상 리스너.
- * <p>구체 클래스는 {@link #getEmitterManager()}와 {@link #getEventName()}을 구현하여
- * 도메인별 Emitter 관리자와 이벤트 이름을 제공한다.
- * {@link #sendToAll(Object)}를 호출하면 연결된 모든 SSE 클라이언트에 이벤트가 전송된다.</p>
- *
- * @param <E> 전송할 이벤트 데이터 타입
- */
 @Slf4j
 public abstract class AbstractSseEventListener<E> {
 
-    /**
-     * 이벤트를 전송할 {@link AbstractSseEmitterManager}를 반환한다.
-     *
-     * @return 도메인별 Emitter 관리자
-     */
     protected abstract AbstractSseEmitterManager<?> getEmitterManager();
 
-    /**
-     * SSE 이벤트 이름을 반환한다.
-     *
-     * @return 이벤트 이름 문자열
-     */
     protected abstract String getEventName();
 
-    /**
-     * 연결된 모든 SSE 클라이언트에 이벤트를 전송한다.
-     * <p>각 Emitter에 동기화(synchronized)하여 스레드 안전성을 보장하며,
-     * 전송 실패 시 해당 Emitter를 오류 완료 처리한다.</p>
-     *
-     * @param event 전송할 이벤트 데이터
-     */
     protected void sendToAll(E event) {
-        getEmitterManager().getAllEmitters().forEach(emitter -> {
-            synchronized (emitter) {
-                try {
-                    emitter.send(SseEmitter.event().name(getEventName()).data(event));
-                } catch (Exception e) {
-                    log.error("SSE 전송 실패", e);
-                    emitter.completeWithError(e);
-                }
+        getEmitterManager().forEachEmitterSafe(emitter -> {
+            try {
+                emitter.send(SseEmitter.event().name(getEventName()).data(event));
+            } catch (Exception e) {
+                log.error("SSE 전송 실패", e);
+                emitter.completeWithError(e);
             }
         });
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,11 +2,18 @@ spring:
   application:
     name: gwangjutalentfestival
 
+  threads:
+    virtual:
+      enabled: true
+
   datasource:
     url: ${DB_URL:jdbc:mysql://localhost:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:1234}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
 
   data:
     redis:


### PR DESCRIPTION
## ✨ 작업 내용
Java 21 + Spring Boot 3.5.11 환경에서 Virtual Thread(Project Loom)를 도입하였습니다.

- `spring.threads.virtual.enabled: true` 활성화로 Tomcat 요청 처리 스레드를 가상 스레드로 전환하였습니다.
- `AsyncConfig` — `ThreadPoolTaskExecutor`(core: 5, max: 10)를 `VirtualThreadTaskExecutor`로 교체하였습니다.
- `SchedulerConfig` — `ThreadPoolTaskScheduler`를 `SimpleAsyncTaskScheduler`(가상 스레드)로 교체하였습니다.
- `AbstractSseEventListener` — `synchronized` 블록을 `ReentrantLock`으로 교체하여 carrier thread pinning 문제를 해결하였습니다.
- `AbstractSseEmitterManager` — per-emitter `ReentrantLock` 관리 및 `forEachEmitterSafe()` 메서드를 추가하였습니다.
- HikariCP `maximum-pool-size: 20` 명시로 가상 스레드 환경에서의 커넥션 수를 제어하였습니다.

---

## 🔍 리뷰 시 참고사항
- `synchronized(emitter)` 블록은 가상 스레드가 모니터 락을 점유할 때 carrier thread에 pinning되어 성능 저하를 유발합니다. `ReentrantLock`은 pinning 없이 동작하므로 함께 교체하였습니다.
- `forEachEmitterSafe()`는 `AbstractSseEmitterManager` 내부에서 락 획득/해제를 캡슐화하여 `AbstractSseEventListener`가 락 관리에 의존하지 않도록 설계하였습니다.
- Virtual Thread 환경에서 Spring Boot 3.2+는 HikariCP를 세마포어 기반으로 자동 전환하지만, `maximum-pool-size`는 명시적으로 지정하는 것이 권장됩니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #71
