### PR TITLE
SendVerifyCodeRequest phoneNumber null 검증 누락 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/request/SendVerifyCodeRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/auth/presentation/data/request/SendVerifyCodeRequest.java
@@ -1,5 +1,6 @@
 package team.startup.gwangjutalentfestival.domain.auth.presentation.data.request;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 /**
@@ -8,6 +9,7 @@ import jakarta.validation.constraints.Pattern;
  * @param phoneNumber 인증번호를 받을 휴대폰 번호 (010으로 시작하는 11자리)
  */
 public record SendVerifyCodeRequest(
+        @NotNull(message = "휴대폰 번호는 필수입니다.")
         @Pattern(
                 regexp = "^010\\d{8}$",
                 message = "유효한 휴대폰 번호 형식이 아닙니다."


### PR DESCRIPTION
## ✨ 작업 내용
`SendVerifyCodeRequest`의 `phoneNumber` 필드에 `@NotNull` 검증이 누락되어 있었습니다.
클라이언트가 `phoneNumber` 필드를 누락하거나 잘못된 필드명으로 요청할 경우 null이 역직렬화되어 `verifyCodeRepository.existsById(null)` 호출로 이어졌으며, 이로 인해 500 Internal Server Error가 발생하였습니다.
`@NotNull`을 추가하여 null 요청 시 400 Bad Request로 처리되도록 수정하였습니다.

---

## 🔍 리뷰 시 참고사항
- `@Pattern`은 null을 허용하므로 단독으로는 null 방어가 되지 않습니다. `@NotNull`을 함께 선언해야 의도한 검증이 동작합니다.
- 실제 배포 환경 로그에서 `The given id must not be null` 에러가 다수 발생한 것을 확인 후 수정하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- #97 
