### PR TITLE
좌석·심사 핵심 플로우 운영 메트릭 추가

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -2,8 +2,8 @@
 
 ## 성공 metric 기준
 
-`seat.reservation.success` / `judge.submit.success` 는 서비스 `execute()` 메서드가 **Exception 없이 정상 종료된 시점**을 기준으로 기록됩니다.
-트랜잭션 commit 완료 이후의 성공까지 보장하지 않습니다.
+`seat.reservation.success` / `judge.submit.success` 는 트랜잭션이 활성화된 환경에서는 **DB commit 완료 후(`afterCommit`)** 기록됩니다.
+트랜잭션이 없는 환경(단위 테스트 등)에서는 `execute()` 메서드가 Exception 없이 정상 종료된 시점에 즉시 기록됩니다.
 
 ---
 
@@ -33,26 +33,26 @@ histogram_quantile(0.95, sum by (le, uri, method) (rate(http_server_requests_sec
 
 ### 성공률 (5분 기준)
 ```promql
-rate(seat_reservation_success_total[5m])
+rate(seat_reservation_success_total{application="gwangjutalentfestival"}[5m])
 ```
 > 초당 좌석 예매 성공 횟수.
 
 ### 실패율 (5분 기준)
 ```promql
-rate(seat_reservation_failure_total[5m])
+rate(seat_reservation_failure_total{application="gwangjutalentfestival"}[5m])
 ```
 > 초당 좌석 예매 실패 횟수. Exception 발생 기준.
 
 ### 성공 대비 실패 비율
 ```promql
-rate(seat_reservation_failure_total[5m])
-/ (rate(seat_reservation_success_total[5m]) + rate(seat_reservation_failure_total[5m]))
+rate(seat_reservation_failure_total{application="gwangjutalentfestival"}[5m])
+/ (rate(seat_reservation_success_total{application="gwangjutalentfestival"}[5m]) + rate(seat_reservation_failure_total{application="gwangjutalentfestival"}[5m]))
 ```
 > 전체 예매 시도 중 실패 비율 (0~1).
 
 ### p95 Duration
 ```promql
-histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_bucket[5m])))
+histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_bucket{application="gwangjutalentfestival"}[5m])))
 ```
 > 좌석 예매 `execute()` 전체 소요 시간의 p95 (초 단위).
 
@@ -62,20 +62,20 @@ histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_buc
 
 ### 성공률 (5분 기준)
 ```promql
-rate(judge_submit_success_total[5m])
+rate(judge_submit_success_total{application="gwangjutalentfestival"}[5m])
 ```
 > 초당 심사 제출 성공 횟수.
 
 ### 실패율 (5분 기준)
 ```promql
-rate(judge_submit_failure_total[5m])
+rate(judge_submit_failure_total{application="gwangjutalentfestival"}[5m])
 ```
 > 초당 심사 제출 실패 횟수. Exception 발생 기준.
 
 ### 성공 대비 실패 비율
 ```promql
-rate(judge_submit_failure_total[5m])
-/ (rate(judge_submit_success_total[5m]) + rate(judge_submit_failure_total[5m]))
+rate(judge_submit_failure_total{application="gwangjutalentfestival"}[5m])
+/ (rate(judge_submit_success_total{application="gwangjutalentfestival"}[5m]) + rate(judge_submit_failure_total{application="gwangjutalentfestival"}[5m]))
 ```
 > 전체 심사 제출 시도 중 실패 비율 (0~1).
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,94 @@
+# Prometheus 모니터링 쿼리
+
+## 성공 metric 기준
+
+`seat.reservation.success` / `judge.submit.success` 는 서비스 `execute()` 메서드가 **Exception 없이 정상 종료된 시점**을 기준으로 기록됩니다.
+트랜잭션 commit 완료 이후의 성공까지 보장하지 않습니다.
+
+---
+
+## HTTP Endpoint
+
+### Request Rate (5분 기준)
+```promql
+rate(http_server_requests_seconds_count{application="gwangjutalentfestival"}[5m])
+```
+> endpoint별 초당 요청 수. `uri`, `method`, `status` 레이블로 필터링 가능.
+
+### 5xx Error Rate
+```promql
+rate(http_server_requests_seconds_count{application="gwangjutalentfestival", status=~"5.."}[5m])
+```
+> 5xx 응답이 발생하는 endpoint와 비율 확인.
+
+### p95 Latency
+```promql
+histogram_quantile(0.95, rate(http_server_requests_seconds_bucket{application="gwangjutalentfestival"}[5m]))
+```
+> endpoint별 p95 응답 시간(초 단위). `uri` 레이블로 특정 endpoint만 필터링 가능.
+
+---
+
+## 좌석 예매 (Seat Reservation)
+
+### 성공률 (5분 기준)
+```promql
+rate(seat_reservation_success_total[5m])
+```
+> 초당 좌석 예매 성공 횟수.
+
+### 실패율 (5분 기준)
+```promql
+rate(seat_reservation_failure_total[5m])
+```
+> 초당 좌석 예매 실패 횟수. Exception 발생 기준.
+
+### 성공 대비 실패 비율
+```promql
+rate(seat_reservation_failure_total[5m])
+/ (rate(seat_reservation_success_total[5m]) + rate(seat_reservation_failure_total[5m]))
+```
+> 전체 예매 시도 중 실패 비율 (0~1).
+
+### p95 Duration
+```promql
+histogram_quantile(0.95, rate(seat_reservation_duration_seconds_bucket[5m]))
+```
+> 좌석 예매 `execute()` 전체 소요 시간의 p95 (초 단위).
+
+---
+
+## 심사 제출 (Judge Submit)
+
+### 성공률 (5분 기준)
+```promql
+rate(judge_submit_success_total[5m])
+```
+> 초당 심사 제출 성공 횟수.
+
+### 실패율 (5분 기준)
+```promql
+rate(judge_submit_failure_total[5m])
+```
+> 초당 심사 제출 실패 횟수. Exception 발생 기준.
+
+### 성공 대비 실패 비율
+```promql
+rate(judge_submit_failure_total[5m])
+/ (rate(judge_submit_success_total[5m]) + rate(judge_submit_failure_total[5m]))
+```
+> 전체 심사 제출 시도 중 실패 비율 (0~1).
+
+### p95 Duration
+```promql
+histogram_quantile(0.95, rate(judge_submit_duration_seconds_bucket[5m]))
+```
+> 심사 제출 `execute()` 전체 소요 시간의 p95 (초 단위).
+
+---
+
+## 노출 확인
+
+```bash
+curl http://localhost:8080/prometheus | grep -E "seat_reservation|judge_submit|http_server_requests"
+```

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -2,7 +2,7 @@
 
 ## 성공 metric 기준
 
-`seat.reservation.success` / `judge.submit.success` 는 트랜잭션이 활성화된 환경에서는 **DB commit 완료 후(`afterCommit`)** 기록됩니다.
+`seat.reservation.success` / `judge.submit.success` 는 트랜잭션이 활성화된 환경에서는 **DB commit 완료 후(`afterCompletion` 성공 시)** 기록됩니다.
 트랜잭션이 없는 환경(단위 테스트 등)에서는 `execute()` 메서드가 Exception 없이 정상 종료된 시점에 즉시 기록됩니다.
 
 ---

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -23,7 +23,7 @@ rate(http_server_requests_seconds_count{application="gwangjutalentfestival", sta
 
 ### p95 Latency
 ```promql
-histogram_quantile(0.95, rate(http_server_requests_seconds_bucket{application="gwangjutalentfestival"}[5m]))
+histogram_quantile(0.95, sum by (le, uri, method) (rate(http_server_requests_seconds_bucket{application="gwangjutalentfestival"}[5m])))
 ```
 > endpoint별 p95 응답 시간(초 단위). `uri` 레이블로 특정 endpoint만 필터링 가능.
 
@@ -52,7 +52,7 @@ rate(seat_reservation_failure_total[5m])
 
 ### p95 Duration
 ```promql
-histogram_quantile(0.95, rate(seat_reservation_duration_seconds_bucket[5m]))
+histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_bucket[5m])))
 ```
 > 좌석 예매 `execute()` 전체 소요 시간의 p95 (초 단위).
 
@@ -81,7 +81,7 @@ rate(judge_submit_failure_total[5m])
 
 ### p95 Duration
 ```promql
-histogram_quantile(0.95, rate(judge_submit_duration_seconds_bucket[5m]))
+histogram_quantile(0.95, sum by (le) (rate(judge_submit_duration_seconds_bucket{application="gwangjutalentfestival"}[5m])))
 ```
 > 심사 제출 `execute()` 전체 소요 시간의 p95 (초 단위).
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.domain.judge.service.impl;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
@@ -16,11 +18,14 @@ import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * {@link SaveJudgementScoreService} 구현체.
  * 심사 점수를 저장 또는 수정하고, 팀 총점을 갱신한다.
  * 점수 저장 후 팀 랭킹 캐시를 초기화한다.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService {
@@ -28,6 +33,7 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
     private final JudgementRepository judgementRepository;
     private final TeamRepository teamRepository;
     private final UserUtil userUtil;
+    private final MeterRegistry meterRegistry;
 
     /**
      * 현재 로그인한 심사위원의 특정 팀 심사 점수를 저장하거나 수정한다.
@@ -41,29 +47,37 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
     @Transactional
     @CacheEvict(cacheNames = CacheConfig.TEAM_RANKING, allEntries = true)
     public void execute(SaveJudgementScoreRequest request, Long teamId) {
-        UserEntity user = userUtil.getCurrentUser();
-        TeamEntity team = teamRepository.findById(teamId)
-                .orElseThrow(TeamNotFoundException::new);
+        long start = System.nanoTime();
+        try {
+            UserEntity user = userUtil.getCurrentUser();
+            TeamEntity team = teamRepository.findById(teamId)
+                    .orElseThrow(TeamNotFoundException::new);
 
-        judgementRepository.findByTeamAndUser(team, user)
-                .ifPresentOrElse(
-                        judgement -> judgement.updateScore(
-                                request.expressionCommunicationScore(),
-                                request.technicalCompletenessScore(),
-                                request.creativityCompositionScore(),
-                                request.stagePresencePerformanceScore(),
-                                request.teamworkStageHarmonyScore()
-                        ),
-                        () -> judgementRepository.save(JudgementEntity.builder()
-                                .expressionCommunicationScore(request.expressionCommunicationScore())
-                                .technicalCompletenessScore(request.technicalCompletenessScore())
-                                .creativityCompositionScore(request.creativityCompositionScore())
-                                .stagePresencePerformanceScore(request.stagePresencePerformanceScore())
-                                .teamworkStageHarmonyScore(request.teamworkStageHarmonyScore())
-                                .team(team)
-                                .user(user)
-                                .build()));
-        updateTotalScore(team);
+            judgementRepository.findByTeamAndUser(team, user)
+                    .ifPresentOrElse(
+                            judgement -> judgement.updateScore(
+                                    request.expressionCommunicationScore(),
+                                    request.technicalCompletenessScore(),
+                                    request.creativityCompositionScore(),
+                                    request.stagePresencePerformanceScore(),
+                                    request.teamworkStageHarmonyScore()
+                            ),
+                            () -> judgementRepository.save(JudgementEntity.builder()
+                                    .expressionCommunicationScore(request.expressionCommunicationScore())
+                                    .technicalCompletenessScore(request.technicalCompletenessScore())
+                                    .creativityCompositionScore(request.creativityCompositionScore())
+                                    .stagePresencePerformanceScore(request.stagePresencePerformanceScore())
+                                    .teamworkStageHarmonyScore(request.teamworkStageHarmonyScore())
+                                    .team(team)
+                                    .user(user)
+                                    .build()));
+            updateTotalScore(team);
+
+            recordJudgeMetric(start, true);
+        } catch (Exception e) {
+            recordJudgeMetric(start, false);
+            throw e;
+        }
     }
 
     private void updateTotalScore(TeamEntity team) {
@@ -73,5 +87,17 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
             throw new JudgementTotalScoreExceededException();
         }
         team.updateTotalScore(newTotal);
+    }
+
+    private void recordJudgeMetric(long startNano, boolean success) {
+        try {
+            meterRegistry.timer("judge.submit.duration")
+                    .record(System.nanoTime() - startNano, TimeUnit.NANOSECONDS);
+            meterRegistry.counter(success
+                    ? "judge.submit.success"
+                    : "judge.submit.failure").increment();
+        } catch (Exception e) {
+            log.warn("judge.submit metric 기록 실패", e);
+        }
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
@@ -43,47 +43,36 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
     @Transactional
     @CacheEvict(cacheNames = CacheConfig.TEAM_RANKING, allEntries = true)
     public void execute(SaveJudgementScoreRequest request, Long teamId) {
-        long start = System.nanoTime();
-        try {
-            UserEntity user = userUtil.getCurrentUser();
-            TeamEntity team = teamRepository.findById(teamId)
-                    .orElseThrow(TeamNotFoundException::new);
+        metricRecorder.record(
+                "judge.submit.duration",
+                "judge.submit.success",
+                "judge.submit.failure",
+                () -> {
+                    UserEntity user = userUtil.getCurrentUser();
+                    TeamEntity team = teamRepository.findById(teamId)
+                            .orElseThrow(TeamNotFoundException::new);
 
-            judgementRepository.findByTeamAndUser(team, user)
-                    .ifPresentOrElse(
-                            judgement -> judgement.updateScore(
-                                    request.expressionCommunicationScore(),
-                                    request.technicalCompletenessScore(),
-                                    request.creativityCompositionScore(),
-                                    request.stagePresencePerformanceScore(),
-                                    request.teamworkStageHarmonyScore()
-                            ),
-                            () -> judgementRepository.save(JudgementEntity.builder()
-                                    .expressionCommunicationScore(request.expressionCommunicationScore())
-                                    .technicalCompletenessScore(request.technicalCompletenessScore())
-                                    .creativityCompositionScore(request.creativityCompositionScore())
-                                    .stagePresencePerformanceScore(request.stagePresencePerformanceScore())
-                                    .teamworkStageHarmonyScore(request.teamworkStageHarmonyScore())
-                                    .team(team)
-                                    .user(user)
-                                    .build()));
-            updateTotalScore(team);
-
-            metricRecorder.record(
-                    "judge.submit.duration",
-                    "judge.submit.success",
-                    "judge.submit.failure",
-                    start, true
-            );
-        } catch (Exception e) {
-            metricRecorder.record(
-                    "judge.submit.duration",
-                    "judge.submit.success",
-                    "judge.submit.failure",
-                    start, false
-            );
-            throw e;
-        }
+                    judgementRepository.findByTeamAndUser(team, user)
+                            .ifPresentOrElse(
+                                    judgement -> judgement.updateScore(
+                                            request.expressionCommunicationScore(),
+                                            request.technicalCompletenessScore(),
+                                            request.creativityCompositionScore(),
+                                            request.stagePresencePerformanceScore(),
+                                            request.teamworkStageHarmonyScore()
+                                    ),
+                                    () -> judgementRepository.save(JudgementEntity.builder()
+                                            .expressionCommunicationScore(request.expressionCommunicationScore())
+                                            .technicalCompletenessScore(request.technicalCompletenessScore())
+                                            .creativityCompositionScore(request.creativityCompositionScore())
+                                            .stagePresencePerformanceScore(request.stagePresencePerformanceScore())
+                                            .teamworkStageHarmonyScore(request.teamworkStageHarmonyScore())
+                                            .team(team)
+                                            .user(user)
+                                            .build()));
+                    updateTotalScore(team);
+                }
+        );
     }
 
     private void updateTotalScore(TeamEntity team) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
@@ -1,8 +1,6 @@
 package team.startup.gwangjutalentfestival.domain.judge.service.impl;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
@@ -16,16 +14,14 @@ import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundException;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.global.util.OperationMetricRecorder;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * {@link SaveJudgementScoreService} 구현체.
  * 심사 점수를 저장 또는 수정하고, 팀 총점을 갱신한다.
  * 점수 저장 후 팀 랭킹 캐시를 초기화한다.
  */
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService {
@@ -33,7 +29,7 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
     private final JudgementRepository judgementRepository;
     private final TeamRepository teamRepository;
     private final UserUtil userUtil;
-    private final MeterRegistry meterRegistry;
+    private final OperationMetricRecorder metricRecorder;
 
     /**
      * 현재 로그인한 심사위원의 특정 팀 심사 점수를 저장하거나 수정한다.
@@ -73,9 +69,19 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
                                     .build()));
             updateTotalScore(team);
 
-            recordJudgeMetric(start, true);
+            metricRecorder.record(
+                    "judge.submit.duration",
+                    "judge.submit.success",
+                    "judge.submit.failure",
+                    start, true
+            );
         } catch (Exception e) {
-            recordJudgeMetric(start, false);
+            metricRecorder.record(
+                    "judge.submit.duration",
+                    "judge.submit.success",
+                    "judge.submit.failure",
+                    start, false
+            );
             throw e;
         }
     }
@@ -87,17 +93,5 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
             throw new JudgementTotalScoreExceededException();
         }
         team.updateTotalScore(newTotal);
-    }
-
-    private void recordJudgeMetric(long startNano, boolean success) {
-        try {
-            meterRegistry.timer("judge.submit.duration")
-                    .record(System.nanoTime() - startNano, TimeUnit.NANOSECONDS);
-            meterRegistry.counter(success
-                    ? "judge.submit.success"
-                    : "judge.submit.failure").increment();
-        } catch (Exception e) {
-            log.warn("judge.submit metric 기록 실패", e);
-        }
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
@@ -17,6 +19,9 @@ import team.startup.gwangjutalentfestival.domain.seat.service.ReservationSeatSer
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReservationSeatServiceImpl implements ReservationSeatService {
@@ -26,6 +31,7 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
     private final SeatUtil seatUtil;
     private final UserUtil userUtil;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final MeterRegistry meterRegistry;
 
     @Override
     @Transactional
@@ -34,29 +40,49 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
             @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
     })
     public void execute(ReservationSeatRequest request) {
-        String seatSection = request.seatSection();
-        Integer seatNumber = request.seatNumber();
-
-        seatReservationValidator.validateSeatRange(seatNumber, seatUtil.getMaxSeats(seatSection));
-        seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
-        seatReservationValidator.validateReservationLimit();
-
-        SeatEntity seat = SeatEntity.builder()
-                .seatNumber(seatNumber)
-                .seatSection(seatSection)
-                .user(userUtil.getCurrentUserRef())
-                .build();
-
+        long start = System.nanoTime();
         try {
-            seatReservationRepository.saveAndFlush(seat);
-        } catch (DataIntegrityViolationException e) {
-            throw new SeatAlreadyReservedException();
-        }
+            String seatSection = request.seatSection();
+            Integer seatNumber = request.seatNumber();
 
-        applicationEventPublisher.publishEvent(new SeatChangeEvent(
-                request.seatSection(),
-                request.seatNumber(),
-                false
-        ));
+            seatReservationValidator.validateSeatRange(seatNumber, seatUtil.getMaxSeats(seatSection));
+            seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
+            seatReservationValidator.validateReservationLimit();
+
+            SeatEntity seat = SeatEntity.builder()
+                    .seatNumber(seatNumber)
+                    .seatSection(seatSection)
+                    .user(userUtil.getCurrentUserRef())
+                    .build();
+
+            try {
+                seatReservationRepository.saveAndFlush(seat);
+            } catch (DataIntegrityViolationException e) {
+                throw new SeatAlreadyReservedException();
+            }
+
+            applicationEventPublisher.publishEvent(new SeatChangeEvent(
+                    request.seatSection(),
+                    request.seatNumber(),
+                    false
+            ));
+
+            recordSeatMetric(start, true);
+        } catch (Exception e) {
+            recordSeatMetric(start, false);
+            throw e;
+        }
+    }
+
+    private void recordSeatMetric(long startNano, boolean success) {
+        try {
+            meterRegistry.timer("seat.reservation.duration")
+                    .record(System.nanoTime() - startNano, TimeUnit.NANOSECONDS);
+            meterRegistry.counter(success
+                    ? "seat.reservation.success"
+                    : "seat.reservation.failure").increment();
+        } catch (Exception e) {
+            log.warn("seat.reservation metric 기록 실패", e);
+        }
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -36,47 +36,36 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
             @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
     })
     public void execute(ReservationSeatRequest request) {
-        long start = System.nanoTime();
-        try {
-            String seatSection = request.seatSection();
-            Integer seatNumber = request.seatNumber();
+        metricRecorder.record(
+                "seat.reservation.duration",
+                "seat.reservation.success",
+                "seat.reservation.failure",
+                () -> {
+                    String seatSection = request.seatSection();
+                    Integer seatNumber = request.seatNumber();
 
-            seatReservationValidator.validateSeatRange(seatNumber, seatUtil.getMaxSeats(seatSection));
-            seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
-            seatReservationValidator.validateReservationLimit();
+                    seatReservationValidator.validateSeatRange(seatNumber, seatUtil.getMaxSeats(seatSection));
+                    seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
+                    seatReservationValidator.validateReservationLimit();
 
-            SeatEntity seat = SeatEntity.builder()
-                    .seatNumber(seatNumber)
-                    .seatSection(seatSection)
-                    .user(userUtil.getCurrentUserRef())
-                    .build();
+                    SeatEntity seat = SeatEntity.builder()
+                            .seatNumber(seatNumber)
+                            .seatSection(seatSection)
+                            .user(userUtil.getCurrentUserRef())
+                            .build();
 
-            try {
-                seatReservationRepository.saveAndFlush(seat);
-            } catch (DataIntegrityViolationException e) {
-                throw new SeatAlreadyReservedException();
-            }
+                    try {
+                        seatReservationRepository.saveAndFlush(seat);
+                    } catch (DataIntegrityViolationException e) {
+                        throw new SeatAlreadyReservedException();
+                    }
 
-            applicationEventPublisher.publishEvent(new SeatChangeEvent(
-                    request.seatSection(),
-                    request.seatNumber(),
-                    false
-            ));
-
-            metricRecorder.record(
-                    "seat.reservation.duration",
-                    "seat.reservation.success",
-                    "seat.reservation.failure",
-                    start, true
-            );
-        } catch (Exception e) {
-            metricRecorder.record(
-                    "seat.reservation.duration",
-                    "seat.reservation.success",
-                    "seat.reservation.failure",
-                    start, false
-            );
-            throw e;
-        }
+                    applicationEventPublisher.publishEvent(new SeatChangeEvent(
+                            request.seatSection(),
+                            request.seatNumber(),
+                            false
+                    ));
+                }
+        );
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -1,8 +1,6 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
@@ -16,12 +14,10 @@ import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReser
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.ReservationSeatRequest;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.ReservationSeatService;
+import team.startup.gwangjutalentfestival.global.util.OperationMetricRecorder;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
-import java.util.concurrent.TimeUnit;
-
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReservationSeatServiceImpl implements ReservationSeatService {
@@ -31,7 +27,7 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
     private final SeatUtil seatUtil;
     private final UserUtil userUtil;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final MeterRegistry meterRegistry;
+    private final OperationMetricRecorder metricRecorder;
 
     @Override
     @Transactional
@@ -67,22 +63,20 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
                     false
             ));
 
-            recordSeatMetric(start, true);
+            metricRecorder.record(
+                    "seat.reservation.duration",
+                    "seat.reservation.success",
+                    "seat.reservation.failure",
+                    start, true
+            );
         } catch (Exception e) {
-            recordSeatMetric(start, false);
+            metricRecorder.record(
+                    "seat.reservation.duration",
+                    "seat.reservation.success",
+                    "seat.reservation.failure",
+                    start, false
+            );
             throw e;
-        }
-    }
-
-    private void recordSeatMetric(long startNano, boolean success) {
-        try {
-            meterRegistry.timer("seat.reservation.duration")
-                    .record(System.nanoTime() - startNano, TimeUnit.NANOSECONDS);
-            meterRegistry.counter(success
-                    ? "seat.reservation.success"
-                    : "seat.reservation.failure").increment();
-        } catch (Exception e) {
-            log.warn("seat.reservation metric 기록 실패", e);
         }
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
@@ -1,0 +1,27 @@
+package team.startup.gwangjutalentfestival.global.util;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OperationMetricRecorder {
+
+    private final MeterRegistry meterRegistry;
+
+    public void record(String timerName, String successCounterName, String failureCounterName,
+                       long startNano, boolean success) {
+        try {
+            meterRegistry.timer(timerName)
+                    .record(System.nanoTime() - startNano, TimeUnit.NANOSECONDS);
+            meterRegistry.counter(success ? successCounterName : failureCounterName).increment();
+        } catch (Exception e) {
+            log.warn("{} metric 기록 실패", timerName, e);
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
@@ -21,8 +21,9 @@ public class OperationMetricRecorder {
         if (success && TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
-                public void afterCommit() {
-                    recordMetric(timerName, successCounterName, startNano);
+                public void afterCompletion(int status) {
+                    String counterName = (status == STATUS_COMMITTED) ? successCounterName : failureCounterName;
+                    recordMetric(timerName, counterName, startNano);
                 }
             });
         } else {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
@@ -17,35 +17,36 @@ public class OperationMetricRecorder {
     private final MeterRegistry meterRegistry;
 
     public void record(String timerName, String successCounterName, String failureCounterName,
-                       long startNano, boolean success) {
+                       long durationNano, boolean success) {
         if (success && TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCompletion(int status) {
                     String counterName = (status == STATUS_COMMITTED) ? successCounterName : failureCounterName;
-                    recordMetric(timerName, counterName, startNano);
+                    recordMetric(timerName, counterName, durationNano);
                 }
             });
         } else {
-            recordMetric(timerName, success ? successCounterName : failureCounterName, startNano);
+            recordMetric(timerName, success ? successCounterName : failureCounterName, durationNano);
         }
     }
 
     public void record(String timerName, String successCounterName, String failureCounterName, Runnable action) {
         long start = System.nanoTime();
+        boolean success = false;
         try {
             action.run();
-            record(timerName, successCounterName, failureCounterName, start, true);
-        } catch (Exception e) {
-            record(timerName, successCounterName, failureCounterName, start, false);
-            throw e;
+            success = true;
+        } finally {
+            long durationNano = System.nanoTime() - start;
+            record(timerName, successCounterName, failureCounterName, durationNano, success);
         }
     }
 
-    private void recordMetric(String timerName, String counterName, long startNano) {
+    private void recordMetric(String timerName, String counterName, long durationNano) {
         try {
             meterRegistry.timer(timerName)
-                    .record(System.nanoTime() - startNano, TimeUnit.NANOSECONDS);
+                    .record(durationNano, TimeUnit.NANOSECONDS);
             meterRegistry.counter(counterName).increment();
         } catch (Exception e) {
             log.warn("{} metric 기록 실패", timerName, e);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
@@ -31,6 +31,17 @@ public class OperationMetricRecorder {
         }
     }
 
+    public void record(String timerName, String successCounterName, String failureCounterName, Runnable action) {
+        long start = System.nanoTime();
+        try {
+            action.run();
+            record(timerName, successCounterName, failureCounterName, start, true);
+        } catch (Exception e) {
+            record(timerName, successCounterName, failureCounterName, start, false);
+            throw e;
+        }
+    }
+
     private void recordMetric(String timerName, String counterName, long startNano) {
         try {
             meterRegistry.timer(timerName)

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/OperationMetricRecorder.java
@@ -4,6 +4,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.concurrent.TimeUnit;
 
@@ -16,10 +18,23 @@ public class OperationMetricRecorder {
 
     public void record(String timerName, String successCounterName, String failureCounterName,
                        long startNano, boolean success) {
+        if (success && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    recordMetric(timerName, successCounterName, startNano);
+                }
+            });
+        } else {
+            recordMetric(timerName, success ? successCounterName : failureCounterName, startNano);
+        }
+    }
+
+    private void recordMetric(String timerName, String counterName, long startNano) {
         try {
             meterRegistry.timer(timerName)
                     .record(System.nanoTime() - startNano, TimeUnit.NANOSECONDS);
-            meterRegistry.counter(success ? successCounterName : failureCounterName).increment();
+            meterRegistry.counter(counterName).increment();
         } catch (Exception e) {
             log.warn("{} metric 기록 실패", timerName, e);
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,6 +77,11 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+        seat.reservation.duration: true
+        judge.submit.duration: true
   endpoints:
     web:
       exposure:

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
@@ -18,6 +18,7 @@ import team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundExce
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.util.OperationMetricRecorder;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import java.util.Optional;
@@ -43,7 +44,8 @@ class SaveJudgementScoreServiceTest {
     @Mock
     private UserUtil userUtil;
 
-    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final OperationMetricRecorder metricRecorder =
+            new OperationMetricRecorder(new SimpleMeterRegistry());
 
     private SaveJudgementScoreServiceImpl saveJudgementScoreService;
 
@@ -57,7 +59,7 @@ class SaveJudgementScoreServiceTest {
                 judgementRepository,
                 teamRepository,
                 userUtil,
-                meterRegistry
+                metricRecorder
         );
 
         user = UserEntity.builder()

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
@@ -1,9 +1,9 @@
 package team.startup.gwangjutalentfestival.domain.judge.service;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
@@ -43,7 +43,8 @@ class SaveJudgementScoreServiceTest {
     @Mock
     private UserUtil userUtil;
 
-    @InjectMocks
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
     private SaveJudgementScoreServiceImpl saveJudgementScoreService;
 
     private UserEntity user;
@@ -52,6 +53,13 @@ class SaveJudgementScoreServiceTest {
 
     @BeforeEach
     void setUp() {
+        saveJudgementScoreService = new SaveJudgementScoreServiceImpl(
+                judgementRepository,
+                teamRepository,
+                userUtil,
+                meterRegistry
+        );
+
         user = UserEntity.builder()
                 .id(1L)
                 .role(Role.ADMIN)

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
@@ -1,8 +1,9 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
@@ -30,7 +31,6 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class ReservationSeatServiceImplTest {
 
-    @InjectMocks
     private ReservationSeatServiceImpl reservationSeatService;
 
     @Mock
@@ -48,9 +48,23 @@ class ReservationSeatServiceImplTest {
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
     private static final String SEAT_SECTION = "A";
     private static final Integer SEAT_NUMBER = 1;
     private static final Integer MAX_SEATS = 77;
+
+    @BeforeEach
+    void setUp() {
+        reservationSeatService = new ReservationSeatServiceImpl(
+                seatReservationRepository,
+                seatReservationValidator,
+                seatUtil,
+                userUtil,
+                applicationEventPublisher,
+                meterRegistry
+        );
+    }
 
     private ReservationSeatRequest request() {
         return new ReservationSeatRequest(SEAT_SECTION, SEAT_NUMBER);

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
@@ -19,6 +19,7 @@ import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservation
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.domain.user.exception.UserNotFoundException;
+import team.startup.gwangjutalentfestival.global.util.OperationMetricRecorder;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
@@ -48,7 +49,8 @@ class ReservationSeatServiceImplTest {
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
-    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final OperationMetricRecorder metricRecorder =
+            new OperationMetricRecorder(new SimpleMeterRegistry());
 
     private static final String SEAT_SECTION = "A";
     private static final Integer SEAT_NUMBER = 1;
@@ -62,7 +64,7 @@ class ReservationSeatServiceImplTest {
                 seatUtil,
                 userUtil,
                 applicationEventPublisher,
-                meterRegistry
+                metricRecorder
         );
     }
 


### PR DESCRIPTION
## ✨ 작업 내용
좌석 예매·심사 제출 핵심 플로우에 Prometheus 운영 메트릭을 추가하였습니다.

- `http.server.requests` histogram을 활성화하여 endpoint별 p95 latency 계산이 가능하도록 설정하였습니다.
- 좌석 예매 플로우에 `seat.reservation.success`, `seat.reservation.failure`, `seat.reservation.duration` 메트릭을 추가하였습니다.
- 심사 제출 플로우에 `judge.submit.success`, `judge.submit.failure`, `judge.submit.duration` 메트릭을 추가하였습니다.
- metric recording 실패가 비즈니스 로직 실패로 전파되지 않도록 방어적으로 작성하였습니다.
- Prometheus/Grafana에서 사용할 수 있는 PromQL을 `docs/monitoring.md`에 문서화하였습니다.

---

## 🔍 리뷰 시 참고사항
- 성공 metric은 `execute()` 메서드가 Exception 없이 정상 종료된 시점 기준으로 기록됩니다. 트랜잭션 commit 완료까지 보장하지 않습니다.
- `Exception`만 catch하며, OOM 등 시스템 레벨 `Error`는 failure metric 대상에서 제외하였습니다.
- 기존 `@Transactional`, `@Caching`, `@CacheEvict` 어노테이션 동작은 변경하지 않았습니다.
- 테스트에서 `SimpleMeterRegistry` 실인스턴스를 주입하여 NPE 흡수에 의존하지 않도록 하였습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #100