### PR TITLE
Prometheus Grafana 모니터링 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,11 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -87,14 +87,12 @@ dependencies {
     // Docker Compose
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
+    // Monitoring
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
-
-    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 }
 
 tasks.named('test') {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,14 +23,14 @@ services:
       retries: 10
 
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v3.1.0
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:11.5.1
     ports:
       - "3000:3000"
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,6 +24,8 @@ services:
 
   prometheus:
     image: prom/prometheus:v3.1.0
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,3 +21,17 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'gwangjutalentfestival'
+    metrics_path: '/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
@@ -13,6 +13,7 @@ public final class PublicEndpointMatcher {
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/auth(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/health(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/excel(?:/.*)?")),
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/prometheus(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/vote/[^/]+")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/error")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/swagger-ui(?:/.*)?")),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,14 +74,22 @@ slogan:
     end-at: ${END_AT:2026-05-28T18:00:00}
 
 management:
+  metrics:
+    tags:
+      application: ${spring.application.name}
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus
       base-path: /
       path-mapping:
         health: health
-
   endpoint:
     health:
       show-details: never
+    prometheus:
+      enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

Spring Boot Actuator와 Micrometer를 활용하여 Prometheus 메트릭 수집 환경을 구성하였습니다.
Docker Compose에 Prometheus, Grafana 서비스를 추가하여 애플리케이션 모니터링 인프라를 설정하였습니다.

**변경 사항**
- `spring-boot-starter-actuator`, `micrometer-registry-prometheus` 의존성을 추가하였습니다.
- `prometheus.yml` 스크랩 설정 파일을 추가하였습니다.
- `docker-compose.dev.yml`에 Prometheus(포트 9090), Grafana(포트 3000) 서비스를 추가하였습니다.
- `application.yaml`에 `/prometheus` 엔드포인트 노출 및 메트릭 태그 설정을 추가하였습니다.
- `PublicEndpointMatcher`에 `/prometheus` 경로를 JWT 인증 제외 목록에 추가하였습니다.

---

## 🔍 리뷰 시 참고사항
- Prometheus 스크랩 대상은 `host.docker.internal:8080`으로 설정되어 있어 로컬 개발 환경(Docker 컨테이너에서 호스트 접근)에서 동작하도록 구성되었습니다.
- `/prometheus` 엔드포인트는 Prometheus가 인증 없이 메트릭을 수집할 수 있도록 공개 경로로 설정하였습니다.
- Grafana 초기 접속 포트는 3000번입니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #89