### PR TITLE
좌석·심사 운영 메트릭 이상 탐지 알림 추가

### DIFF
--- a/docs/anomaly-detection.md
+++ b/docs/anomaly-detection.md
@@ -1,0 +1,97 @@
+# 이상 탐지 모듈 (Anomaly Detection)
+
+## 개요
+
+rule-based detector 방식으로 구현된 이상 탐지 모듈입니다. ML 기반이 아닌, 사전 정의된 규칙(임계값)에 따라 Prometheus 메트릭을 주기적으로 조회하고 이상을 감지합니다.
+
+감지 주기: 60초 (fixedDelay)
+
+## 환경 변수
+
+| 변수명 | 기본값 | 설명 |
+|--------|--------|------|
+| `ANOMALY_DETECTOR_ENABLED` | `false` | 이상 탐지 스케줄러 활성화 여부 |
+| `PROMETHEUS_BASE_URL` | `http://localhost:9090` | Prometheus 서버 주소 |
+| `DISCORD_WEBHOOK_URL` | (없음) | Discord 알림 웹훅 URL (빈값이면 알림 비활성화) |
+
+## 탐지 규칙
+
+| 도메인 | 메트릭 | 임계값 | 설명 |
+|--------|--------|--------|------|
+| seat | failure_rate | 5% | 좌석 예매 실패율 |
+| seat | p95_duration | 2.5s | 좌석 예매 p95 응답 시간 |
+| judge | failure_rate | 3% | 심사 제출 실패율 |
+| judge | p95_duration | 2.0s | 심사 제출 p95 응답 시간 |
+
+## Prometheus Query API
+
+Prometheus의 instant query 엔드포인트를 사용합니다.
+
+```
+GET {PROMETHEUS_BASE_URL}/api/v1/query?query={promql}
+```
+
+### 실패율 PromQL 패턴
+
+```
+rate(seat_reservation_failure_total{application="gwangjutalentfestival"}[5m])
+/ (
+  rate(seat_reservation_success_total{application="gwangjutalentfestival"}[5m])
+  + rate(seat_reservation_failure_total{application="gwangjutalentfestival"}[5m])
+)
+```
+
+### p95 응답시간 PromQL 패턴
+
+```
+histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_bucket{application="gwangjutalentfestival"}[5m])))
+```
+
+## Discord 알림 예시
+
+```
+🚫 [seat] failure_rate 이상: 7.20% >= 5.00%
+(좌석 예매 실패율이 기준치를 초과했습니다.)
+```
+
+```
+🚫 [judge] p95_duration 이상: 3.10s >= 2.00s
+(심사 제출 p95 응답 시간이 기준치를 초과했습니다.)
+```
+
+동일 도메인/메트릭에 대한 OPEN 이벤트가 이미 존재하면 중복 알림을 보내지 않습니다.
+
+## 실행 방법
+
+### 활성화
+
+`ANOMALY_DETECTOR_ENABLED=true` 환경 변수를 설정합니다.
+
+```bash
+ANOMALY_DETECTOR_ENABLED=true \
+PROMETHEUS_BASE_URL=http://prometheus:9090 \
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/... \
+java -jar app.jar
+```
+
+### curl 테스트
+
+Prometheus instant query API 직접 호출:
+
+```bash
+# 좌석 예매 실패율 조회
+curl -G 'http://localhost:9090/api/v1/query' \
+  --data-urlencode 'query=rate(seat_reservation_failure_total{application="gwangjutalentfestival"}[5m]) / (rate(seat_reservation_success_total{application="gwangjutalentfestival"}[5m]) + rate(seat_reservation_failure_total{application="gwangjutalentfestival"}[5m]))'
+
+# 좌석 예매 p95 응답시간 조회
+curl -G 'http://localhost:9090/api/v1/query' \
+  --data-urlencode 'query=histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_bucket{application="gwangjutalentfestival"}[5m])))'
+```
+
+Discord 웹훅 직접 테스트:
+
+```bash
+curl -X POST https://discord.com/api/webhooks/YOUR_WEBHOOK_URL \
+  -H "Content-Type: application/json" \
+  -d '{"content": "🚫 [test] anomaly detection 테스트 메시지"}'
+```

--- a/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
 import team.startup.gwangjutalentfestival.domain.slogan.properties.SloganSubmissionProperties;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProperties;
 import team.startup.gwangjutalentfestival.global.security.properties.CorsProperties;
