### PR TITLE
ML 학습용 이상 탐지 데이터셋 CSV export 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,9 @@ dependencies {
     // Monitoring
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
+    // CSV
+    implementation 'org.apache.commons:commons-csv:1.12.0'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docs/anomaly-detection.md
+++ b/docs/anomaly-detection.md
@@ -181,3 +181,104 @@ curl -H "Authorization: Bearer TOKEN" \
   "falsePositiveRate": 0.4
 }
 ```
+
+## Dataset Export
+
+anomaly_event + incident_feedback 데이터를 Prometheus 시계열과 결합하여 ML 학습용 CSV 데이터셋을 생성합니다.
+Isolation Forest 등 이상 탐지 모델 학습에 사용합니다. 학습 자체는 이 서버의 범위가 아닙니다.
+
+### 환경 변수
+
+| 변수명 | 기본값 | 설명 |
+|--------|--------|------|
+| `MONITORING_DATASET_EXPORT_PATH` | `./exports` | CSV 파일 저장 경로 |
+
+### API
+
+```bash
+# 전체 기간 export (7일 이내, step=60초)
+curl -X POST http://localhost:8080/monitoring/datasets/export \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start": "2026-05-25T00:00:00",
+    "end": "2026-06-01T00:00:00",
+    "stepSeconds": 60
+  }'
+
+# seat 도메인만 export
+curl -X POST http://localhost:8080/monitoring/datasets/export \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start": "2026-05-25T00:00:00",
+    "end": "2026-06-01T00:00:00",
+    "stepSeconds": 60,
+    "domain": "seat"
+  }'
+
+# 특정 메트릭만 export
+curl -X POST http://localhost:8080/monitoring/datasets/export \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "start": "2026-05-25T00:00:00",
+    "end": "2026-06-01T00:00:00",
+    "domain": "seat",
+    "metricName": "failure_rate"
+  }'
+```
+
+응답 예시:
+```json
+{
+  "filePath": "./exports/dataset_20260601_143205.csv",
+  "rowCount": 10080
+}
+```
+
+### 요청 파라미터
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|----------|------|------|------|
+| start | ISO-8601 | ✓ | 조회 시작 시각 (Asia/Seoul 기준) |
+| end | ISO-8601 | ✓ | 조회 종료 시각, start보다 이후여야 함 |
+| stepSeconds | Integer | - | step 간격(초), 60~3600, 기본값 60 |
+| domain | String | - | seat 또는 judge, null이면 전체 |
+| metricName | String | - | failure_rate 또는 p95_duration, null이면 전체 |
+
+### CSV 스키마
+
+```csv
+domain,metricName,timestamp,value,hourOfDay,dayOfWeek,label
+seat,failure_rate,2026-06-01T09:00:00,0.023,9,MONDAY,normal
+seat,failure_rate,2026-06-01T09:01:00,0.087,9,MONDAY,anomaly
+seat,p95_duration,2026-06-01T09:00:00,1.234,9,MONDAY,normal
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| domain | String | seat / judge |
+| metricName | String | failure_rate / p95_duration |
+| timestamp | ISO-8601 | step 단위 정규화, Asia/Seoul 기준 |
+| value | double | Prometheus 관측값 |
+| hourOfDay | int | 0~23 (Asia/Seoul 기준) |
+| dayOfWeek | String | MONDAY~SUNDAY |
+| label | String | anomaly / normal |
+
+### label 매핑 규칙
+
+| 조건 | label | CSV 포함 |
+|------|-------|--------|
+| TRUE_INCIDENT feedback 있는 포인트 | anomaly | ✓ |
+| FALSE_POSITIVE feedback 있는 포인트 | normal | ✓ |
+| anomaly_event가 없는 일반 시계열 포인트 | normal | ✓ |
+| IGNORED feedback 있는 포인트 | — | ✗ 제외 |
+| feedback 없는 OPEN anomaly_event 포인트 | — | ✗ 제외 |
+
+### label 정책 한계
+
+- 일반 시계열 포인트는 별도 incident feedback이 없는 구간이므로 normal로 간주합니다. 실제 탐지되지 않은 이상 징후가 포함될 수 있습니다.
+- TRUE_INCIDENT는 createdAt이 속한 step bucket 1개만 anomaly로 라벨링합니다. 이상 지속 구간 전체를 커버하지 않습니다.
+- IGNORED와 feedback 없는 OPEN 이벤트는 CSV에서 제외됩니다. 학습 데이터 양이 줄어들 수 있습니다.
+- 동일 timestamp에 Prometheus series가 여러 개 반환될 경우 첫 번째 정상 값을 사용합니다. (중복 row 방지)

--- a/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.DatasetProperties;
 import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
 import team.startup.gwangjutalentfestival.domain.slogan.properties.SloganSubmissionProperties;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProperties;
@@ -20,7 +21,7 @@ import team.startup.gwangjutalentfestival.global.sms.properties.SolapiProperties
 @EnableFeignClients
 @EnableAsync
 @EnableScheduling
