### PR TITLE
시트 탭 범위 지정 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapter.java
@@ -71,6 +71,9 @@ public class GoogleSheetsAdapter {
     }
 
     static String toAppendRange(String sheetPage) {
+        if (sheetPage == null || sheetPage.isBlank()) {
+            throw new IllegalArgumentException("sheetPage must not be null or blank");
+        }
         return "'" + sheetPage.replace("'", "''") + "'!A1";
     }
 

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapter.java
@@ -53,7 +53,7 @@ public class GoogleSheetsAdapter {
             ValueRange valueRange = new ValueRange().setValues(rows);
 
             sheets.spreadsheets().values()
-                    .append(properties.sheetId(), sheetPage, valueRange)
+                    .append(properties.sheetId(), toAppendRange(sheetPage), valueRange)
                     .setValueInputOption("RAW")
                     .setInsertDataOption("INSERT_ROWS")
                     .execute();
@@ -68,6 +68,10 @@ public class GoogleSheetsAdapter {
             log.error("Google Sheets 예기치 못한 오류 발생 - message: {}", e.getMessage());
             throw new GoogleSheetsException();
         }
+    }
+
+    static String toAppendRange(String sheetPage) {
+        return "'" + sheetPage.replace("'", "''") + "'!A1";
     }
 
     private List<List<Object>> toEnrolledRows(List<EnrolledSloganSheetRowData> data) {

--- a/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapterTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapterTest.java
@@ -3,6 +3,7 @@ package team.startup.gwangjutalentfestival.global.thirdparty.google.adapter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class GoogleSheetsAdapterTest {
 
@@ -18,5 +19,19 @@ class GoogleSheetsAdapterTest {
         String range = GoogleSheetsAdapter.toAppendRange("학생's");
 
         assertThat(range).isEqualTo("'학생''s'!A1");
+    }
+
+    @Test
+    void nullSheetPageThrowsException() {
+        assertThatThrownBy(() -> GoogleSheetsAdapter.toAppendRange(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("sheetPage must not be null or blank");
+    }
+
+    @Test
+    void blankSheetPageThrowsException() {
+        assertThatThrownBy(() -> GoogleSheetsAdapter.toAppendRange(" "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("sheetPage must not be null or blank");
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapterTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleSheetsAdapterTest.java
@@ -1,0 +1,22 @@
+package team.startup.gwangjutalentfestival.global.thirdparty.google.adapter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GoogleSheetsAdapterTest {
+
+    @Test
+    void sheetPageWithSpacesIsConvertedToQuotedA1Range() {
+        String range = GoogleSheetsAdapter.toAppendRange("학교 밖 청소년");
+
+        assertThat(range).isEqualTo("'학교 밖 청소년'!A1");
+    }
+
+    @Test
+    void sheetPageWithSingleQuoteEscapesQuote() {
+        String range = GoogleSheetsAdapter.toAppendRange("학생's");
+
+        assertThat(range).isEqualTo("'학생''s'!A1");
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

- Google Sheets append range에 시트 탭명을 명시적으로 지정하도록 수정하였습니다.
- 공백 또는 작은따옴표가 포함된 시트 탭명도 안전하게 A1 range로 변환하도록 테스트를 추가하였습니다.

---

## 🔍 리뷰 시 참고사항
- `학교 밖 청소년`처럼 공백이 포함된 탭명을 Google Sheets API range로 넘길 때 시트명을 quote 처리하도록 변경하였습니다.
- 재학생 탭도 동일하게 quote된 range를 사용하며, Google Sheets A1 notation상 유효한 형식입니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #
