### PR TITLE
 Prometheus Docker 네트워크 타겟 설정 변경

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -5,4 +5,4 @@ scrape_configs:
   - job_name: 'gwangjutalentfestival'
     metrics_path: '/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8080']
+      - targets: ['spring-app:8080']


### PR DESCRIPTION
## ✨ 작업 내용
> `prometheus.yml`의 스크랩 타겟을 `host.docker.internal:8080`에서 `spring-app:8080`으로 변경하였습니다.
> Docker Compose 환경에서 Prometheus가 Spring 애플리케이션 컨테이너를 서비스명으로 직접 참조할 수 있도록 수정하였습니다.

---

## 🔍 리뷰 시 참고사항
- `host.docker.internal`은 로컬 개발 환경(macOS/Windows)에서 호스트를 가리키는 주소로, Linux 기반 Docker Compose 환경에서는 동작하지 않을 수 있습니다.
- `spring-app`은 Docker Compose에 정의된 Spring 애플리케이션 서비스명으로, 동일 네트워크 내에서 컨테이너 간 통신이 가능합니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- 해당 없음