@@ -19,7 +20,7 @@ import team.startup.gwangjutalentfestival.global.sms.properties.SolapiProperties
 @EnableFeignClients
 @EnableAsync
 @EnableScheduling
-@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class, SolapiProperties.class, SmsVerifyProperties.class,SloganSubmissionProperties.class})
+@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class, SolapiProperties.class, SmsVerifyProperties.class, SloganSubmissionProperties.class, MonitoringProperties.class})
 @SpringBootApplication
 public class GwangjutalentfestivalApplication {
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/DiscordWebhookClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/DiscordWebhookClient.java
@@ -39,7 +39,7 @@ public class DiscordWebhookClient {
                     .retrieve()
                     .toBodilessEntity();
         } catch (Exception e) {
-            log.warn("Discord 알림 전송 실패. error={}", e.getMessage());
+            log.warn("Discord 알림 전송 실패.", e);
         }
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/DiscordWebhookClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/DiscordWebhookClient.java
@@ -1,0 +1,45 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class DiscordWebhookClient {
+
+    private final RestClient discordRestClient;
+    private final MonitoringProperties monitoringProperties;
+
+    public DiscordWebhookClient(
+            @Qualifier("discordRestClient") RestClient discordRestClient,
+            MonitoringProperties monitoringProperties
+    ) {
+        this.discordRestClient = discordRestClient;
+        this.monitoringProperties = monitoringProperties;
+    }
+
+    public void send(String message) {
+        String webhookUrl = monitoringProperties.discordWebhookUrl();
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            log.warn("Discord webhook URL이 설정되지 않아 알림을 전송하지 않습니다.");
+            return;
+        }
+
+        try {
+            discordRestClient.post()
+                    .uri(webhookUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("content", message))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("Discord 알림 전송 실패. error={}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
@@ -25,8 +25,8 @@ public class PrometheusClient {
     }
 
     public Optional<Double> query(String promql) {
+        String resolvedPromql = promql.replace("{application}", applicationName);
         try {
-            String resolvedPromql = promql.replace("{application}", applicationName);
             PrometheusResponse response = prometheusRestClient.get()
                     .uri("/api/v1/query?query={promql}", resolvedPromql)
                     .retrieve()
@@ -43,23 +43,24 @@ public class PrometheusClient {
                 return Optional.empty();
             }
 
-            List<Object> valueList = response.data().result().get(0).value();
-            if (valueList == null || valueList.size() < 2) {
+            PrometheusResult firstResult = response.data().result().get(0);
+            if (firstResult == null || firstResult.value() == null || firstResult.value().size() < 2) {
                 log.warn("Prometheus query 결과의 value 형식이 올바르지 않습니다. promql={}", resolvedPromql);
                 return Optional.empty();
             }
 
+            List<Object> valueList = firstResult.value();
             String rawValue = valueList.get(1).toString();
             double value = Double.parseDouble(rawValue);
 
             if (Double.isNaN(value) || Double.isInfinite(value)) {
-                log.warn("Prometheus query 값이 NaN 또는 Infinite입니다. promql={}, value={}", promql, rawValue);
+                log.debug("Prometheus query 값이 NaN 또는 Infinite입니다. promql={}, value={}", resolvedPromql, rawValue);
                 return Optional.empty();
             }
 
             return Optional.of(value);
         } catch (Exception e) {
-            log.warn("Prometheus query 실패. promql={}, error={}", promql, e.getMessage());
+            log.warn("Prometheus query 실패. promql={}", resolvedPromql, e);
             return Optional.empty();
         }
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
@@ -2,6 +2,7 @@ package team.startup.gwangjutalentfestival.domain.monitoring.client;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
@@ -15,28 +16,38 @@ public class PrometheusClient {
 
     private final RestClient prometheusRestClient;
     private final MonitoringProperties monitoringProperties;
+    private final String applicationName;
 
     public PrometheusClient(
             @Qualifier("prometheusRestClient") RestClient prometheusRestClient,
-            MonitoringProperties monitoringProperties
+            MonitoringProperties monitoringProperties,
+            @Value("${spring.application.name}") String applicationName
     ) {
         this.prometheusRestClient = prometheusRestClient;
         this.monitoringProperties = monitoringProperties;
+        this.applicationName = applicationName;
     }
 
     public Optional<Double> query(String promql) {
         try {
+            String resolvedPromql = promql.replace("{application}", applicationName);
             PrometheusResponse response = prometheusRestClient.get()
-                    .uri(monitoringProperties.prometheusBaseUrl() + "/api/v1/query?query={promql}", promql)
+                    .uri(monitoringProperties.prometheusBaseUrl() + "/api/v1/query?query={promql}", resolvedPromql)
                     .retrieve()
                     .body(PrometheusResponse.class);
 
             if (response == null || response.data() == null || response.data().result() == null || response.data().result().isEmpty()) {
-                log.warn("Prometheus query 결과가 비어있습니다. promql={}", promql);
+                log.warn("Prometheus query 결과가 비어있습니다. promql={}", resolvedPromql);
                 return Optional.empty();
             }
 
-            String rawValue = response.data().result().get(0).value().get(1).toString();
+            List<Object> valueList = response.data().result().get(0).value();
+            if (valueList == null || valueList.size() < 2) {
+                log.warn("Prometheus query 결과의 value 형식이 올바르지 않습니다. promql={}", resolvedPromql);
+                return Optional.empty();
+            }
+
+            String rawValue = valueList.get(1).toString();
             double value = Double.parseDouble(rawValue);
 
             if (Double.isNaN(value) || Double.isInfinite(value)) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
-import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,16 +14,13 @@ import java.util.Optional;
 public class PrometheusClient {
 
     private final RestClient prometheusRestClient;
-    private final MonitoringProperties monitoringProperties;
     private final String applicationName;
 
     public PrometheusClient(
             @Qualifier("prometheusRestClient") RestClient prometheusRestClient,
-            MonitoringProperties monitoringProperties,
             @Value("${spring.application.name}") String applicationName
     ) {
         this.prometheusRestClient = prometheusRestClient;
-        this.monitoringProperties = monitoringProperties;
         this.applicationName = applicationName;
     }
 
@@ -32,12 +28,18 @@ public class PrometheusClient {
         try {
             String resolvedPromql = promql.replace("{application}", applicationName);
             PrometheusResponse response = prometheusRestClient.get()
-                    .uri(monitoringProperties.prometheusBaseUrl() + "/api/v1/query?query={promql}", resolvedPromql)
+                    .uri("/api/v1/query?query={promql}", resolvedPromql)
                     .retrieve()
                     .body(PrometheusResponse.class);
 
-            if (response == null || response.data() == null || response.data().result() == null || response.data().result().isEmpty()) {
-                log.warn("Prometheus query 결과가 비어있습니다. promql={}", resolvedPromql);
+            if (response == null || !"success".equals(response.status())) {
+                log.warn("Prometheus query 호출 실패 또는 에러 응답. status={}, promql={}",
+                        response != null ? response.status() : "null", resolvedPromql);
+                return Optional.empty();
+            }
+
+            if (response.data() == null || response.data().result() == null || response.data().result().isEmpty()) {
+                log.debug("Prometheus query 결과가 비어있습니다. promql={}", resolvedPromql);
                 return Optional.empty();
             }
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
@@ -1,0 +1,59 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class PrometheusClient {
+
+    private final RestClient prometheusRestClient;
+    private final MonitoringProperties monitoringProperties;
+
+    public PrometheusClient(
+            @Qualifier("prometheusRestClient") RestClient prometheusRestClient,
+            MonitoringProperties monitoringProperties
+    ) {
+        this.prometheusRestClient = prometheusRestClient;
+        this.monitoringProperties = monitoringProperties;
+    }
+
+    public Optional<Double> query(String promql) {
+        try {
+            PrometheusResponse response = prometheusRestClient.get()
+                    .uri(monitoringProperties.prometheusBaseUrl() + "/api/v1/query?query={promql}", promql)
+                    .retrieve()
+                    .body(PrometheusResponse.class);
+
+            if (response == null || response.data() == null || response.data().result() == null || response.data().result().isEmpty()) {
+                log.warn("Prometheus query 결과가 비어있습니다. promql={}", promql);
+                return Optional.empty();
+            }
+
+            String rawValue = response.data().result().get(0).value().get(1).toString();
+            double value = Double.parseDouble(rawValue);
+
+            if (Double.isNaN(value) || Double.isInfinite(value)) {
+                log.warn("Prometheus query 값이 NaN 또는 Infinite입니다. promql={}, value={}", promql, rawValue);
+                return Optional.empty();
+            }
+
+            return Optional.of(value);
+        } catch (Exception e) {
+            log.warn("Prometheus query 실패. promql={}, error={}", promql, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    record PrometheusResponse(String status, PrometheusData data) {}
+
+    record PrometheusData(List<PrometheusResult> result) {}
+
+    record PrometheusResult(List<Object> value) {}
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetector.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetector.java
@@ -1,0 +1,64 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.detector;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.DiscordWebhookClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusClient;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnomalyDetector {
+
+    private final PrometheusClient prometheusClient;
+    private final DiscordWebhookClient discordWebhookClient;
+    private final AnomalyEventAppender anomalyEventAppender;
+
+    public void detectAll() {
+        for (AnomalyRule rule : AnomalyRule.ALL) {
+            Optional<Double> result = prometheusClient.query(rule.promql());
+            if (result.isEmpty()) {
+                log.warn("Prometheus 쿼리 결과 없음. domain={}, metric={}", rule.domain(), rule.metricName());
+                continue;
+            }
+
+            double value = result.get();
+            if (value >= rule.threshold()) {
+                boolean saved;
+                try {
+                    saved = anomalyEventAppender.appendIfNotDuplicate(rule, value);
+                } catch (Exception e) {
+                    log.warn("이상 이벤트 저장 실패. domain={}, metric={}, error={}", rule.domain(), rule.metricName(), e.getMessage());
+                    continue;
+                }
+
+                if (saved) {
+                    String message = buildMessage(rule, value);
+                    discordWebhookClient.send(message);
+                }
+            }
+        }
+    }
+
+    private String buildMessage(AnomalyRule rule, double value) {
+        if ("failure_rate".equals(rule.metricName())) {
+            return "🚫 [%s] %s 이상: %.2f%% >= %.2f%%\n(%s)".formatted(
+                    rule.domain(),
+                    rule.metricName(),
+                    value * 100,
+                    rule.threshold() * 100,
+                    rule.reason()
+            );
+        }
+        return "🚫 [%s] %s 이상: %.2fs >= %.2fs\n(%s)".formatted(
+                rule.domain(),
+                rule.metricName(),
+                value,
+                rule.threshold(),
+                rule.reason()
+        );
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppender.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppender.java
@@ -1,0 +1,39 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.detector;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AnomalyEventAppender {
+
+    private final AnomalyEventRepository anomalyEventRepository;
+
+    @Transactional
+    public boolean appendIfNotDuplicate(AnomalyRule rule, double detectedValue) {
+        if (anomalyEventRepository.existsByDomainAndMetricNameAndStatus(
+                rule.domain(), rule.metricName(), AnomalyEventStatus.OPEN)) {
+            return false;
+        }
+
+        anomalyEventRepository.save(
+                AnomalyEventEntity.builder()
+                        .domain(rule.domain())
+                        .metricName(rule.metricName())
+                        .status(AnomalyEventStatus.OPEN)
+                        .detectedValue(detectedValue)
+                        .thresholdValue(rule.threshold())
+                        .reason(rule.reason())
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        return true;
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppender.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppender.java
@@ -7,8 +7,6 @@ import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventE
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
 import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
 
-import java.time.LocalDateTime;
-
 @Service
 @RequiredArgsConstructor
 public class AnomalyEventAppender {
@@ -30,7 +28,6 @@ public class AnomalyEventAppender {
                         .detectedValue(detectedValue)
                         .thresholdValue(rule.threshold())
                         .reason(rule.reason())
-                        .createdAt(LocalDateTime.now())
                         .build()
         );
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyRule.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyRule.java
@@ -1,0 +1,42 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.detector;
+
+import java.util.List;
+
+public record AnomalyRule(
+        String domain,
+        String metricName,
+        String promql,
+        double threshold,
+        String reason
+) {
+    public static final List<AnomalyRule> ALL = List.of(
+            new AnomalyRule(
+                    "seat",
+                    "failure_rate",
+                    "rate(seat_reservation_failure_total{application=\"gwangjutalentfestival\"}[5m]) / (rate(seat_reservation_success_total{application=\"gwangjutalentfestival\"}[5m]) + rate(seat_reservation_failure_total{application=\"gwangjutalentfestival\"}[5m]))",
+                    0.05,
+                    "좌석 예매 실패율이 기준치를 초과했습니다."
+            ),
+            new AnomalyRule(
+                    "seat",
+                    "p95_duration",
+                    "histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_bucket{application=\"gwangjutalentfestival\"}[5m])))",
+                    2.5,
+                    "좌석 예매 p95 응답 시간이 기준치를 초과했습니다."
+            ),
+            new AnomalyRule(
+                    "judge",
+                    "failure_rate",
+                    "rate(judge_submit_failure_total{application=\"gwangjutalentfestival\"}[5m]) / (rate(judge_submit_success_total{application=\"gwangjutalentfestival\"}[5m]) + rate(judge_submit_failure_total{application=\"gwangjutalentfestival\"}[5m]))",
+                    0.03,
+                    "심사 제출 실패율이 기준치를 초과했습니다."
+            ),
+            new AnomalyRule(
+                    "judge",
+                    "p95_duration",
+                    "histogram_quantile(0.95, sum by (le) (rate(judge_submit_duration_seconds_bucket{application=\"gwangjutalentfestival\"}[5m])))",
+                    2.0,
+                    "심사 제출 p95 응답 시간이 기준치를 초과했습니다."
+            )
+    );
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyRule.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyRule.java
@@ -13,28 +13,28 @@ public record AnomalyRule(
             new AnomalyRule(
                     "seat",
                     "failure_rate",
-                    "rate(seat_reservation_failure_total{application=\"gwangjutalentfestival\"}[5m]) / (rate(seat_reservation_success_total{application=\"gwangjutalentfestival\"}[5m]) + rate(seat_reservation_failure_total{application=\"gwangjutalentfestival\"}[5m]))",
+                    "rate(seat_reservation_failure_total{application=\"{application}\"}[5m]) / (rate(seat_reservation_success_total{application=\"{application}\"}[5m]) + rate(seat_reservation_failure_total{application=\"{application}\"}[5m]))",
                     0.05,
                     "좌석 예매 실패율이 기준치를 초과했습니다."
             ),
             new AnomalyRule(
                     "seat",
                     "p95_duration",
-                    "histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_bucket{application=\"gwangjutalentfestival\"}[5m])))",
+                    "histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_bucket{application=\"{application}\"}[5m])))",
                     2.5,
                     "좌석 예매 p95 응답 시간이 기준치를 초과했습니다."
             ),
             new AnomalyRule(
                     "judge",
                     "failure_rate",
-                    "rate(judge_submit_failure_total{application=\"gwangjutalentfestival\"}[5m]) / (rate(judge_submit_success_total{application=\"gwangjutalentfestival\"}[5m]) + rate(judge_submit_failure_total{application=\"gwangjutalentfestival\"}[5m]))",
+                    "rate(judge_submit_failure_total{application=\"{application}\"}[5m]) / (rate(judge_submit_success_total{application=\"{application}\"}[5m]) + rate(judge_submit_failure_total{application=\"{application}\"}[5m]))",
                     0.03,
                     "심사 제출 실패율이 기준치를 초과했습니다."
             ),
             new AnomalyRule(
                     "judge",
                     "p95_duration",
-                    "histogram_quantile(0.95, sum by (le) (rate(judge_submit_duration_seconds_bucket{application=\"gwangjutalentfestival\"}[5m])))",
+                    "histogram_quantile(0.95, sum by (le) (rate(judge_submit_duration_seconds_bucket{application=\"{application}\"}[5m])))",
                     2.0,
                     "심사 제출 p95 응답 시간이 기준치를 초과했습니다."
             )

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventEntity.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -47,7 +48,8 @@ public class AnomalyEventEntity {
     @Column(nullable = false)
     private String reason;
 
-    @Column(name = "created_at", nullable = false)
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Column(name = "resolved_at", nullable = true)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventEntity.java
@@ -1,0 +1,55 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "anomaly_event")
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AnomalyEventEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String domain;
+
+    @Column(name = "metric_name", nullable = false)
+    private String metricName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnomalyEventStatus status;
+
+    @Column(name = "detected_value", nullable = false)
+    private Double detectedValue;
+
+    @Column(name = "threshold_value", nullable = false)
+    private Double thresholdValue;
+
+    @Column(nullable = false)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "resolved_at", nullable = true)
+    private LocalDateTime resolvedAt;
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventStatus.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventStatus.java
@@ -1,0 +1,5 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.entity;
+
+public enum AnomalyEventStatus {
+    OPEN, RESOLVED
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/properties/MonitoringProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/properties/MonitoringProperties.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("monitoring.anomaly")
+public record MonitoringProperties(
+        boolean enabled,
+        String prometheusBaseUrl,
+        String discordWebhookUrl
+) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/AnomalyEventRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/AnomalyEventRepository.java
@@ -1,0 +1,12 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+
+public interface AnomalyEventRepository extends JpaRepository<AnomalyEventEntity, Long> {
+
+    boolean existsByDomainAndMetricNameAndStatus(
+            String domain, String metricName, AnomalyEventStatus status
+    );
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/scheduler/AnomalyDetectionScheduler.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/scheduler/AnomalyDetectionScheduler.java
@@ -1,0 +1,26 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import team.startup.gwangjutalentfestival.domain.monitoring.detector.AnomalyDetector;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "monitoring.anomaly", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class AnomalyDetectionScheduler {
+
+    private final AnomalyDetector anomalyDetector;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void execute() {
+        try {
+            anomalyDetector.detectAll();
+        } catch (Exception e) {
+            log.error("anomaly detection 실행 실패", e);
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/MonitoringClientConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/MonitoringClientConfig.java
@@ -1,0 +1,30 @@
+package team.startup.gwangjutalentfestival.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class MonitoringClientConfig {
+
+    @Bean
+    public RestClient prometheusRestClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(5000);
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+
+    @Bean
+    public RestClient discordRestClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(5000);
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/MonitoringClientConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/MonitoringClientConfig.java
@@ -4,16 +4,18 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
 
 @Configuration
 public class MonitoringClientConfig {
 
     @Bean
-    public RestClient prometheusRestClient() {
+    public RestClient prometheusRestClient(MonitoringProperties monitoringProperties) {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(3000);
         factory.setReadTimeout(5000);
         return RestClient.builder()
+                .baseUrl(monitoringProperties.prometheusBaseUrl())
                 .requestFactory(factory)
                 .build();
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -98,3 +98,9 @@ management:
     metrics:
       export:
         enabled: true
+
+monitoring:
+  anomaly:
+    enabled: ${ANOMALY_DETECTOR_ENABLED:false}
+    prometheus-base-url: ${PROMETHEUS_BASE_URL:http://localhost:9090}
+    discord-webhook-url: ${DISCORD_WEBHOOK_URL:}


### PR DESCRIPTION
## ✨ 작업 내용
Prometheus Query API를 주기적으로 조회하여 좌석 예매·심사 제출 플로우의 실패율 및 p95 latency 이상 징후를 탐지하고, Discord Webhook으로 알림을 전송하는 Rule-based Anomaly Detection 기반을 추가하였습니다.

**추가된 주요 컴포넌트:**
- `PrometheusClient`: `GET /api/v1/query` 호출, NaN·Inf·빈 결과 방어 처리
- `DiscordWebhookClient`: Webhook URL 미설정·전송 실패 방어 처리
- `AnomalyRule`: 4개 탐지 룰 (좌석 실패율 ≥ 5%, 좌석 p95 ≥ 2.5s, 심사 실패율 ≥ 3%, 심사 p95 ≥ 2s)
- `AnomalyEventAppender`: `@Transactional` 내 중복 체크 + 저장 (DB 저장 성공 시에만 Discord 알림)
- `AnomalyDetectionScheduler`: 1분 주기 스케줄러, `ANOMALY_DETECTOR_ENABLED=false` 기본값으로 로컬·테스트 환경 비활성화

---

## 🔍 리뷰 시 참고사항
- `AnomalyEventAppender`를 `AnomalyDetector`와 별도 `@Service`로 분리하였습니다. 같은 클래스 내 `@Transactional` 메서드 호출 시 Spring AOP 프록시를 우회하는 문제를 방지하기 위함입니다.
- DB 저장 실패 시 Discord 알림도 skip되도록 순서를 보장하였습니다. 저장되지 않은 이벤트는 다음 feedback loop에서 추적할 수 없기 때문입니다.
- `resolved_at`, `detected_value`, `threshold_value`, `reason` 필드를 스키마에 포함하였습니다. 다음 PR의 incident feedback loop 연동을 고려한 사전 설계입니다.
- ML, Isolation Forest, feedback API는 이번 PR 범위에 포함되지 않았습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #108