### PR TITLE
Prometheus 스크랩 타겟을 app 서비스명으로 수정

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -5,4 +5,4 @@ scrape_configs:
   - job_name: 'gwangjutalentfestival'
     metrics_path: '/prometheus'
     static_configs:
-      - targets: ['spring-app:8080']
+      - targets: ['app:8080']


### PR DESCRIPTION
## ✨ 작업 내용
> `prometheus.yml`의 스크랩 타겟을 `spring-app:8080`에서 `app:8080`으로 수정하였습니다.
> Docker Compose 내부 네트워크에서는 서비스명(`app`)을 통해 통신하므로, `container_name`인 `spring-app` 대신 올바른 서비스명을 사용하도록 수정하였습니다.

---

## 🔍 리뷰 시 참고사항
- `docker-compose.yml`에서 서비스명은 `app`, 컨테이너명은 `spring-app`으로 정의되어 있습니다.
- Docker Compose 내부 네트워크는 서비스명 기준으로 통신하므로 `app:8080`이 올바른 타겟입니다.
- PR #98에서 잘못 변경된 값을 되돌리는 수정입니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- 해당 없음