-@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class, SolapiProperties.class, SmsVerifyProperties.class, SloganSubmissionProperties.class, MonitoringProperties.class})
+@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class, SolapiProperties.class, SmsVerifyProperties.class, SloganSubmissionProperties.class, MonitoringProperties.class, DatasetProperties.class})
 @SpringBootApplication
 public class GwangjutalentfestivalApplication {
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -62,6 +63,55 @@ public class PrometheusClient {
         } catch (Exception e) {
             log.warn("Prometheus query 실패. promql={}", resolvedPromql, e);
             return Optional.empty();
+        }
+    }
+
+    public List<PrometheusRangePoint> queryRange(String promql, long start, long end, int stepSeconds) {
+        String resolvedPromql = promql.replace("{application}", applicationName);
+        try {
+            PrometheusRangeResponse response = prometheusRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/api/v1/query_range")
+                            .queryParam("query", resolvedPromql)
+                            .queryParam("start", start)
+                            .queryParam("end", end)
+                            .queryParam("step", stepSeconds)
+                            .build())
+                    .retrieve()
+                    .body(PrometheusRangeResponse.class);
+
+            if (response == null || !"success".equals(response.status())) {
+                log.warn("Prometheus queryRange 호출 실패 또는 에러 응답. promql={}", resolvedPromql);
+                return List.of();
+            }
+
+            if (response.data() == null || response.data().result() == null || response.data().result().isEmpty()) {
+                log.debug("Prometheus queryRange 결과가 비어있습니다. promql={}", resolvedPromql);
+                return List.of();
+            }
+
+            List<PrometheusRangePoint> points = new ArrayList<>();
+            for (PrometheusRangeSeries series : response.data().result()) {
+                if (series.values() == null) continue;
+                for (List<Object> pair : series.values()) {
+                    if (pair == null || pair.size() < 2) continue;
+                    try {
+                        long timestamp = ((Number) pair.get(0)).longValue();
+                        double value = Double.parseDouble(pair.get(1).toString());
+                        if (Double.isNaN(value) || Double.isInfinite(value)) {
+                            log.debug("Prometheus queryRange 값이 NaN 또는 Infinite. promql={}, timestamp={}", resolvedPromql, timestamp);
+                            continue;
+                        }
+                        points.add(new PrometheusRangePoint(timestamp, value));
+                    } catch (Exception e) {
+                        log.debug("Prometheus queryRange 포인트 파싱 실패. pair={}", pair);
+                    }
+                }
+            }
+            return points;
+        } catch (Exception e) {
+            log.warn("Prometheus queryRange 실패. promql={}", resolvedPromql, e);
+            return List.of();
         }
     }
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClient.java
@@ -92,7 +92,7 @@ public class PrometheusClient {
 
             List<PrometheusRangePoint> points = new ArrayList<>();
             for (PrometheusRangeSeries series : response.data().result()) {
-                if (series.values() == null) continue;
+                if (series == null || series.values() == null) continue;
                 for (List<Object> pair : series.values()) {
                     if (pair == null || pair.size() < 2) continue;
                     try {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusRangeData.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusRangeData.java
@@ -1,0 +1,5 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client;
+
+import java.util.List;
+
+public record PrometheusRangeData(List<PrometheusRangeSeries> result) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusRangePoint.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusRangePoint.java
@@ -1,0 +1,3 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client;
+
+public record PrometheusRangePoint(long timestamp, double value) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusRangeResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusRangeResponse.java
@@ -1,0 +1,3 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client;
+
+public record PrometheusRangeResponse(String status, PrometheusRangeData data) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusRangeSeries.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusRangeSeries.java
@@ -1,0 +1,6 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client;
+
+import java.util.List;
+import java.util.Map;
+
+public record PrometheusRangeSeries(Map<String, String> metric, List<List<Object>> values) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/DatasetMetricQuery.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/DatasetMetricQuery.java
@@ -1,0 +1,44 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.detector;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum DatasetMetricQuery {
+
+    SEAT_FAILURE_RATE(
+            "seat",
+            "failure_rate",
+            "rate(seat_reservation_failure_total{application=\"{application}\"}[5m]) / (rate(seat_reservation_success_total{application=\"{application}\"}[5m]) + rate(seat_reservation_failure_total{application=\"{application}\"}[5m]))"
+    ),
+    SEAT_P95_DURATION(
+            "seat",
+            "p95_duration",
+            "histogram_quantile(0.95, sum by (le) (rate(seat_reservation_duration_seconds_bucket{application=\"{application}\"}[5m])))"
+    ),
+    JUDGE_FAILURE_RATE(
+            "judge",
+            "failure_rate",
+            "rate(judge_submit_failure_total{application=\"{application}\"}[5m]) / (rate(judge_submit_success_total{application=\"{application}\"}[5m]) + rate(judge_submit_failure_total{application=\"{application}\"}[5m]))"
+    ),
+    JUDGE_P95_DURATION(
+            "judge",
+            "p95_duration",
+            "histogram_quantile(0.95, sum by (le) (rate(judge_submit_duration_seconds_bucket{application=\"{application}\"}[5m])))"
+    );
+
+    public static final List<DatasetMetricQuery> ALL = Arrays.asList(values());
+
+    private final String domain;
+    private final String metricName;
+    private final String promql;
+
+    DatasetMetricQuery(String domain, String metricName, String promql) {
+        this.domain = domain;
+        this.metricName = metricName;
+        this.promql = promql;
+    }
+
+    public String getDomain() { return domain; }
+    public String getMetricName() { return metricName; }
+    public String getPromql() { return promql; }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/ExportFailedException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/ExportFailedException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.exception;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+public class ExportFailedException extends GlobalException {
+    public ExportFailedException() {
+        super(ErrorCode.EXPORT_FAILED);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/ExportInvalidFilterException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/ExportInvalidFilterException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.exception;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+public class ExportInvalidFilterException extends GlobalException {
+    public ExportInvalidFilterException() {
+        super(ErrorCode.EXPORT_INVALID_FILTER);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/ExportInvalidPeriodException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/ExportInvalidPeriodException.java
@@ -1,0 +1,11 @@
+
+package team.startup.gwangjutalentfestival.domain.monitoring.exception;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+public class ExportInvalidPeriodException extends GlobalException {
+    public ExportInvalidPeriodException() {
+        super(ErrorCode.EXPORT_INVALID_PERIOD);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/ExportPeriodExceededException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/exception/ExportPeriodExceededException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.exception;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+public class ExportPeriodExceededException extends GlobalException {
+    public ExportPeriodExceededException() {
+        super(ErrorCode.EXPORT_PERIOD_EXCEEDED);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/controller/MonitoringController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/controller/MonitoringController.java
@@ -18,10 +18,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
 import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.CreateIncidentFeedbackRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.ExportDatasetRequest;
 import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventDetailResponse;
 import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventListResponse;
 import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.AnomalyEventSummaryResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.ExportDatasetResponse;
 import team.startup.gwangjutalentfestival.domain.monitoring.service.CreateIncidentFeedbackService;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.ExportDatasetService;
 import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventDetailService;
 import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventListService;
 import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventSummaryService;
@@ -36,6 +39,7 @@ public class MonitoringController {
     private final GetAnomalyEventDetailService getAnomalyEventDetailService;
     private final CreateIncidentFeedbackService createIncidentFeedbackService;
     private final GetAnomalyEventSummaryService getAnomalyEventSummaryService;
+    private final ExportDatasetService exportDatasetService;
 
     @Operation(summary = "이상 탐지 이벤트 목록 조회", description = "최신순으로 정렬된 이상 탐지 이벤트 목록을 페이지 단위로 조회합니다.")
     @ApiResponses({
@@ -86,5 +90,18 @@ public class MonitoringController {
     ) {
         createIncidentFeedbackService.execute(id, request);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "학습 데이터셋 export", description = "Prometheus 시계열과 incident feedback를 결합해 ML 학습용 CSV 데이터셋을 생성합니다. 최대 7일 기간 지원.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "export 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 기간 또는 필터")
+    })
+    @SecurityRequirement(name = "Authorization")
+    @PostMapping("/datasets/export")
+    public ResponseEntity<ExportDatasetResponse> exportDataset(
+            @Valid @RequestBody ExportDatasetRequest request
+    ) {
+        return ResponseEntity.ok(exportDatasetService.execute(request));
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/request/ExportDatasetRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/request/ExportDatasetRequest.java
@@ -1,0 +1,15 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record ExportDatasetRequest(
+        @NotNull LocalDateTime start,
+        @NotNull LocalDateTime end,
+        @Min(60) @Max(3600) Integer stepSeconds,
+        String domain,
+        String metricName
+) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/ExportDatasetResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/presentation/data/response/ExportDatasetResponse.java
@@ -1,0 +1,3 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response;
+
+public record ExportDatasetResponse(String filePath, long rowCount) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/properties/DatasetProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/properties/DatasetProperties.java
@@ -1,0 +1,6 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("monitoring.dataset")
+public record DatasetProperties(String exportPath) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/AnomalyEventRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/AnomalyEventRepository.java
@@ -3,8 +3,13 @@ package team.startup.gwangjutalentfestival.domain.monitoring.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface AnomalyEventRepository extends JpaRepository<AnomalyEventEntity, Long> {
 
@@ -17,4 +22,17 @@ public interface AnomalyEventRepository extends JpaRepository<AnomalyEventEntity
     Page<AnomalyEventEntity> findAllByStatus(AnomalyEventStatus status, Pageable pageable);
 
     long countByStatus(AnomalyEventStatus status);
+
+    @Query("""
+            SELECT e FROM AnomalyEventEntity e
+            WHERE e.createdAt BETWEEN :start AND :end
+            AND (:domain IS NULL OR e.domain = :domain)
+            AND (:metricName IS NULL OR e.metricName = :metricName)
+            """)
+    List<AnomalyEventEntity> findForDataset(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("domain") String domain,
+            @Param("metricName") String metricName
+    );
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/IncidentFeedbackRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/repository/IncidentFeedbackRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.IncidentFeedbackEntity;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface IncidentFeedbackRepository extends JpaRepository<IncidentFeedbackEntity, Long> {
@@ -13,4 +15,6 @@ public interface IncidentFeedbackRepository extends JpaRepository<IncidentFeedba
     Optional<IncidentFeedbackEntity> findByAnomalyEventId(Long anomalyEventId);
 
     long countByLabel(FeedbackLabel label);
+
+    List<IncidentFeedbackEntity> findAllByAnomalyEvent_IdIn(Collection<Long> anomalyEventIds);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/ExportDatasetService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/ExportDatasetService.java
@@ -1,0 +1,8 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.ExportDatasetRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.ExportDatasetResponse;
+
+public interface ExportDatasetService {
+    ExportDatasetResponse execute(ExportDatasetRequest request);
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/ExportDatasetServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/ExportDatasetServiceImpl.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -71,7 +72,8 @@ public class ExportDatasetServiceImpl implements ExportDatasetService {
         }
 
         Path exportDir = prepareExportDir();
-        String fileName = "dataset_" + LocalDateTime.now(ZONE).format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".csv";
+        String uniqueId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String fileName = "dataset_" + LocalDateTime.now(ZONE).format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + "_" + uniqueId + ".csv";
         Path filePath = exportDir.resolve(fileName).normalize();
         if (!filePath.startsWith(exportDir)) {
             throw new ExportFailedException();
@@ -130,6 +132,11 @@ public class ExportDatasetServiceImpl implements ExportDatasetService {
             }
         } catch (IOException e) {
             log.error("CSV 파일 작성 실패. path={}", filePath, e);
+            try {
+                Files.deleteIfExists(filePath);
+            } catch (IOException deleteEx) {
+                log.error("불완전한 CSV 파일 삭제 실패. path={}", filePath, deleteEx);
+            }
             throw new ExportFailedException();
         }
 
@@ -189,7 +196,11 @@ public class ExportDatasetServiceImpl implements ExportDatasetService {
         Map<Long, IncidentFeedbackEntity> feedbackMap = incidentFeedbackRepository
                 .findAllByAnomalyEvent_IdIn(eventIds)
                 .stream()
-                .collect(Collectors.toMap(f -> f.getAnomalyEvent().getId(), f -> f));
+                .collect(Collectors.toMap(
+                        f -> f.getAnomalyEvent().getId(),
+                        f -> f,
+                        (existing, replacement) -> existing
+                ));
 
         long startEpoch = start.toEpochSecond(ZONE_OFFSET);
         for (AnomalyEventEntity event : events) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/ExportDatasetServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/ExportDatasetServiceImpl.java
@@ -22,8 +22,9 @@ import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEv
 import team.startup.gwangjutalentfestival.domain.monitoring.repository.IncidentFeedbackRepository;
 import team.startup.gwangjutalentfestival.domain.monitoring.service.ExportDatasetService;
 
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -88,7 +89,8 @@ public class ExportDatasetServiceImpl implements ExportDatasetService {
                 .build();
 
         long rowCount = 0;
-        try (CSVPrinter printer = new CSVPrinter(new FileWriter(filePath.toFile()), format)) {
+        try (Writer writer = Files.newBufferedWriter(filePath, StandardCharsets.UTF_8);
+             CSVPrinter printer = new CSVPrinter(writer, format)) {
             for (DatasetMetricQuery query : queries) {
                 List<PrometheusRangePoint> rawPoints = prometheusClient.queryRange(query.getPromql(), startEpoch, endEpoch, step);
                 if (rawPoints.isEmpty()) {
@@ -189,8 +191,9 @@ public class ExportDatasetServiceImpl implements ExportDatasetService {
                 .stream()
                 .collect(Collectors.toMap(f -> f.getAnomalyEvent().getId(), f -> f));
 
+        long startEpoch = start.toEpochSecond(ZONE_OFFSET);
         for (AnomalyEventEntity event : events) {
-            long floorEpoch = (event.getCreatedAt().toEpochSecond(ZONE_OFFSET) / step) * step;
+            long floorEpoch = startEpoch + ((event.getCreatedAt().toEpochSecond(ZONE_OFFSET) - startEpoch) / step) * step;
             String key = event.getDomain() + ":" + event.getMetricName() + ":" + floorEpoch;
 
             IncidentFeedbackEntity feedback = feedbackMap.get(event.getId());

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/ExportDatasetServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/ExportDatasetServiceImpl.java
@@ -1,0 +1,210 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.springframework.stereotype.Service;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusRangePoint;
+import team.startup.gwangjutalentfestival.domain.monitoring.detector.DatasetMetricQuery;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.IncidentFeedbackEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.ExportFailedException;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.ExportInvalidFilterException;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.ExportInvalidPeriodException;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.ExportPeriodExceededException;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.ExportDatasetRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.ExportDatasetResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.DatasetProperties;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.IncidentFeedbackRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.ExportDatasetService;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExportDatasetServiceImpl implements ExportDatasetService {
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final ZoneOffset ZONE_OFFSET = ZoneOffset.of("+09:00");
+    private static final int DEFAULT_STEP_SECONDS = 60;
+    private static final int MAX_EXPORT_DAYS = 7;
+    private static final Set<String> ALLOWED_DOMAINS = Set.of("seat", "judge");
+    private static final Set<String> ALLOWED_METRIC_NAMES = Set.of("failure_rate", "p95_duration");
+
+    private final PrometheusClient prometheusClient;
+    private final AnomalyEventRepository anomalyEventRepository;
+    private final IncidentFeedbackRepository incidentFeedbackRepository;
+    private final DatasetProperties datasetProperties;
+
+    @Override
+    public ExportDatasetResponse execute(ExportDatasetRequest request) {
+        int step = request.stepSeconds() != null ? request.stepSeconds() : DEFAULT_STEP_SECONDS;
+
+        validatePeriod(request.start(), request.end());
+        validateFilter(request.domain(), request.metricName());
+
+        List<DatasetMetricQuery> queries = resolveQueries(request.domain(), request.metricName());
+        if (queries.isEmpty()) {
+            throw new ExportInvalidFilterException();
+        }
+
+        Path exportDir = prepareExportDir();
+        String fileName = "dataset_" + LocalDateTime.now(ZONE).format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".csv";
+        Path filePath = exportDir.resolve(fileName).normalize();
+        if (!filePath.startsWith(exportDir)) {
+            throw new ExportFailedException();
+        }
+
+        Map<String, String> labelMap = new HashMap<>();
+        Set<String> excludeSet = new HashSet<>();
+        buildLabelMapping(request.start(), request.end(), request.domain(), request.metricName(), step, labelMap, excludeSet);
+
+        long startEpoch = request.start().toEpochSecond(ZONE_OFFSET);
+        long endEpoch = request.end().toEpochSecond(ZONE_OFFSET);
+
+        CSVFormat format = CSVFormat.DEFAULT.builder()
+                .setHeader("domain", "metricName", "timestamp", "value", "hourOfDay", "dayOfWeek", "label")
+                .build();
+
+        long rowCount = 0;
+        try (CSVPrinter printer = new CSVPrinter(new FileWriter(filePath.toFile()), format)) {
+            for (DatasetMetricQuery query : queries) {
+                List<PrometheusRangePoint> rawPoints = prometheusClient.queryRange(query.getPromql(), startEpoch, endEpoch, step);
+                if (rawPoints.isEmpty()) {
+                    log.warn("Prometheus queryRange 결과 없음. domain={}, metricName={}", query.getDomain(), query.getMetricName());
+                    continue;
+                }
+
+                // 동일 timestamp 중복 시 첫 번째 정상 값 사용 (여러 series가 반환될 경우 대비)
+                LinkedHashMap<Long, Double> deduped = new LinkedHashMap<>();
+                for (PrometheusRangePoint point : rawPoints) {
+                    deduped.putIfAbsent(point.timestamp(), point.value());
+                }
+
+                for (Map.Entry<Long, Double> entry : deduped.entrySet()) {
+                    long ts = entry.getKey();
+                    double value = entry.getValue();
+                    String key = query.getDomain() + ":" + query.getMetricName() + ":" + ts;
+
+                    if (excludeSet.contains(key)) {
+                        continue;
+                    }
+
+                    String label = labelMap.getOrDefault(key, "normal");
+                    LocalDateTime timestamp = LocalDateTime.ofEpochSecond(ts, 0, ZONE_OFFSET);
+
+                    printer.printRecord(
+                            query.getDomain(),
+                            query.getMetricName(),
+                            timestamp.toString(),
+                            value,
+                            timestamp.getHour(),
+                            timestamp.getDayOfWeek().name(),
+                            label
+                    );
+                    rowCount++;
+                }
+            }
+        } catch (IOException e) {
+            log.error("CSV 파일 작성 실패. path={}", filePath, e);
+            throw new ExportFailedException();
+        }
+
+        log.info("데이터셋 export 완료. path={}, rowCount={}", filePath, rowCount);
+        return new ExportDatasetResponse(filePath.toString(), rowCount);
+    }
+
+    private void validatePeriod(LocalDateTime start, LocalDateTime end) {
+        if (!end.isAfter(start)) {
+            throw new ExportInvalidPeriodException();
+        }
+        if (Duration.between(start, end).compareTo(Duration.ofDays(MAX_EXPORT_DAYS)) > 0) {
+            throw new ExportPeriodExceededException();
+        }
+    }
+
+    private void validateFilter(String domain, String metricName) {
+        if (domain != null && !ALLOWED_DOMAINS.contains(domain)) {
+            throw new ExportInvalidFilterException();
+        }
+        if (metricName != null && !ALLOWED_METRIC_NAMES.contains(metricName)) {
+            throw new ExportInvalidFilterException();
+        }
+    }
+
+    private List<DatasetMetricQuery> resolveQueries(String domain, String metricName) {
+        return DatasetMetricQuery.ALL.stream()
+                .filter(q -> domain == null || q.getDomain().equals(domain))
+                .filter(q -> metricName == null || q.getMetricName().equals(metricName))
+                .collect(Collectors.toList());
+    }
+
+    private Path prepareExportDir() {
+        Path exportDir = Paths.get(datasetProperties.exportPath()).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(exportDir);
+        } catch (IOException e) {
+            log.error("export 디렉터리 생성 실패. path={}", exportDir, e);
+            throw new ExportFailedException();
+        }
+        return exportDir;
+    }
+
+    private void buildLabelMapping(
+            LocalDateTime start, LocalDateTime end,
+            String domain, String metricName,
+            int step,
+            Map<String, String> labelMap,
+            Set<String> excludeSet
+    ) {
+        List<AnomalyEventEntity> events = anomalyEventRepository.findForDataset(start, end, domain, metricName);
+        if (events.isEmpty()) {
+            return;
+        }
+
+        List<Long> eventIds = events.stream().map(AnomalyEventEntity::getId).collect(Collectors.toList());
+        Map<Long, IncidentFeedbackEntity> feedbackMap = incidentFeedbackRepository
+                .findAllByAnomalyEvent_IdIn(eventIds)
+                .stream()
+                .collect(Collectors.toMap(f -> f.getAnomalyEvent().getId(), f -> f));
+
+        for (AnomalyEventEntity event : events) {
+            long floorEpoch = (event.getCreatedAt().toEpochSecond(ZONE_OFFSET) / step) * step;
+            String key = event.getDomain() + ":" + event.getMetricName() + ":" + floorEpoch;
+
+            IncidentFeedbackEntity feedback = feedbackMap.get(event.getId());
+            if (feedback == null) {
+                // feedback 없는 OPEN 이벤트 — 학습 데이터에서 제외
+                excludeSet.add(key);
+            } else if (feedback.getLabel() == FeedbackLabel.TRUE_INCIDENT) {
+                labelMap.put(key, "anomaly");
+            } else if (feedback.getLabel() == FeedbackLabel.FALSE_POSITIVE) {
+                labelMap.put(key, "normal");
+            } else if (feedback.getLabel() == FeedbackLabel.IGNORED) {
+                // IGNORED — 학습 데이터에서 제외
+                excludeSet.add(key);
+            }
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
@@ -62,6 +62,10 @@ public enum ErrorCode {
     ANOMALY_EVENT_NOT_FOUND(404, "이상 탐지 이벤트를 찾을 수 없습니다."),
     FEEDBACK_ALREADY_EXISTS(409, "이미 피드백이 등록된 이벤트입니다."),
     ANOMALY_EVENT_NOT_OPEN(400, "이미 처리된 이상 탐지 이벤트입니다."),
+    EXPORT_INVALID_PERIOD(400, "end는 start보다 이후여야 합니다."),
+    EXPORT_PERIOD_EXCEEDED(400, "export 기간은 최대 7일입니다."),
+    EXPORT_INVALID_FILTER(400, "허용되지 않는 domain 또는 metricName입니다."),
+    EXPORT_FAILED(500, "데이터셋 export 중 오류가 발생했습니다."),
 
     // Google Sheets
     GOOGLE_SHEETS(500, "Google Sheets 연동 중 오류가 발생했습니다."),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,3 +104,5 @@ monitoring:
     enabled: ${ANOMALY_DETECTOR_ENABLED:false}
     prometheus-base-url: ${PROMETHEUS_BASE_URL:http://localhost:9090}
     discord-webhook-url: ${DISCORD_WEBHOOK_URL:}
+  dataset:
+    export-path: ${MONITORING_DATASET_EXPORT_PATH:./exports}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClientRangeQueryTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/client/PrometheusClientRangeQueryTest.java
@@ -1,0 +1,108 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class PrometheusClientRangeQueryTest {
+
+    @Mock
+    private RestClient prometheusRestClient;
+
+    private PrometheusClient prometheusClient;
+
+    @BeforeEach
+    void setUp() {
+        prometheusClient = new PrometheusClient(prometheusRestClient, "gwangjutalentfestival");
+    }
+
+    @Test
+    void 정상_range_query_응답이면_PrometheusRangePoint_목록을_반환한다() {
+        PrometheusRangeSeries series = new PrometheusRangeSeries(
+                null,
+                List.of(
+                        List.of(1748736000L, "0.023"),
+                        List.of(1748736060L, "0.045")
+                )
+        );
+        PrometheusRangeResponse response = new PrometheusRangeResponse(
+                "success",
+                new PrometheusRangeData(List.of(series))
+        );
+
+        RestClient.RequestHeadersUriSpec uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        given(prometheusRestClient.get()).willReturn(uriSpec);
+        given(uriSpec.uri(any(java.util.function.Function.class))).willReturn(headersSpec);
+        given(headersSpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.body(PrometheusRangeResponse.class)).willReturn(response);
+
+        List<PrometheusRangePoint> result = prometheusClient.queryRange(
+                "rate(seat_reservation_failure_total[5m])", 1748736000L, 1748736120L, 60
+        );
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).timestamp()).isEqualTo(1748736000L);
+        assertThat(result.get(0).value()).isEqualTo(0.023);
+        assertThat(result.get(1).timestamp()).isEqualTo(1748736060L);
+        assertThat(result.get(1).value()).isEqualTo(0.045);
+    }
+
+    @Test
+    void NaN_값이_포함된_경우_해당_포인트를_skip한다() {
+        PrometheusRangeSeries series = new PrometheusRangeSeries(
+                null,
+                List.of(
+                        List.of(1748736000L, "NaN"),
+                        List.of(1748736060L, "0.012")
+                )
+        );
+        PrometheusRangeResponse response = new PrometheusRangeResponse(
+                "success",
+                new PrometheusRangeData(List.of(series))
+        );
+
+        RestClient.RequestHeadersUriSpec uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec headersSpec = mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+        given(prometheusRestClient.get()).willReturn(uriSpec);
+        given(uriSpec.uri(any(java.util.function.Function.class))).willReturn(headersSpec);
+        given(headersSpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.body(PrometheusRangeResponse.class)).willReturn(response);
+
+        List<PrometheusRangePoint> result = prometheusClient.queryRange(
+                "rate(seat_reservation_failure_total[5m])", 1748736000L, 1748736120L, 60
+        );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).timestamp()).isEqualTo(1748736060L);
+    }
+
+    @Test
+    void Prometheus_호출_실패_시_빈_리스트를_반환한다() {
+        RestClient.RequestHeadersUriSpec uriSpec = mock(RestClient.RequestHeadersUriSpec.class);
+
+        given(prometheusRestClient.get()).willReturn(uriSpec);
+        given(uriSpec.uri(any(java.util.function.Function.class))).willThrow(new RuntimeException("connection refused"));
+
+        List<PrometheusRangePoint> result = prometheusClient.queryRange(
+                "rate(seat_reservation_failure_total[5m])", 1748736000L, 1748736120L, 60
+        );
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/ExportDatasetServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/ExportDatasetServiceTest.java
@@ -1,0 +1,246 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusRangePoint;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.FeedbackLabel;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.IncidentFeedbackEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.ExportInvalidFilterException;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.ExportInvalidPeriodException;
+import team.startup.gwangjutalentfestival.domain.monitoring.exception.ExportPeriodExceededException;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.request.ExportDatasetRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.data.response.ExportDatasetResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.DatasetProperties;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.IncidentFeedbackRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.impl.ExportDatasetServiceImpl;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class ExportDatasetServiceTest {
+
+    private static final ZoneOffset ZONE_OFFSET = ZoneOffset.of("+09:00");
+    private static final LocalDateTime START = LocalDateTime.of(2026, 6, 1, 0, 0, 0);
+    private static final LocalDateTime END = LocalDateTime.of(2026, 6, 1, 1, 0, 0);
+    // prometheus 포인트 timestamp: START epoch (step=60 정렬)
+    private static final long POINT_TS = (START.toEpochSecond(ZONE_OFFSET) / 60) * 60;
+    // createdAt: POINT_TS + 30초 내에 위치 → floorEpoch == POINT_TS
+    private static final LocalDateTime EVENT_CREATED_AT = LocalDateTime.ofEpochSecond(POINT_TS + 30, 0, ZONE_OFFSET);
+
+    @Mock
+    private PrometheusClient prometheusClient;
+    @Mock
+    private AnomalyEventRepository anomalyEventRepository;
+    @Mock
+    private IncidentFeedbackRepository incidentFeedbackRepository;
+    @Mock
+    private DatasetProperties datasetProperties;
+
+    @InjectMocks
+    private ExportDatasetServiceImpl exportDatasetService;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(datasetProperties.exportPath()).thenReturn(tempDir.toString());
+    }
+
+    @Test
+    void anomaly_event가_없는_구간은_normal로_CSV에_포함된다() {
+        given(anomalyEventRepository.findForDataset(any(), any(), any(), any())).willReturn(List.of());
+        given(prometheusClient.queryRange(anyString(), anyLong(), anyLong(), anyInt()))
+                .willReturn(List.of(new PrometheusRangePoint(POINT_TS, 0.012)));
+
+        ExportDatasetResponse response = exportDatasetService.execute(
+                new ExportDatasetRequest(START, END, 60, "seat", "failure_rate")
+        );
+
+        assertThat(response.rowCount()).isEqualTo(1);
+        assertThat(Files.exists(Path.of(response.filePath()))).isTrue();
+    }
+
+    @Test
+    void TRUE_INCIDENT_피드백_포인트는_anomaly_label로_CSV에_포함된다() throws Exception {
+        AnomalyEventEntity event = buildEvent(1L, "seat", "failure_rate", AnomalyEventStatus.RESOLVED,
+                EVENT_CREATED_AT);
+        IncidentFeedbackEntity feedback = buildFeedback(event, FeedbackLabel.TRUE_INCIDENT);
+
+        given(anomalyEventRepository.findForDataset(any(), any(), any(), any())).willReturn(List.of(event));
+        given(incidentFeedbackRepository.findAllByAnomalyEvent_IdIn(any())).willReturn(List.of(feedback));
+        given(prometheusClient.queryRange(anyString(), anyLong(), anyLong(), anyInt()))
+                .willReturn(List.of(new PrometheusRangePoint(POINT_TS, 0.087)));
+
+        ExportDatasetResponse response = exportDatasetService.execute(
+                new ExportDatasetRequest(START, END, 60, "seat", "failure_rate")
+        );
+
+        assertThat(response.rowCount()).isEqualTo(1);
+        String content = Files.readString(Path.of(response.filePath()));
+        assertThat(content).contains("anomaly");
+    }
+
+    @Test
+    void FALSE_POSITIVE_피드백_포인트는_normal_label로_CSV에_포함된다() throws Exception {
+        AnomalyEventEntity event = buildEvent(1L, "seat", "failure_rate", AnomalyEventStatus.RESOLVED,
+                EVENT_CREATED_AT);
+        IncidentFeedbackEntity feedback = buildFeedback(event, FeedbackLabel.FALSE_POSITIVE);
+
+        given(anomalyEventRepository.findForDataset(any(), any(), any(), any())).willReturn(List.of(event));
+        given(incidentFeedbackRepository.findAllByAnomalyEvent_IdIn(any())).willReturn(List.of(feedback));
+        given(prometheusClient.queryRange(anyString(), anyLong(), anyLong(), anyInt()))
+                .willReturn(List.of(new PrometheusRangePoint(POINT_TS, 0.087)));
+
+        ExportDatasetResponse response = exportDatasetService.execute(
+                new ExportDatasetRequest(START, END, 60, "seat", "failure_rate")
+        );
+
+        assertThat(response.rowCount()).isEqualTo(1);
+        String content = Files.readString(Path.of(response.filePath()));
+        assertThat(content).doesNotContain("anomaly");
+        assertThat(content).contains("normal");
+    }
+
+    @Test
+    void IGNORED_피드백_포인트는_CSV에_포함되지_않는다() {
+        AnomalyEventEntity event = buildEvent(1L, "seat", "failure_rate", AnomalyEventStatus.IGNORED,
+                EVENT_CREATED_AT);
+        IncidentFeedbackEntity feedback = buildFeedback(event, FeedbackLabel.IGNORED);
+
+        given(anomalyEventRepository.findForDataset(any(), any(), any(), any())).willReturn(List.of(event));
+        given(incidentFeedbackRepository.findAllByAnomalyEvent_IdIn(any())).willReturn(List.of(feedback));
+        given(prometheusClient.queryRange(anyString(), anyLong(), anyLong(), anyInt()))
+                .willReturn(List.of(new PrometheusRangePoint(POINT_TS, 0.087)));
+
+        ExportDatasetResponse response = exportDatasetService.execute(
+                new ExportDatasetRequest(START, END, 60, "seat", "failure_rate")
+        );
+
+        assertThat(response.rowCount()).isEqualTo(0);
+    }
+
+    @Test
+    void feedback_없는_OPEN_이벤트_포인트는_CSV에_포함되지_않는다() {
+        AnomalyEventEntity event = buildEvent(1L, "seat", "failure_rate", AnomalyEventStatus.OPEN,
+                EVENT_CREATED_AT);
+
+        given(anomalyEventRepository.findForDataset(any(), any(), any(), any())).willReturn(List.of(event));
+        given(incidentFeedbackRepository.findAllByAnomalyEvent_IdIn(any())).willReturn(List.of());
+        given(prometheusClient.queryRange(anyString(), anyLong(), anyLong(), anyInt()))
+                .willReturn(List.of(new PrometheusRangePoint(POINT_TS, 0.087)));
+
+        ExportDatasetResponse response = exportDatasetService.execute(
+                new ExportDatasetRequest(START, END, 60, "seat", "failure_rate")
+        );
+
+        assertThat(response.rowCount()).isEqualTo(0);
+    }
+
+    @Test
+    void Prometheus_queryRange_실패_시_해당_메트릭_skip_후_나머지_정상_처리된다() {
+        given(anomalyEventRepository.findForDataset(any(), any(), any(), any())).willReturn(List.of());
+        given(prometheusClient.queryRange(anyString(), anyLong(), anyLong(), anyInt()))
+                .willReturn(List.of())
+                .willReturn(List.of(new PrometheusRangePoint(POINT_TS, 1.5)));
+
+        ExportDatasetResponse response = exportDatasetService.execute(
+                new ExportDatasetRequest(START, END, 60, "seat", null)
+        );
+
+        assertThat(response.rowCount()).isEqualTo(1);
+    }
+
+    @Test
+    void CSV_파일이_실제로_생성된다() {
+        given(anomalyEventRepository.findForDataset(any(), any(), any(), any())).willReturn(List.of());
+        given(prometheusClient.queryRange(anyString(), anyLong(), anyLong(), anyInt()))
+                .willReturn(List.of(new PrometheusRangePoint(1748736000L, 0.01)));
+
+        ExportDatasetResponse response = exportDatasetService.execute(
+                new ExportDatasetRequest(START, END, 60, "seat", "failure_rate")
+        );
+
+        assertThat(Files.exists(Path.of(response.filePath()))).isTrue();
+        assertThat(response.filePath()).endsWith(".csv");
+    }
+
+    @Test
+    void end가_start보다_이전이면_ExportInvalidPeriodException이_발생한다() {
+        assertThatThrownBy(() -> exportDatasetService.execute(
+                new ExportDatasetRequest(END, START, 60, null, null)
+        )).isInstanceOf(ExportInvalidPeriodException.class);
+    }
+
+    @Test
+    void end가_start와_같으면_ExportInvalidPeriodException이_발생한다() {
+        assertThatThrownBy(() -> exportDatasetService.execute(
+                new ExportDatasetRequest(START, START, 60, null, null)
+        )).isInstanceOf(ExportInvalidPeriodException.class);
+    }
+
+    @Test
+    void 기간이_7일_초과면_ExportPeriodExceededException이_발생한다() {
+        assertThatThrownBy(() -> exportDatasetService.execute(
+                new ExportDatasetRequest(START, START.plusDays(8), 60, null, null)
+        )).isInstanceOf(ExportPeriodExceededException.class);
+    }
+
+    @Test
+    void 허용되지_않는_domain이면_ExportInvalidFilterException이_발생한다() {
+        assertThatThrownBy(() -> exportDatasetService.execute(
+                new ExportDatasetRequest(START, END, 60, "unknown", null)
+        )).isInstanceOf(ExportInvalidFilterException.class);
+    }
+
+    @Test
+    void 허용되지_않는_metricName이면_ExportInvalidFilterException이_발생한다() {
+        assertThatThrownBy(() -> exportDatasetService.execute(
+                new ExportDatasetRequest(START, END, 60, null, "unknown_metric")
+        )).isInstanceOf(ExportInvalidFilterException.class);
+    }
+
+    private AnomalyEventEntity buildEvent(Long id, String domain, String metricName,
+                                           AnomalyEventStatus status, LocalDateTime createdAt) {
+        return AnomalyEventEntity.builder()
+                .id(id)
+                .domain(domain)
+                .metricName(metricName)
+                .status(status)
+                .detectedValue(0.087)
+                .thresholdValue(0.05)
+                .reason("테스트")
+                .createdAt(createdAt)
+                .build();
+    }
+
+    private IncidentFeedbackEntity buildFeedback(AnomalyEventEntity event, FeedbackLabel label) {
+        return IncidentFeedbackEntity.builder()
+                .id(1L)
+                .anomalyEvent(event)
+                .label(label)
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

Prometheus 시계열 데이터와 incident feedback(TRUE_INCIDENT / FALSE_POSITIVE / IGNORED)을 결합하여 ML 이상 탐지 모델 학습에 사용할 CSV 데이터셋을 생성하는 기능을 추가하였습니다.

- Prometheus `/api/v1/query_range` API를 호출하는 `PrometheusClient.queryRange` 메서드를 추가하였습니다.
- 4개 메트릭(seat.failure_rate, seat.p95_duration, judge.failure_rate, judge.p95_duration)에 대해 과거 시계열 데이터를 조회하는 `DatasetMetricQuery` enum을 정의하였습니다.
- `POST /monitoring/datasets/export` API를 추가하였습니다. 조회 기간(최대 7일), stepSeconds(60~3600초), domain/metricName 필터를 지원합니다.
- anomaly_event 상태와 incident_feedback label을 기반으로 label을 매핑하였습니다. TRUE_INCIDENT → anomaly, FALSE_POSITIVE / 이상 미탐지 구간 → normal, IGNORED / OPEN(feedback 없음) → 제외합니다.
- export 결과를 Apache Commons CSV를 사용하여 `dataset_{yyyyMMdd_HHmmss}.csv` 형태로 저장합니다.

---

## 🔍 리뷰 시 참고사항
- 리뷰어가 알면 좋은 변경 이유, 배경, 고려했던 점 등을 적어주세요.

**label 매핑 정책**
- 일반 시계열 포인트(anomaly_event 없는 구간)는 정상(normal)으로 간주합니다.
- TRUE_INCIDENT는 createdAt이 속한 step bucket 1개만 anomaly로 라벨링합니다. 이상 지속 구간 전체가 아닌 감지 시점 1포인트만 대상입니다.
- IGNORED 및 feedback 없는 OPEN 이벤트 포인트는 학습 데이터에서 제외됩니다.

**동시성 및 중복 방어**
- 동일 timestamp에 Prometheus series가 여러 개 반환될 경우 첫 번째 정상 값을 사용합니다(LinkedHashMap.putIfAbsent).
- Prometheus 호출 실패 시 해당 메트릭을 skip하고 나머지 메트릭은 정상 처리됩니다.

**보안**
- exportPath는 설정값이며, 파일명은 서버가 직접 생성한 `dataset_{timestamp}.csv`만 사용합니다. Path traversal을 `filePath.startsWith(exportDir)` 검증으로 방어하였습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #112