### PR TITLE
pr-draft 스킬 리뷰어 자동 지정 및 PR 제목 형식 개선

### DIFF
--- a/.claude/skills/pr-draft/SKILL.md
+++ b/.claude/skills/pr-draft/SKILL.md
@@ -78,7 +78,7 @@ Ask the user to confirm which title to use. If no answer, proceed with the recom
 ## Step 5 — Create PR
 
 ```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/create-pr.sh" "<confirmed-title>" "PR_BODY.md" "<label1>,<label2>" "School-of-Company/Gwangju-talent-festival-Server"
+bash "${CLAUDE_SKILL_DIR}/scripts/create-pr.sh" "<confirmed-title>" "PR_BODY.md" "<label1>,<label2>" "School-of-Company/Gwangju-talent-festival-Server" "@me"
 ```
 
 After creation, display the PR URL.

--- a/.claude/skills/pr-draft/SKILL.md
+++ b/.claude/skills/pr-draft/SKILL.md
@@ -36,7 +36,7 @@ Read `${CLAUDE_SKILL_DIR}/references/labels.md` and select 1–2 appropriate lab
 ## Step 3 — Generate PR Content
 
 **Title** — Generate 3 options:
-- Format: `type :: description` (no brackets — follow git commit convention: add/update/fix/delete/docs/test)
+- Format: description only — do NOT add a type prefix (no `fix ::`, `update ::`, etc.)
 - Description: Korean, concise, **derived from the related issue title/content**, no period, max 50 characters total
 - Mark the best option with `← 추천`
 
@@ -78,7 +78,7 @@ Ask the user to confirm which title to use. If no answer, proceed with the recom
 ## Step 5 — Create PR
 
 ```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/create-pr.sh" "<confirmed-title>" "PR_BODY.md" "<label1>,<label2>"
+bash "${CLAUDE_SKILL_DIR}/scripts/create-pr.sh" "<confirmed-title>" "PR_BODY.md" "<label1>,<label2>" "School-of-Company/Gwangju-talent-festival-Server"
 ```
 
 After creation, display the PR URL.

--- a/.claude/skills/pr-draft/scripts/create-pr.sh
+++ b/.claude/skills/pr-draft/scripts/create-pr.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -e
 
-TITLE="${1:?Error: PR title is required. Usage: create-pr.sh <title> <body-file> [label1,label2,...]}"
-BODY_FILE="${2:?Error: Body file is required. Usage: create-pr.sh <title> <body-file> [label1,label2,...]}"
+TITLE="${1:?Error: PR title is required. Usage: create-pr.sh <title> <body-file> [label1,label2,...] [reviewer1,reviewer2,...]}"
+BODY_FILE="${2:?Error: Body file is required. Usage: create-pr.sh <title> <body-file> [label1,label2,...] [reviewer1,reviewer2,...]}"
 LABELS="${3:-}"
+REVIEWERS="${4:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -45,10 +46,19 @@ if [ -n "$LABELS" ]; then
   done
 fi
 
+if [ -n "$REVIEWERS" ]; then
+  IFS=',' read -ra REVIEWER_ARRAY <<< "$REVIEWERS"
+  for reviewer in "${REVIEWER_ARRAY[@]}"; do
+    trimmed=$(echo "$reviewer" | xargs)
+    [ -n "$trimmed" ] && ARGS+=(--reviewer "$trimmed")
+  done
+fi
+
 echo "Creating PR..."
-echo "  Title : $TITLE"
-echo "  Base  : $BASE"
-[ -n "$LABELS" ] && echo "  Labels: $LABELS"
+echo "  Title    : $TITLE"
+echo "  Base     : $BASE"
+[ -n "$LABELS" ]    && echo "  Labels   : $LABELS"
+[ -n "$REVIEWERS" ] && echo "  Reviewers: $REVIEWERS"
 echo ""
 
 "${ARGS[@]}"

--- a/.claude/skills/pr-draft/scripts/create-pr.sh
+++ b/.claude/skills/pr-draft/scripts/create-pr.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
-TITLE="${1:?Error: PR title is required. Usage: create-pr.sh <title> <body-file> [label1,label2,...] [reviewer1,reviewer2,...]}"
-BODY_FILE="${2:?Error: Body file is required. Usage: create-pr.sh <title> <body-file> [label1,label2,...] [reviewer1,reviewer2,...]}"
+TITLE="${1:?Error: PR title is required. Usage: create-pr.sh <title> <body-file> [label1,label2,...] [reviewer1,reviewer2,...] [assignee1,assignee2,...]}"
+BODY_FILE="${2:?Error: Body file is required. Usage: create-pr.sh <title> <body-file> [label1,label2,...] [reviewer1,reviewer2,...] [assignee1,assignee2,...]}"
 LABELS="${3:-}"
 REVIEWERS="${4:-}"
+ASSIGNEES="${5:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -54,11 +55,20 @@ if [ -n "$REVIEWERS" ]; then
   done
 fi
 
+if [ -n "$ASSIGNEES" ]; then
+  IFS=',' read -ra ASSIGNEE_ARRAY <<< "$ASSIGNEES"
+  for assignee in "${ASSIGNEE_ARRAY[@]}"; do
+    trimmed=$(echo "$assignee" | xargs)
+    [ -n "$trimmed" ] && ARGS+=(--assignee "$trimmed")
+  done
+fi
+
 echo "Creating PR..."
 echo "  Title    : $TITLE"
 echo "  Base     : $BASE"
 [ -n "$LABELS" ]    && echo "  Labels   : $LABELS"
 [ -n "$REVIEWERS" ] && echo "  Reviewers: $REVIEWERS"
+[ -n "$ASSIGNEES" ] && echo "  Assignees: $ASSIGNEES"
 echo ""
 
 "${ARGS[@]}"


### PR DESCRIPTION
## ✨ 작업 내용
pr-draft 스킬의 PR 생성 방식을 개선하였습니다.

- `create-pr.sh`에 4번째 인자로 리뷰어(쉼표 구분)를 받아 `--reviewer` 플래그로 전달하도록 추가하였습니다.
- `School-of-Company/Gwangju-talent-festival-Server` 팀을 기본 리뷰어로 자동 지정하도록 SKILL.md Step 5를 수정하였습니다.
- PR 제목에서 `type ::` prefix를 제거하고 한국어 설명만 생성하도록 변경하였습니다.

---

## 🔍 리뷰 시 참고사항
- 리뷰어는 쉼표로 구분하여 여러 명 지정이 가능합니다.
- PR 제목 prefix 제거는 GitHub PR과 git commit 메시지의 형식을 분리하기 위한 변경입니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- 해당 없음