### PR TITLE
슬로건 제출 나이 제한 검증 추가

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/exception/InvalidSloganAgeException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/exception/InvalidSloganAgeException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.slogan.exception;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+public class InvalidSloganAgeException extends GlobalException {
+    public InvalidSloganAgeException() {
+        super(ErrorCode.INVALID_AGE);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
@@ -28,6 +28,9 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class CreateSloganServiceImpl implements CreateSloganService {
 
+    private static final int MIN_SLOGAN_AGE = 7;
+    private static final int MAX_SLOGAN_AGE = 18;
+
     private final SloganRepository sloganRepository;
     private final SloganSubmissionProperties sloganSubmissionProperties;
 
@@ -92,7 +95,7 @@ public class CreateSloganServiceImpl implements CreateSloganService {
 
     private void validateAge(LocalDate birthDate) {
         int age = LocalDate.now(TimeConstants.SEOUL_ZONE_ID).getYear() - birthDate.getYear();
-        if (age < 7 || age > 18) {
+        if (age < MIN_SLOGAN_AGE || age > MAX_SLOGAN_AGE) {
             throw new InvalidSloganAgeException();
         }
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/slogan/service/impl/CreateSloganServiceImpl.java
@@ -7,6 +7,7 @@ import team.startup.gwangjutalentfestival.domain.auth.exception.DuplicatePhoneNu
 import team.startup.gwangjutalentfestival.domain.slogan.entity.SloganEntity;
 import team.startup.gwangjutalentfestival.domain.slogan.enums.SchoolStatus;
 import team.startup.gwangjutalentfestival.domain.slogan.enums.SheetSyncStatus;
+import team.startup.gwangjutalentfestival.domain.slogan.exception.InvalidSloganAgeException;
 import team.startup.gwangjutalentfestival.domain.slogan.exception.SloganRequiredFieldMissingException;
 import team.startup.gwangjutalentfestival.domain.slogan.exception.SloganSubmissionPeriodException;
 import team.startup.gwangjutalentfestival.domain.slogan.presentation.data.request.CreateSloganRequest;
@@ -15,6 +16,7 @@ import team.startup.gwangjutalentfestival.domain.slogan.repository.SloganReposit
 import team.startup.gwangjutalentfestival.domain.slogan.service.CreateSloganService;
 import team.startup.gwangjutalentfestival.global.constant.TimeConstants;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
@@ -54,6 +56,7 @@ public class CreateSloganServiceImpl implements CreateSloganService {
         if (request.birthDate() == null) {
             throw new SloganRequiredFieldMissingException();
         }
+        validateAge(request.birthDate());
 
         return SloganEntity.builder()
                 .name(request.name())
@@ -85,6 +88,13 @@ public class CreateSloganServiceImpl implements CreateSloganService {
                 .sheetSyncStatus(SheetSyncStatus.PENDING)
                 .nextRetryAt(LocalDateTime.now(TimeConstants.SEOUL_ZONE_ID))
                 .build();
+    }
+
+    private void validateAge(LocalDate birthDate) {
+        int age = LocalDate.now(TimeConstants.SEOUL_ZONE_ID).getYear() - birthDate.getYear();
+        if (age < 7 || age > 18) {
+            throw new InvalidSloganAgeException();
+        }
     }
 
     private boolean isBlank(String value) {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
@@ -42,7 +42,7 @@ public enum ErrorCode {
     // Slogan
     SLOGAN_SUBMISSION_PERIOD_INVALID(400, "슬로건 접수 가능 기간이 아닙니다."),
     SLOGAN_REQUIRED_FIELD_MISSING(400, "필수 항목이 누락되었습니다."),
-    INVALID_AGE(400, "나이는 만 7세 이상 만 19세 미만이어야 합니다."),
+    INVALID_AGE(400, "나이는 7세 이상 18세 이하(출생 연도 기준)이어야 합니다."),
 
     // Seat
     SEAT_NOT_EXISTS_IN_SECTION(400, "해당 섹션에 존재하지 않는 좌석입니다."),

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     // Slogan
     SLOGAN_SUBMISSION_PERIOD_INVALID(400, "슬로건 접수 가능 기간이 아닙니다."),
     SLOGAN_REQUIRED_FIELD_MISSING(400, "필수 항목이 누락되었습니다."),
+    INVALID_AGE(400, "나이는 만 7세 이상 만 19세 미만이어야 합니다."),
 
     // Seat
     SEAT_NOT_EXISTS_IN_SECTION(400, "해당 섹션에 존재하지 않는 좌석입니다."),


### PR DESCRIPTION
## ✨ 작업 내용
슬로건 제출 시 `OUT_OF_SCHOOL` 상태의 제출자에 대해 생년월일 기반 나이 유효성 검증을 추가하였습니다.
현재 연도에서 출생연도를 차감하여 만 7세(초등학생) 이상, 만 18세 이하인 경우에만 제출이 가능하도록 제한하였습니다.

---

## 🔍 리뷰 시 참고사항
- 나이 계산은 `현재 연도 - 출생연도` 방식으로, 생일 경과 여부와 무관하게 연도 기준으로 판단합니다.
- 허용 범위: 2026년 기준 2008년생 ~ 2019년생 (매년 자동 갱신됩니다.)
- 범위 초과 시 `INVALID_AGE(400)` 에러코드와 함께 `InvalidSloganAgeException`이 발생합니다.
- 검증은 `CreateSloganServiceImpl.buildOutOfSchoolSlogan()` 내부에서 수행되며, `ENROLLED` 상태에는 영향이 없습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #82
