### PR TITLE
/actuator/prometheus 접근 허용 및 스크랩 경로 정리

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -3,6 +3,6 @@ global:
 
 scrape_configs:
   - job_name: 'gwangjutalentfestival'
-    metrics_path: '/prometheus'
+    metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['app:8080']

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -81,9 +81,7 @@ management:
     web:
       exposure:
         include: health, prometheus
-      base-path: /
-      path-mapping:
-        health: health
+      base-path: /actuator
   endpoint:
     health:
       show-details: never


### PR DESCRIPTION
## ✨ 작업 내용
> Prometheus가 `/actuator/prometheus` 엔드포인트에 정상적으로 접근할 수 있도록 Spring Security 허용 설정, actuator base-path 통일, prometheus.yml 스크랩 경로를 수정하였습니다.

- `PublicEndpointMatcher`에 `/actuator/prometheus` 경로를 permitAll 목록에 추가하였습니다.
- `application.yaml`의 actuator `base-path`를 `/actuator`로 통일하고 불필요한 `path-mapping` 설정을 제거하였습니다.
- `prometheus.yml`의 `metrics_path`를 `/prometheus`에서 `/actuator/prometheus`로 변경하였습니다.
- Promtail 로그 수집기 설정 파일(`promtail-config.yaml`)을 추가하였습니다.

---

## 🔍 리뷰 시 참고사항
- 기존에는 actuator `base-path`가 `/`로 설정되어 있어 `/prometheus`로 접근 가능하였으나, Spring Boot 기본값인 `/actuator`로 통일하였습니다.
- `management.security.enabled: false`는 Spring Boot 2.x 이후 무시되는 무효 설정으로, Security 허용은 `PublicEndpointMatcher`에서 처리하도록 수정하였습니다.
- Promtail은 Docker 컨테이너 로그를 Loki로 전달하는 설정이며, 현재 파일 내용은 추후 채워질 예정입니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #
