### PR TITLE
Prometheus 메트릭 스크랩을 위한 management security 비활성화

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
@@ -14,6 +14,7 @@ public final class PublicEndpointMatcher {
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/health(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/excel(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/prometheus(?:/.*)?")),
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/actuator/prometheus(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/vote/[^/]+")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/error")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/swagger-ui(?:/.*)?")),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,8 +74,6 @@ slogan:
     end-at: ${END_AT:2026-05-28T18:00:00}
 
 management:
-  security:
-    enabled: false
   metrics:
     tags:
       application: ${spring.application.name}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,6 +74,8 @@ slogan:
     end-at: ${END_AT:2026-05-28T18:00:00}
 
 management:
+  security:
+    enabled: false
   metrics:
     tags:
       application: ${spring.application.name}


### PR DESCRIPTION
## ✨ 작업 내용
> `application.yaml`의 `management.security.enabled` 값을 `false`로 설정하여 Prometheus가 `/actuator/prometheus` 엔드포인트에 인증 없이 접근할 수 있도록 수정하였습니다.


---

## 🔍 리뷰 시 참고사항
- Spring Boot Actuator는 기본적으로 management 엔드포인트에 보안을 적용합니다.
- 해당 설정이 활성화된 상태에서는 Prometheus 스크랩 요청이 401 응답으로 거부되어 메트릭 수집이 불가능하였습니다.
- `management.security.enabled: false`를 추가하여 Prometheus가 인증 없이 메트릭 엔드포인트에 접근할 수 있도록 허용하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #
