### PR TITLE
Prometheus 스크랩 경로 수정 및 Promtail 모니터링 설정 추가

### DIFF
--- a/promtail-config.yaml
+++ b/promtail-config.yaml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        target_label: container

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,6 +74,8 @@ slogan:
     end-at: ${END_AT:2026-05-28T18:00:00}
 
 management:
+  security:
+    enabled: false
   metrics:
     tags:
       application: ${spring.application.name}


### PR DESCRIPTION
## ✨ 작업 내용
> Prometheus 메트릭 수집 경로를 `/actuator/prometheus`로 통일하고, Promtail을 이용한 Docker 컨테이너 로그 수집 설정을 추가하였습니다.

- `PublicEndpointMatcher`에 `/actuator/prometheus` 경로를 인증 없이 접근 가능하도록 추가하였습니다.
- `application.yaml`의 actuator `base-path`를 기본값인 `/actuator`로 변경하고 불필요한 `path-mapping` 설정을 제거하였습니다.
- `prometheus.yml`의 `metrics_path`를 `/prometheus`에서 `/actuator/prometheus`로 수정하였습니다.
- `promtail-config.yaml`을 추가하여 Docker 컨테이너 로그를 Loki로 전달하는 설정을 구성하였습니다.

---

## 🔍 리뷰 시 참고사항
- 기존에는 actuator `base-path`가 `/`로 설정되어 `/prometheus`로 직접 접근 가능하였으나, Spring Boot 기본 경로인 `/actuator`로 통일하였습니다.
- `management.security.enabled: false`는 Spring Boot 2.x 이후 무시되는 무효 설정으로, Security 허용은 `PublicEndpointMatcher`에서 올바르게 처리하도록 수정하였습니다.
- Promtail은 Docker 소켓을 통해 실행 중인 컨테이너 이름을 라벨로 붙여 Loki(`http://loki:3100`)로 로그를 전송합니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #
