### PR TITLE
이상 탐지 이벤트 피드백 기능 추가

### DIFF
--- a/docs/anomaly-detection.md
+++ b/docs/anomaly-detection.md
@@ -95,3 +95,89 @@ curl -X POST https://discord.com/api/webhooks/YOUR_WEBHOOK_URL \
   -H "Content-Type: application/json" \
   -d '{"content": "🚫 [test] anomaly detection 테스트 메시지"}'
 ```
+
+## Feedback Loop
+
+anomaly_event에 대한 운영자 피드백을 등록하고 이벤트 상태를 관리하는 기능입니다.
+
+### 상태 전이 규칙
+
+| FeedbackLabel | anomaly_event 상태 전이 | resolved_at |
+|---------------|------------------------|-------------|
+| `TRUE_INCIDENT` | OPEN → **RESOLVED** | 피드백 등록 시점 |
+| `FALSE_POSITIVE` | OPEN → **RESOLVED** | 피드백 등록 시점 |
+| `IGNORED` | OPEN → **IGNORED** | 피드백 등록 시점 |
+
+### falsePositiveRate 정의
+
+```
+falsePositiveRate = falsePositiveCount / (trueIncidentCount + falsePositiveCount)
+```
+
+- OPEN 또는 IGNORED 상태 이벤트(피드백 없음)는 분모에서 제외됩니다.
+- 분모가 0이면 falsePositiveRate는 0.0입니다.
+
+### API 목록
+
+모든 API는 ADMIN 권한이 필요합니다. `Authorization: Bearer {token}` 헤더를 포함해야 합니다.
+
+#### 이상 탐지 이벤트 목록 조회
+
+```bash
+# 전체 목록 (최신순, 기본 20개)
+curl -H "Authorization: Bearer TOKEN" \
+  'http://localhost:8080/monitoring/anomalies?page=0&size=20'
+
+# OPEN 상태 필터
+curl -H "Authorization: Bearer TOKEN" \
+  'http://localhost:8080/monitoring/anomalies?page=0&size=20&status=OPEN'
+```
+
+#### 이상 탐지 이벤트 단일 조회
+
+```bash
+curl -H "Authorization: Bearer TOKEN" \
+  http://localhost:8080/monitoring/anomalies/1
+```
+
+#### 피드백 등록
+
+```bash
+# 실제 장애로 판단
+curl -X POST http://localhost:8080/monitoring/anomalies/1/feedback \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"label": "TRUE_INCIDENT", "note": "실제 트래픽 급증으로 인한 장애"}'
+
+# 오탐으로 판단
+curl -X POST http://localhost:8080/monitoring/anomalies/1/feedback \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"label": "FALSE_POSITIVE", "note": "정상적인 이벤트 트래픽"}'
+
+# 무시
+curl -X POST http://localhost:8080/monitoring/anomalies/1/feedback \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"label": "IGNORED"}'
+```
+
+#### 요약 조회
+
+```bash
+curl -H "Authorization: Bearer TOKEN" \
+  http://localhost:8080/monitoring/anomalies/summary
+```
+
+응답 예시:
+```json
+{
+  "totalEvents": 10,
+  "openEvents": 3,
+  "resolvedEvents": 5,
+  "ignoredEvents": 2,
+  "trueIncidentCount": 3,
+  "falsePositiveCount": 2,
+  "falsePositiveRate": 0.4
+}
+```

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventEntity.java
@@ -54,4 +54,14 @@ public class AnomalyEventEntity {
 
     @Column(name = "resolved_at", nullable = true)
     private LocalDateTime resolvedAt;
+
+    public void resolve(LocalDateTime resolvedAt) {
+        this.status = AnomalyEventStatus.RESOLVED;
+        this.resolvedAt = resolvedAt;
+    }
+
+    public void ignore(LocalDateTime resolvedAt) {
+        this.status = AnomalyEventStatus.IGNORED;
+        this.resolvedAt = resolvedAt;
+    }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/FeedbackLabel.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/FeedbackLabel.java
@@ -1,5 +1,5 @@
 package team.startup.gwangjutalentfestival.domain.monitoring.entity;
 
-public enum AnomalyEventStatus {
-    OPEN, RESOLVED, IGNORED
+public enum FeedbackLabel {
+    TRUE_INCIDENT, FALSE_POSITIVE, IGNORED
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/IncidentFeedbackEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/IncidentFeedbackEntity.java
@@ -1,0 +1,53 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "incident_feedback",
+        uniqueConstraints = @UniqueConstraint(name = "uq_feedback_anomaly_event", columnNames = "anomaly_event_id")
+)
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class IncidentFeedbackEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "anomaly_event_id", nullable = false, unique = true)
+    private AnomalyEventEntity anomalyEvent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FeedbackLabel label;
+
+    @Column(nullable = true, length = 500)
+    private String note;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/AnomalyEventNotFoundException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/AnomalyEventNotFoundException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.exception;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+public class AnomalyEventNotFoundException extends GlobalException {
+    public AnomalyEventNotFoundException() {
+        super(ErrorCode.ANOMALY_EVENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/AnomalyEventNotOpenException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/AnomalyEventNotOpenException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.exception;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+public class AnomalyEventNotOpenException extends GlobalException {
+    public AnomalyEventNotOpenException() {
+        super(ErrorCode.ANOMALY_EVENT_NOT_OPEN);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/FeedbackAlreadyExistsException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/FeedbackAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.exception;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+public class FeedbackAlreadyExistsException extends GlobalException {
+    public FeedbackAlreadyExistsException() {
+        super(ErrorCode.FEEDBACK_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/controller/MonitoringController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/controller/MonitoringController.java
@@ -1,0 +1,90 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.CreateIncidentFeedbackRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventDetailResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventListResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventSummaryResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.CreateIncidentFeedbackService;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventDetailService;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventListService;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventSummaryService;
+
+@Tag(name = "Monitoring", description = "이상 탐지 모니터링 API (ADMIN 전용)")
+@RestController
+@RequestMapping("/monitoring")
+@RequiredArgsConstructor
+public class MonitoringController {
+
+    private final GetAnomalyEventListService getAnomalyEventListService;
+    private final GetAnomalyEventDetailService getAnomalyEventDetailService;
+    private final CreateIncidentFeedbackService createIncidentFeedbackService;
+    private final GetAnomalyEventSummaryService getAnomalyEventSummaryService;
+
+    @Operation(summary = "이상 탐지 이벤트 목록 조회", description = "최신순으로 정렬된 이상 탐지 이벤트 목록을 페이지 단위로 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @SecurityRequirement(name = "Authorization")
+    @GetMapping("/anomalies")
+    public ResponseEntity<Page<AnomalyEventListResponse>> getAnomalyEventList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) AnomalyEventStatus status
+    ) {
+        return ResponseEntity.ok(getAnomalyEventListService.execute(page, size, status));
+    }
+
+    @Operation(summary = "이상 탐지 요약 조회", description = "전체 이벤트 수, 상태별 카운트, 오탐률을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @SecurityRequirement(name = "Authorization")
+    @GetMapping("/anomalies/summary")
+    public ResponseEntity<AnomalyEventSummaryResponse> getAnomalyEventSummary() {
+        return ResponseEntity.ok(getAnomalyEventSummaryService.execute());
+    }
+
+    @Operation(summary = "이상 탐지 이벤트 단일 조회", description = "특정 이벤트의 상세 정보와 피드백을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음")
+    })
+    @SecurityRequirement(name = "Authorization")
+    @GetMapping("/anomalies/{id}")
+    public ResponseEntity<AnomalyEventDetailResponse> getAnomalyEventDetail(@PathVariable Long id) {
+        return ResponseEntity.ok(getAnomalyEventDetailService.execute(id));
+    }
+
+    @Operation(summary = "이상 탐지 피드백 등록", description = "이벤트에 피드백을 등록하고 상태를 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "피드백 등록 성공"),
+            @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 피드백이 존재함")
+    })
+    @SecurityRequirement(name = "Authorization")
+    @PostMapping("/anomalies/{id}/feedback")
+    public ResponseEntity<Void> createIncidentFeedback(
+            @PathVariable Long id,
+            @Valid @RequestBody CreateIncidentFeedbackRequest request
+    ) {
+        createIncidentFeedbackService.execute(id, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/request/CreateIncidentFeedbackRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/request/CreateIncidentFeedbackRequest.java
@@ -1,0 +1,11 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
+
+public record CreateIncidentFeedbackRequest(
+        @NotNull FeedbackLabel label,
+        @Size(max = 500) String note
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/AnomalyEventDetailResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/AnomalyEventDetailResponse.java
@@ -1,0 +1,19 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response;
+
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+
+import java.time.LocalDateTime;
+
+public record AnomalyEventDetailResponse(
+        Long id,
+        String domain,
+        String metricName,
+        AnomalyEventStatus status,
+        Double detectedValue,
+        Double thresholdValue,
+        String reason,
+        LocalDateTime createdAt,
+        LocalDateTime resolvedAt,
+        IncidentFeedbackResponse feedback
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/AnomalyEventListResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/AnomalyEventListResponse.java
@@ -1,0 +1,18 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response;
+
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+
+import java.time.LocalDateTime;
+
+public record AnomalyEventListResponse(
+        Long id,
+        String domain,
+        String metricName,
+        AnomalyEventStatus status,
+        Double detectedValue,
+        Double thresholdValue,
+        String reason,
+        LocalDateTime createdAt,
+        LocalDateTime resolvedAt
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/AnomalyEventSummaryResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/AnomalyEventSummaryResponse.java
@@ -1,0 +1,12 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response;
+
+public record AnomalyEventSummaryResponse(
+        long totalEvents,
+        long openEvents,
+        long resolvedEvents,
+        long ignoredEvents,
+        long trueIncidentCount,
+        long falsePositiveCount,
+        double falsePositiveRate
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/IncidentFeedbackResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/IncidentFeedbackResponse.java
@@ -1,0 +1,13 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response;
+
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
+
+import java.time.LocalDateTime;
+
+public record IncidentFeedbackResponse(
+        Long id,
+        FeedbackLabel label,
+        String note,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/AnomalyEventRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/AnomalyEventRepository.java
@@ -12,9 +12,9 @@ public interface AnomalyEventRepository extends JpaRepository<AnomalyEventEntity
             String domain, String metricName, AnomalyEventStatus status
     );
 
-    Page<AnomalyEventEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<AnomalyEventEntity> findAll(Pageable pageable);
 
-    Page<AnomalyEventEntity> findAllByStatusOrderByCreatedAtDesc(AnomalyEventStatus status, Pageable pageable);
+    Page<AnomalyEventEntity> findAllByStatus(AnomalyEventStatus status, Pageable pageable);
 
     long countByStatus(AnomalyEventStatus status);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/AnomalyEventRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/AnomalyEventRepository.java
@@ -1,5 +1,7 @@
 package team.startup.gwangjutalentfestival.domain.monitoring.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
@@ -9,4 +11,10 @@ public interface AnomalyEventRepository extends JpaRepository<AnomalyEventEntity
     boolean existsByDomainAndMetricNameAndStatus(
             String domain, String metricName, AnomalyEventStatus status
     );
+
+    Page<AnomalyEventEntity> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Page<AnomalyEventEntity> findAllByStatusOrderByCreatedAtDesc(AnomalyEventStatus status, Pageable pageable);
+
+    long countByStatus(AnomalyEventStatus status);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/IncidentFeedbackRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/IncidentFeedbackRepository.java
@@ -1,0 +1,16 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.IncidentFeedbackEntity;
+
+import java.util.Optional;
+
+public interface IncidentFeedbackRepository extends JpaRepository<IncidentFeedbackEntity, Long> {
+
+    boolean existsByAnomalyEventId(Long anomalyEventId);
+
+    Optional<IncidentFeedbackEntity> findByAnomalyEventId(Long anomalyEventId);
+
+    long countByLabel(FeedbackLabel label);
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/CreateIncidentFeedbackService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/CreateIncidentFeedbackService.java
@@ -1,0 +1,8 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.CreateIncidentFeedbackRequest;
+
+public interface CreateIncidentFeedbackService {
+
+    void execute(Long anomalyEventId, CreateIncidentFeedbackRequest request);
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventDetailService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventDetailService.java
@@ -1,0 +1,8 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventDetailResponse;
+
+public interface GetAnomalyEventDetailService {
+
+    AnomalyEventDetailResponse execute(Long id);
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventListService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventListService.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import org.springframework.data.domain.Page;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventListResponse;
+
+public interface GetAnomalyEventListService {
+
+    Page<AnomalyEventListResponse> execute(int page, int size, AnomalyEventStatus status);
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventSummaryService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventSummaryService.java
@@ -1,0 +1,8 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventSummaryResponse;
+
+public interface GetAnomalyEventSummaryService {
+
+    AnomalyEventSummaryResponse execute();
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/CreateIncidentFeedbackServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/CreateIncidentFeedbackServiceImpl.java
@@ -1,0 +1,55 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.IncidentFeedbackEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.AnomalyEventNotFoundException;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.FeedbackAlreadyExistsException;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.CreateIncidentFeedbackRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.IncidentFeedbackRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.CreateIncidentFeedbackService;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class CreateIncidentFeedbackServiceImpl implements CreateIncidentFeedbackService {
+
+    private final AnomalyEventRepository anomalyEventRepository;
+    private final IncidentFeedbackRepository incidentFeedbackRepository;
+
+    @Transactional
+    @Override
+    public void execute(Long anomalyEventId, CreateIncidentFeedbackRequest request) {
+        AnomalyEventEntity event = anomalyEventRepository.findById(anomalyEventId)
+                .orElseThrow(AnomalyEventNotFoundException::new);
+
+        if (incidentFeedbackRepository.existsByAnomalyEventId(anomalyEventId)) {
+            throw new FeedbackAlreadyExistsException();
+        }
+
+        try {
+            incidentFeedbackRepository.save(
+                    IncidentFeedbackEntity.builder()
+                            .anomalyEvent(event)
+                            .label(request.label())
+                            .note(request.note())
+                            .build()
+            );
+        } catch (DataIntegrityViolationException e) {
+            throw new FeedbackAlreadyExistsException();
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (request.label() == FeedbackLabel.IGNORED) {
+            event.ignore(now);
+        } else {
+            event.resolve(now);
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/CreateIncidentFeedbackServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/CreateIncidentFeedbackServiceImpl.java
@@ -7,7 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.IncidentFeedbackEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
 import team.startup.gwangjutalentfestival.domain.monitoring.exception.AnomalyEventNotFoundException;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.AnomalyEventNotOpenException;
 import team.startup.gwangjutalentfestival.domain.monitoring.exception.FeedbackAlreadyExistsException;
 import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.CreateIncidentFeedbackRequest;
 import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
@@ -28,6 +30,10 @@ public class CreateIncidentFeedbackServiceImpl implements CreateIncidentFeedback
     public void execute(Long anomalyEventId, CreateIncidentFeedbackRequest request) {
         AnomalyEventEntity event = anomalyEventRepository.findById(anomalyEventId)
                 .orElseThrow(AnomalyEventNotFoundException::new);
+
+        if (event.getStatus() != AnomalyEventStatus.OPEN) {
+            throw new AnomalyEventNotOpenException();
+        }
 
         if (incidentFeedbackRepository.existsByAnomalyEventId(anomalyEventId)) {
             throw new FeedbackAlreadyExistsException();

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/CreateIncidentFeedbackServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/CreateIncidentFeedbackServiceImpl.java
@@ -40,7 +40,7 @@ public class CreateIncidentFeedbackServiceImpl implements CreateIncidentFeedback
         }
 
         try {
-            incidentFeedbackRepository.save(
+            incidentFeedbackRepository.saveAndFlush(
                     IncidentFeedbackEntity.builder()
                             .anomalyEvent(event)
                             .label(request.label())

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/GetAnomalyEventDetailServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/GetAnomalyEventDetailServiceImpl.java
@@ -1,0 +1,42 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.IncidentFeedbackEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.AnomalyEventNotFoundException;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventDetailResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.IncidentFeedbackResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.IncidentFeedbackRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventDetailService;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class GetAnomalyEventDetailServiceImpl implements GetAnomalyEventDetailService {
+
+    private final AnomalyEventRepository anomalyEventRepository;
+    private final IncidentFeedbackRepository incidentFeedbackRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public AnomalyEventDetailResponse execute(Long id) {
+        AnomalyEventEntity event = anomalyEventRepository.findById(id)
+                .orElseThrow(AnomalyEventNotFoundException::new);
+
+        Optional<IncidentFeedbackEntity> feedbackOpt = incidentFeedbackRepository.findByAnomalyEventId(id);
+
+        IncidentFeedbackResponse feedbackResponse = feedbackOpt.map(f -> new IncidentFeedbackResponse(
+                f.getId(), f.getLabel(), f.getNote(), f.getCreatedAt()
+        )).orElse(null);
+
+        return new AnomalyEventDetailResponse(
+                event.getId(), event.getDomain(), event.getMetricName(), event.getStatus(),
+                event.getDetectedValue(), event.getThresholdValue(), event.getReason(),
+                event.getCreatedAt(), event.getResolvedAt(), feedbackResponse
+        );
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/GetAnomalyEventListServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/GetAnomalyEventListServiceImpl.java
@@ -1,0 +1,38 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventListResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventListService;
+
+@Service
+@RequiredArgsConstructor
+public class GetAnomalyEventListServiceImpl implements GetAnomalyEventListService {
+
+    private final AnomalyEventRepository anomalyEventRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<AnomalyEventListResponse> execute(int page, int size, AnomalyEventStatus status) {
+        int safePage = Math.max(0, page);
+        int safeSize = Math.min(Math.max(1, size), 50);
+        PageRequest pageRequest = PageRequest.of(safePage, safeSize, Sort.by("createdAt").descending());
+
+        Page<AnomalyEventEntity> events = (status == null)
+                ? anomalyEventRepository.findAllByOrderByCreatedAtDesc(pageRequest)
+                : anomalyEventRepository.findAllByStatusOrderByCreatedAtDesc(status, pageRequest);
+
+        return events.map(e -> new AnomalyEventListResponse(
+                e.getId(), e.getDomain(), e.getMetricName(), e.getStatus(),
+                e.getDetectedValue(), e.getThresholdValue(), e.getReason(),
+                e.getCreatedAt(), e.getResolvedAt()
+        ));
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/GetAnomalyEventListServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/GetAnomalyEventListServiceImpl.java
@@ -26,8 +26,8 @@ public class GetAnomalyEventListServiceImpl implements GetAnomalyEventListServic
         PageRequest pageRequest = PageRequest.of(safePage, safeSize, Sort.by("createdAt").descending());
 
         Page<AnomalyEventEntity> events = (status == null)
-                ? anomalyEventRepository.findAllByOrderByCreatedAtDesc(pageRequest)
-                : anomalyEventRepository.findAllByStatusOrderByCreatedAtDesc(status, pageRequest);
+                ? anomalyEventRepository.findAll(pageRequest)
+                : anomalyEventRepository.findAllByStatus(status, pageRequest);
 
         return events.map(e -> new AnomalyEventListResponse(
                 e.getId(), e.getDomain(), e.getMetricName(), e.getStatus(),

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/GetAnomalyEventSummaryServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/GetAnomalyEventSummaryServiceImpl.java
@@ -1,0 +1,38 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventSummaryResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.IncidentFeedbackRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventSummaryService;
+
+@Service
+@RequiredArgsConstructor
+public class GetAnomalyEventSummaryServiceImpl implements GetAnomalyEventSummaryService {
+
+    private final AnomalyEventRepository anomalyEventRepository;
+    private final IncidentFeedbackRepository incidentFeedbackRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public AnomalyEventSummaryResponse execute() {
+        long totalEvents = anomalyEventRepository.count();
+        long openEvents = anomalyEventRepository.countByStatus(AnomalyEventStatus.OPEN);
+        long resolvedEvents = anomalyEventRepository.countByStatus(AnomalyEventStatus.RESOLVED);
+        long ignoredEvents = anomalyEventRepository.countByStatus(AnomalyEventStatus.IGNORED);
+        long trueIncidentCount = incidentFeedbackRepository.countByLabel(FeedbackLabel.TRUE_INCIDENT);
+        long falsePositiveCount = incidentFeedbackRepository.countByLabel(FeedbackLabel.FALSE_POSITIVE);
+
+        long denominator = trueIncidentCount + falsePositiveCount;
+        double falsePositiveRate = denominator > 0 ? (double) falsePositiveCount / denominator : 0.0;
+
+        return new AnomalyEventSummaryResponse(
+                totalEvents, openEvents, resolvedEvents, ignoredEvents,
+                trueIncidentCount, falsePositiveCount, falsePositiveRate
+        );
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
@@ -58,6 +58,10 @@ public enum ErrorCode {
     INVALID_JUDGEMENT_SCORE(400, "입력한 점수가 유효한 범위를 벗어났습니다."),
     JUDGEMENT_TOTAL_SCORE_EXCEEDED(400, "총점은 100점을 초과할 수 없습니다."),
 
+    // Monitoring
+    ANOMALY_EVENT_NOT_FOUND(404, "이상 탐지 이벤트를 찾을 수 없습니다."),
+    FEEDBACK_ALREADY_EXISTS(409, "이미 피드백이 등록된 이벤트입니다."),
+
     // Google Sheets
     GOOGLE_SHEETS(500, "Google Sheets 연동 중 오류가 발생했습니다."),
     GOOGLE_SHEETS_API_ERROR(502, "Google Sheets API 오류가 발생했습니다."),

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     // Monitoring
     ANOMALY_EVENT_NOT_FOUND(404, "이상 탐지 이벤트를 찾을 수 없습니다."),
     FEEDBACK_ALREADY_EXISTS(409, "이미 피드백이 등록된 이벤트입니다."),
+    ANOMALY_EVENT_NOT_OPEN(400, "이미 처리된 이상 탐지 이벤트입니다."),
 
     // Google Sheets
     GOOGLE_SHEETS(500, "Google Sheets 연동 중 오류가 발생했습니다."),

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
@@ -86,7 +86,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/judge/{teamId}").hasAnyAuthority(Role.ADMIN.name())
 
                         // monitoring
-                        .requestMatchers("/monitoring/**").hasRole("ADMIN")
+                        .requestMatchers("/monitoring/**").hasAnyAuthority(Role.ADMIN.name())
 
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
@@ -85,6 +85,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/judge/{teamId}").hasAnyAuthority(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.PATCH, "/judge/{teamId}").hasAnyAuthority(Role.ADMIN.name())
 
+                        // monitoring
+                        .requestMatchers("/monitoring/**").hasRole("ADMIN")
+
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/CreateIncidentFeedbackServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/CreateIncidentFeedbackServiceTest.java
@@ -13,6 +13,7 @@ import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventS
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.IncidentFeedbackEntity;
 import team.startup.gwangjutalentfestival.domain.monitoring.exception.AnomalyEventNotFoundException;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.AnomalyEventNotOpenException;
 import team.startup.gwangjutalentfestival.domain.monitoring.exception.FeedbackAlreadyExistsException;
 import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.CreateIncidentFeedbackRequest;
 import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
@@ -43,6 +44,7 @@ class CreateIncidentFeedbackServiceTest {
     private CreateIncidentFeedbackServiceImpl createIncidentFeedbackService;
 
     private AnomalyEventEntity openEvent;
+    private AnomalyEventEntity resolvedEvent;
 
     @BeforeEach
     void setUp() {
@@ -51,6 +53,16 @@ class CreateIncidentFeedbackServiceTest {
                 .domain("seat")
                 .metricName("failure_rate")
                 .status(AnomalyEventStatus.OPEN)
+                .detectedValue(7.0)
+                .thresholdValue(5.0)
+                .reason("좌석 예매 실패율이 기준치를 초과했습니다.")
+                .build();
+
+        resolvedEvent = AnomalyEventEntity.builder()
+                .id(EVENT_ID)
+                .domain("seat")
+                .metricName("failure_rate")
+                .status(AnomalyEventStatus.RESOLVED)
                 .detectedValue(7.0)
                 .thresholdValue(5.0)
                 .reason("좌석 예매 실패율이 기준치를 초과했습니다.")
@@ -91,6 +103,15 @@ class CreateIncidentFeedbackServiceTest {
 
         assertThat(openEvent.getStatus()).isEqualTo(AnomalyEventStatus.IGNORED);
         assertThat(openEvent.getResolvedAt()).isNotNull();
+    }
+
+    @Test
+    void OPEN_상태가_아닌_이벤트에_피드백_등록_시_AnomalyEventNotOpenException이_발생한다() {
+        given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(resolvedEvent));
+
+        assertThatThrownBy(() -> createIncidentFeedbackService.execute(
+                EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.TRUE_INCIDENT, null)
+        )).isInstanceOf(AnomalyEventNotOpenException.class);
     }
 
     @Test

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/CreateIncidentFeedbackServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/CreateIncidentFeedbackServiceTest.java
@@ -1,0 +1,141 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.IncidentFeedbackEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.AnomalyEventNotFoundException;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.FeedbackAlreadyExistsException;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.CreateIncidentFeedbackRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.IncidentFeedbackRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.impl.CreateIncidentFeedbackServiceImpl;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CreateIncidentFeedbackServiceTest {
+
+    private static final Long EVENT_ID = 1L;
+    private static final Long NOT_FOUND_EVENT_ID = 99L;
+
+    @Mock
+    private AnomalyEventRepository anomalyEventRepository;
+
+    @Mock
+    private IncidentFeedbackRepository incidentFeedbackRepository;
+
+    @InjectMocks
+    private CreateIncidentFeedbackServiceImpl createIncidentFeedbackService;
+
+    private AnomalyEventEntity openEvent;
+
+    @BeforeEach
+    void setUp() {
+        openEvent = AnomalyEventEntity.builder()
+                .id(EVENT_ID)
+                .domain("seat")
+                .metricName("failure_rate")
+                .status(AnomalyEventStatus.OPEN)
+                .detectedValue(7.0)
+                .thresholdValue(5.0)
+                .reason("좌석 예매 실패율이 기준치를 초과했습니다.")
+                .build();
+    }
+
+    @Test
+    void TRUE_INCIDENT_피드백_등록_시_anomaly_event가_RESOLVED_상태로_변경된다() {
+        given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
+        given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
+        given(incidentFeedbackRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        createIncidentFeedbackService.execute(EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.TRUE_INCIDENT, null));
+
+        assertThat(openEvent.getStatus()).isEqualTo(AnomalyEventStatus.RESOLVED);
+        assertThat(openEvent.getResolvedAt()).isNotNull();
+    }
+
+    @Test
+    void FALSE_POSITIVE_피드백_등록_시_anomaly_event가_RESOLVED_상태로_변경된다() {
+        given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
+        given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
+        given(incidentFeedbackRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        createIncidentFeedbackService.execute(EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.FALSE_POSITIVE, "정상 트래픽 증가"));
+
+        assertThat(openEvent.getStatus()).isEqualTo(AnomalyEventStatus.RESOLVED);
+        assertThat(openEvent.getResolvedAt()).isNotNull();
+    }
+
+    @Test
+    void IGNORED_피드백_등록_시_anomaly_event가_IGNORED_상태로_변경된다() {
+        given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
+        given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
+        given(incidentFeedbackRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        createIncidentFeedbackService.execute(EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.IGNORED, null));
+
+        assertThat(openEvent.getStatus()).isEqualTo(AnomalyEventStatus.IGNORED);
+        assertThat(openEvent.getResolvedAt()).isNotNull();
+    }
+
+    @Test
+    void 존재하지_않는_이벤트에_피드백_등록_시_AnomalyEventNotFoundException이_발생한다() {
+        given(anomalyEventRepository.findById(NOT_FOUND_EVENT_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> createIncidentFeedbackService.execute(
+                NOT_FOUND_EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.TRUE_INCIDENT, null)
+        )).isInstanceOf(AnomalyEventNotFoundException.class);
+    }
+
+    @Test
+    void 이미_피드백이_존재하는_이벤트에_등록_시_FeedbackAlreadyExistsException이_발생한다() {
+        given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
+        given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(true);
+
+        assertThatThrownBy(() -> createIncidentFeedbackService.execute(
+                EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.FALSE_POSITIVE, null)
+        )).isInstanceOf(FeedbackAlreadyExistsException.class);
+    }
+
+    @Test
+    void 동시_요청으로_DataIntegrityViolationException_발생_시_FeedbackAlreadyExistsException으로_변환된다() {
+        given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
+        given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
+        given(incidentFeedbackRepository.save(any(IncidentFeedbackEntity.class)))
+                .willThrow(new DataIntegrityViolationException("unique constraint"));
+
+        assertThatThrownBy(() -> createIncidentFeedbackService.execute(
+                EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.TRUE_INCIDENT, null)
+        )).isInstanceOf(FeedbackAlreadyExistsException.class);
+    }
+
+    @Test
+    void 피드백_등록_시_label과_note가_올바르게_저장된다() {
+        given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
+        given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
+        ArgumentCaptor<IncidentFeedbackEntity> captor = ArgumentCaptor.forClass(IncidentFeedbackEntity.class);
+        given(incidentFeedbackRepository.save(captor.capture())).willAnswer(inv -> inv.getArgument(0));
+
+        createIncidentFeedbackService.execute(EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.TRUE_INCIDENT, "실제 장애"));
+
+        IncidentFeedbackEntity saved = captor.getValue();
+        assertThat(saved.getLabel()).isEqualTo(FeedbackLabel.TRUE_INCIDENT);
+        assertThat(saved.getNote()).isEqualTo("실제 장애");
+        verify(incidentFeedbackRepository).save(any(IncidentFeedbackEntity.class));
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/CreateIncidentFeedbackServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/CreateIncidentFeedbackServiceTest.java
@@ -73,7 +73,7 @@ class CreateIncidentFeedbackServiceTest {
     void TRUE_INCIDENT_피드백_등록_시_anomaly_event가_RESOLVED_상태로_변경된다() {
         given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
         given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
-        given(incidentFeedbackRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(incidentFeedbackRepository.saveAndFlush(any())).willAnswer(inv -> inv.getArgument(0));
 
         createIncidentFeedbackService.execute(EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.TRUE_INCIDENT, null));
 
@@ -85,7 +85,7 @@ class CreateIncidentFeedbackServiceTest {
     void FALSE_POSITIVE_피드백_등록_시_anomaly_event가_RESOLVED_상태로_변경된다() {
         given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
         given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
-        given(incidentFeedbackRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(incidentFeedbackRepository.saveAndFlush(any())).willAnswer(inv -> inv.getArgument(0));
 
         createIncidentFeedbackService.execute(EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.FALSE_POSITIVE, "정상 트래픽 증가"));
 
@@ -97,7 +97,7 @@ class CreateIncidentFeedbackServiceTest {
     void IGNORED_피드백_등록_시_anomaly_event가_IGNORED_상태로_변경된다() {
         given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
         given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
-        given(incidentFeedbackRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(incidentFeedbackRepository.saveAndFlush(any())).willAnswer(inv -> inv.getArgument(0));
 
         createIncidentFeedbackService.execute(EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.IGNORED, null));
 
@@ -137,7 +137,7 @@ class CreateIncidentFeedbackServiceTest {
     void 동시_요청으로_DataIntegrityViolationException_발생_시_FeedbackAlreadyExistsException으로_변환된다() {
         given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
         given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
-        given(incidentFeedbackRepository.save(any(IncidentFeedbackEntity.class)))
+        given(incidentFeedbackRepository.saveAndFlush(any(IncidentFeedbackEntity.class)))
                 .willThrow(new DataIntegrityViolationException("unique constraint"));
 
         assertThatThrownBy(() -> createIncidentFeedbackService.execute(
@@ -150,13 +150,13 @@ class CreateIncidentFeedbackServiceTest {
         given(anomalyEventRepository.findById(EVENT_ID)).willReturn(Optional.of(openEvent));
         given(incidentFeedbackRepository.existsByAnomalyEventId(EVENT_ID)).willReturn(false);
         ArgumentCaptor<IncidentFeedbackEntity> captor = ArgumentCaptor.forClass(IncidentFeedbackEntity.class);
-        given(incidentFeedbackRepository.save(captor.capture())).willAnswer(inv -> inv.getArgument(0));
+        given(incidentFeedbackRepository.saveAndFlush(captor.capture())).willAnswer(inv -> inv.getArgument(0));
 
         createIncidentFeedbackService.execute(EVENT_ID, new CreateIncidentFeedbackRequest(FeedbackLabel.TRUE_INCIDENT, "실제 장애"));
 
         IncidentFeedbackEntity saved = captor.getValue();
         assertThat(saved.getLabel()).isEqualTo(FeedbackLabel.TRUE_INCIDENT);
         assertThat(saved.getNote()).isEqualTo("실제 장애");
-        verify(incidentFeedbackRepository).save(any(IncidentFeedbackEntity.class));
+        verify(incidentFeedbackRepository).saveAndFlush(any(IncidentFeedbackEntity.class));
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventListServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventListServiceTest.java
@@ -8,7 +8,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
 import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventListResponse;
 import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
@@ -34,36 +33,36 @@ class GetAnomalyEventListServiceTest {
 
     @Test
     void status가_null이면_전체_조회_메서드가_호출된다() {
-        given(anomalyEventRepository.findAllByOrderByCreatedAtDesc(any(Pageable.class)))
+        given(anomalyEventRepository.findAll(any(Pageable.class)))
                 .willReturn(new PageImpl<>(List.of()));
 
         Page<AnomalyEventListResponse> result = getAnomalyEventListService.execute(0, 20, null);
 
         assertThat(result).isNotNull();
-        verify(anomalyEventRepository).findAllByOrderByCreatedAtDesc(any(Pageable.class));
+        verify(anomalyEventRepository).findAll(any(Pageable.class));
         verifyNoMoreInteractions(anomalyEventRepository);
     }
 
     @Test
     void status가_있으면_필터_조회_메서드가_호출된다() {
-        given(anomalyEventRepository.findAllByStatusOrderByCreatedAtDesc(eq(AnomalyEventStatus.OPEN), any(Pageable.class)))
+        given(anomalyEventRepository.findAllByStatus(eq(AnomalyEventStatus.OPEN), any(Pageable.class)))
                 .willReturn(new PageImpl<>(List.of()));
 
         Page<AnomalyEventListResponse> result = getAnomalyEventListService.execute(0, 20, AnomalyEventStatus.OPEN);
 
         assertThat(result).isNotNull();
-        verify(anomalyEventRepository).findAllByStatusOrderByCreatedAtDesc(eq(AnomalyEventStatus.OPEN), any(Pageable.class));
+        verify(anomalyEventRepository).findAllByStatus(eq(AnomalyEventStatus.OPEN), any(Pageable.class));
         verifyNoMoreInteractions(anomalyEventRepository);
     }
 
     @Test
     void 음수_page와_범위_초과_size는_방어_로직에_의해_보정된다() {
-        given(anomalyEventRepository.findAllByOrderByCreatedAtDesc(any(Pageable.class)))
+        given(anomalyEventRepository.findAll(any(Pageable.class)))
                 .willReturn(new PageImpl<>(List.of()));
 
         Page<AnomalyEventListResponse> result = getAnomalyEventListService.execute(-5, 200, null);
 
         assertThat(result).isNotNull();
-        verify(anomalyEventRepository).findAllByOrderByCreatedAtDesc(any(Pageable.class));
+        verify(anomalyEventRepository).findAll(any(Pageable.class));
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventListServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventListServiceTest.java
@@ -1,0 +1,69 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventListResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.impl.GetAnomalyEventListServiceImpl;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class GetAnomalyEventListServiceTest {
+
+    @Mock
+    private AnomalyEventRepository anomalyEventRepository;
+
+    @InjectMocks
+    private GetAnomalyEventListServiceImpl getAnomalyEventListService;
+
+    @Test
+    void status가_null이면_전체_조회_메서드가_호출된다() {
+        given(anomalyEventRepository.findAllByOrderByCreatedAtDesc(any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of()));
+
+        Page<AnomalyEventListResponse> result = getAnomalyEventListService.execute(0, 20, null);
+
+        assertThat(result).isNotNull();
+        verify(anomalyEventRepository).findAllByOrderByCreatedAtDesc(any(Pageable.class));
+        verifyNoMoreInteractions(anomalyEventRepository);
+    }
+
+    @Test
+    void status가_있으면_필터_조회_메서드가_호출된다() {
+        given(anomalyEventRepository.findAllByStatusOrderByCreatedAtDesc(eq(AnomalyEventStatus.OPEN), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of()));
+
+        Page<AnomalyEventListResponse> result = getAnomalyEventListService.execute(0, 20, AnomalyEventStatus.OPEN);
+
+        assertThat(result).isNotNull();
+        verify(anomalyEventRepository).findAllByStatusOrderByCreatedAtDesc(eq(AnomalyEventStatus.OPEN), any(Pageable.class));
+        verifyNoMoreInteractions(anomalyEventRepository);
+    }
+
+    @Test
+    void 음수_page와_범위_초과_size는_방어_로직에_의해_보정된다() {
+        given(anomalyEventRepository.findAllByOrderByCreatedAtDesc(any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of()));
+
+        Page<AnomalyEventListResponse> result = getAnomalyEventListService.execute(-5, 200, null);
+
+        assertThat(result).isNotNull();
+        verify(anomalyEventRepository).findAllByOrderByCreatedAtDesc(any(Pageable.class));
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventSummaryServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/GetAnomalyEventSummaryServiceTest.java
@@ -1,0 +1,78 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventSummaryResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.IncidentFeedbackRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.impl.GetAnomalyEventSummaryServiceImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GetAnomalyEventSummaryServiceTest {
+
+    @Mock
+    private AnomalyEventRepository anomalyEventRepository;
+
+    @Mock
+    private IncidentFeedbackRepository incidentFeedbackRepository;
+
+    @InjectMocks
+    private GetAnomalyEventSummaryServiceImpl getAnomalyEventSummaryService;
+
+    @Test
+    void 정상_summary_반환_및_falsePositiveRate_계산이_올바르다() {
+        given(anomalyEventRepository.count()).willReturn(10L);
+        given(anomalyEventRepository.countByStatus(AnomalyEventStatus.OPEN)).willReturn(3L);
+        given(anomalyEventRepository.countByStatus(AnomalyEventStatus.RESOLVED)).willReturn(5L);
+        given(anomalyEventRepository.countByStatus(AnomalyEventStatus.IGNORED)).willReturn(2L);
+        given(incidentFeedbackRepository.countByLabel(FeedbackLabel.TRUE_INCIDENT)).willReturn(3L);
+        given(incidentFeedbackRepository.countByLabel(FeedbackLabel.FALSE_POSITIVE)).willReturn(2L);
+
+        AnomalyEventSummaryResponse result = getAnomalyEventSummaryService.execute();
+
+        assertThat(result.totalEvents()).isEqualTo(10L);
+        assertThat(result.openEvents()).isEqualTo(3L);
+        assertThat(result.resolvedEvents()).isEqualTo(5L);
+        assertThat(result.ignoredEvents()).isEqualTo(2L);
+        assertThat(result.trueIncidentCount()).isEqualTo(3L);
+        assertThat(result.falsePositiveCount()).isEqualTo(2L);
+        assertThat(result.falsePositiveRate()).isCloseTo(0.4, offset(0.001));
+    }
+
+    @Test
+    void trueIncidentCount와_falsePositiveCount가_모두_0이면_falsePositiveRate는_0이다() {
+        given(anomalyEventRepository.count()).willReturn(5L);
+        given(anomalyEventRepository.countByStatus(AnomalyEventStatus.OPEN)).willReturn(5L);
+        given(anomalyEventRepository.countByStatus(AnomalyEventStatus.RESOLVED)).willReturn(0L);
+        given(anomalyEventRepository.countByStatus(AnomalyEventStatus.IGNORED)).willReturn(0L);
+        given(incidentFeedbackRepository.countByLabel(FeedbackLabel.TRUE_INCIDENT)).willReturn(0L);
+        given(incidentFeedbackRepository.countByLabel(FeedbackLabel.FALSE_POSITIVE)).willReturn(0L);
+
+        AnomalyEventSummaryResponse result = getAnomalyEventSummaryService.execute();
+
+        assertThat(result.falsePositiveRate()).isEqualTo(0.0);
+    }
+
+    @Test
+    void falsePositive만_존재하면_falsePositiveRate는_1이다() {
+        given(anomalyEventRepository.count()).willReturn(3L);
+        given(anomalyEventRepository.countByStatus(AnomalyEventStatus.OPEN)).willReturn(0L);
+        given(anomalyEventRepository.countByStatus(AnomalyEventStatus.RESOLVED)).willReturn(3L);
+        given(anomalyEventRepository.countByStatus(AnomalyEventStatus.IGNORED)).willReturn(0L);
+        given(incidentFeedbackRepository.countByLabel(FeedbackLabel.TRUE_INCIDENT)).willReturn(0L);
+        given(incidentFeedbackRepository.countByLabel(FeedbackLabel.FALSE_POSITIVE)).willReturn(3L);
+
+        AnomalyEventSummaryResponse result = getAnomalyEventSummaryService.execute();
+
+        assertThat(result.falsePositiveRate()).isCloseTo(1.0, offset(0.001));
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangjutalentfestival.domain.seat.exception.InvalidSeatSectionException;
@@ -19,15 +20,13 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 class GetSeatsBySectionServiceImplTest {
 
     @InjectMocks
     private GetSeatsBySectionServiceImpl getSeatsBySectionService;
-
-    @Mock
-    private UserUtil userUtil;
 
     @Spy
     private SeatUtil seatUtil = new SeatUtil();
@@ -42,51 +41,59 @@ class GetSeatsBySectionServiceImplTest {
 
     @Test
     void 모든_좌석_예약_가능() {
-        given(userUtil.currentUserRole()).willReturn(Role.USER);
-        given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
-        given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of());
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of());
 
-        GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
+            GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
-        assertThat(response.seats()).hasSize(77);
-        assertThat(response.seats()).containsOnly(true);
+            assertThat(response.seats()).hasSize(77);
+            assertThat(response.seats()).containsOnly(true);
+        }
     }
 
     @Test
     void 예약된_좌석은_false() {
-        given(userUtil.currentUserRole()).willReturn(Role.USER);
-        given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of(2, 4));
-        given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of());
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of(2, 4));
+            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of());
 
-        GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
+            GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
-        assertThat(response.seats().get(0)).isTrue();
-        assertThat(response.seats().get(1)).isFalse(); // 2번
-        assertThat(response.seats().get(2)).isTrue();
-        assertThat(response.seats().get(3)).isFalse(); // 4번
-        assertThat(response.seats().get(4)).isTrue();
+            assertThat(response.seats().get(0)).isTrue();
+            assertThat(response.seats().get(1)).isFalse(); // 2번
+            assertThat(response.seats().get(2)).isTrue();
+            assertThat(response.seats().get(3)).isFalse(); // 4번
+            assertThat(response.seats().get(4)).isTrue();
+        }
     }
 
     @Test
     void 차단된_좌석은_false() {
-        given(userUtil.currentUserRole()).willReturn(Role.USER);
-        given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
-        given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of(1, 3));
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of(1, 3));
 
-        GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
+            GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
-        assertThat(response.seats().get(0)).isFalse(); // 1번
-        assertThat(response.seats().get(1)).isTrue();
-        assertThat(response.seats().get(2)).isFalse(); // 3번
+            assertThat(response.seats().get(0)).isFalse(); // 1번
+            assertThat(response.seats().get(1)).isTrue();
+            assertThat(response.seats().get(2)).isFalse(); // 3번
+        }
     }
 
     @Test
     void 잘못된_구역_예외() {
-        given(userUtil.currentUserRole()).willReturn(Role.USER);
-        given(seatReservationCustomRepository.findSeatNumbersBySeatSection("Z")).willReturn(Set.of());
-        given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole("Z", Role.USER)).willReturn(Set.of());
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            given(seatReservationCustomRepository.findSeatNumbersBySeatSection("Z")).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole("Z", Role.USER)).willReturn(Set.of());
 
-        assertThatThrownBy(() -> getSeatsBySectionService.execute("Z"))
-                .isInstanceOf(InvalidSeatSectionException.class);
+            assertThatThrownBy(() -> getSeatsBySectionService.execute("Z"))
+                    .isInstanceOf(InvalidSeatSectionException.class);
+        }
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용

이상 탐지 이벤트에 대한 운영자 피드백 기능(Incident Feedback Loop Foundation)을 추가하였습니다.

- `FeedbackLabel` enum을 추가하였습니다 (TRUE_INCIDENT, FALSE_POSITIVE, IGNORED)
- `IncidentFeedbackEntity` 및 `IncidentFeedbackRepository`를 추가하였습니다
- 피드백 등록 시 `anomaly_event` 상태를 자동으로 전이하도록 구현하였습니다
  - TRUE_INCIDENT, FALSE_POSITIVE → RESOLVED / IGNORED → IGNORED
- 관리자용 모니터링 API 4개를 추가하였습니다
  - `GET /monitoring/anomalies` (페이지네이션, status 필터)
  - `GET /monitoring/anomalies/summary` (오탐률 포함 요약 통계)
  - `GET /monitoring/anomalies/{id}` (피드백 포함 단일 조회)
  - `POST /monitoring/anomalies/{id}/feedback` (피드백 등록 → 상태 전이)
- 피드백 중복 방지를 앱 레벨(existsBy)과 DB unique 제약으로 이중 방어하였습니다
- 동시 요청으로 인한 `DataIntegrityViolationException`을 409로 변환하도록 처리하였습니다

---

## 🔍 리뷰 시 참고사항
- `IncidentFeedbackEntity`는 `@OneToOne` + `@JoinColumn(unique=true)` + `@Table uniqueConstraints`로 이중 방어되어 있습니다
- `falsePositiveRate = falsePositiveCount / (trueIncidentCount + falsePositiveCount)`, 분모 0일 경우 0.0 (OPEN/IGNORED 이벤트는 분모 제외)
- `GET /monitoring/anomalies/summary` 엔드포인트가 `/{id}`보다 앞에 등록되어 path variable 충돌을 방지하였습니다
- `GetSeatsBySectionServiceImplTest`의 기존 버그(존재하지 않는 인스턴스 메서드 호출)를 `mockStatic`으로 수정하였습니다
- ML, Isolation Forest 등은 이번 PR 범위에서 제외하였습니다

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #110
