### PR TITLE
public API JWT 필터 제외

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
@@ -1,0 +1,38 @@
+package team.startup.gwangjutalentfestival.global.security.config;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import java.util.List;
+
+public final class PublicEndpointMatcher {
+
+    private static final List<RequestMatcher> PUBLIC_ENDPOINTS = List.of(
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/auth(?:/.*)?")),
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/health(?:/.*)?")),
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/excel(?:/.*)?")),
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/vote/[^/]+")),
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/error")),
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/swagger-ui(?:/.*)?")),
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/v3/api-docs(?:/.*)?")),
+            RegexRequestMatcher.regexMatcher(HttpMethod.GET, withOptionalQuery("^/team")),
+            RegexRequestMatcher.regexMatcher(HttpMethod.POST, withOptionalQuery("^/slogan"))
+    );
+
+    private PublicEndpointMatcher() {
+    }
+
+    public static RequestMatcher matcher() {
+        return new OrRequestMatcher(PUBLIC_ENDPOINTS);
+    }
+
+    public static RequestMatcher[] matchers() {
+        return PUBLIC_ENDPOINTS.toArray(RequestMatcher[]::new);
+    }
+
+    private static String withOptionalQuery(String pathPattern) {
+        return pathPattern + "(?:\\?.*)?$";
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
@@ -39,16 +39,6 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CorsProperties corsProperties;
 
-    private static final String[] PUBLIC_URLS = {
-            "/auth/**",
-            "/health/**",
-            "/excel/**",
-            "/vote/{teamId}",
-            "/error",
-            "/swagger-ui/**",
-            "/v3/api-docs/**"
-    };
-
     /**
      * HTTP 보안 필터 체인을 구성한다.
      *
@@ -72,14 +62,10 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(it ->it
                         .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
-                        .requestMatchers(PUBLIC_URLS).permitAll()
+                        .requestMatchers(PublicEndpointMatcher.matchers()).permitAll()
 
                         // team
-                        .requestMatchers(HttpMethod.GET, "/team").permitAll()
                         .requestMatchers("/team/**").hasRole("ADMIN")
-
-                        // slogan
-                        .requestMatchers(HttpMethod.POST, "/slogan").permitAll()
 
                         // seat
                         .requestMatchers(HttpMethod.POST, "/seat").authenticated()

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/filter/JwtFilter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/filter/JwtFilter.java
@@ -20,6 +20,7 @@ import team.startup.gwangjutalentfestival.global.auth.CustomUserDetails;
 import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.ErrorResponse;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProvider;
+import team.startup.gwangjutalentfestival.global.security.config.PublicEndpointMatcher;
 
 import java.io.IOException;
 
@@ -36,6 +37,11 @@ public class JwtFilter extends OncePerRequestFilter {
     private final TokenBlacklistRepository tokenBlacklistRepository;
     private final ObjectMapper objectMapper;
     private final JwtProvider jwtProvider;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return PublicEndpointMatcher.matcher().matches(request);
+    }
 
     @Override
     protected void doFilterInternal(

--- a/src/test/java/team/startup/gwangjutalentfestival/global/security/filter/JwtFilterTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/security/filter/JwtFilterTest.java
@@ -1,0 +1,98 @@
+package team.startup.gwangjutalentfestival.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import team.startup.gwangjutalentfestival.domain.auth.repository.TokenBlacklistRepository;
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.jwt.JwtProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtFilterTest {
+
+    @Mock
+    private TokenBlacklistRepository tokenBlacklistRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private JwtFilter jwtFilter;
+
+    @BeforeEach
+    void setUp() {
+        jwtFilter = new JwtFilter(tokenBlacklistRepository, new ObjectMapper(), jwtProvider);
+    }
+
+    @Test
+    void 공개_API는_Authorization_헤더가_있어도_JWT_검증을_건너뛴다() throws Exception {
+        MockHttpServletRequest request = request("POST", "/slogan");
+        request.addHeader("Authorization", "Bearer invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(jwtProvider, never()).resolveToken(request);
+        verify(filterChain).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void 공개_GET_API는_Authorization_헤더가_있어도_JWT_검증을_건너뛴다() throws Exception {
+        MockHttpServletRequest request = request("GET", "/team");
+        request.setQueryString("sort=order");
+        request.addHeader("Authorization", "Bearer invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(jwtProvider, never()).resolveToken(request);
+        verify(filterChain).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void 인증이_필요한_API는_잘못된_JWT를_검증하고_거부한다() throws Exception {
+        MockHttpServletRequest request = request("GET", "/seat");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(jwtProvider.resolveToken(request)).thenReturn("invalid-token");
+        when(jwtProvider.validateToken("invalid-token")).thenReturn(false);
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.INVALID_TOKEN.getStatus());
+        assertThat(response.getContentAsString()).contains(ErrorCode.INVALID_TOKEN.getMessage());
+    }
+
+    @Test
+    void 인증이_필요한_API에_토큰이_없으면_필터를_통과한다() throws Exception {
+        MockHttpServletRequest request = request("GET", "/seat");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        when(jwtProvider.resolveToken(request)).thenReturn(null);
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    private MockHttpServletRequest request(String method, String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+        request.setServletPath(path);
+        return request;
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

public API 요청에 잘못된 `Authorization` 헤더가 포함되어도 JWT 필터가 토큰 검증을 수행하지 않도록 수정하였습니다.

- public API matcher를 공통 클래스로 분리하였습니다.
- `SecurityConfig`와 `JwtFilter`가 동일한 public API 기준을 사용하도록 변경하였습니다.
- public API는 `JwtFilter.shouldNotFilter()`에서 토큰 검증을 건너뛰도록 하였습니다.
- public API와 인증 필요 API의 필터 동작을 검증하는 단위 테스트를 추가하였습니다.

---

## 🔍 리뷰 시 참고사항
- `permitAll()`은 인가 정책이므로 필터 실행 자체를 막지 않습니다. 따라서 JWT 필터에서 public API를 명시적으로 제외하였습니다.
- public API에 유효한 토큰이 포함되어도 인증 사용자로 처리하지 않고 비로그인 요청처럼 통과시킵니다.
- `./gradlew compileJava`, `./gradlew test --tests team.startup.gwangjutalentfestival.global.security.filter.JwtFilterTest`는 통과하였습니다.
- `./gradlew test`는 기존 `contextLoads()`의 DB dialect 설정 문제로 실패하였습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #84
