### PR TITLE
Spring Anomaly Detector와 ML Server 연동

### DIFF
--- a/docs/anomaly-detection.md
+++ b/docs/anomaly-detection.md
@@ -182,6 +182,65 @@ curl -H "Authorization: Bearer TOKEN" \
 }
 ```
 
+## ML Server 연동
+
+rule-based 탐지가 이상을 감지한 경우, 보조 신호로 ML Server의 anomaly score를 함께 요청합니다.
+
+### 역할 분리
+
+- Rule-based threshold 초과가 `anomaly_event` 생성 트리거입니다.
+- ML `predictedLabel`은 이벤트 생성 여부를 결정하지 않습니다.
+- ML이 `normal`을 반환하더라도 rule threshold를 초과했다면 `anomaly_event`는 저장됩니다.
+- `anomalyScore`, `predictedLabel`, `modelVersion`은 운영자 판단을 돕는 보조 정보로만 저장됩니다.
+
+### 환경 변수
+
+| 변수명 | 기본값 | 설명 |
+|--------|--------|------|
+| `ML_ANOMALY_SCORE_ENABLED` | `false` | ML Server 호출 활성화 여부 |
+| `ML_SERVER_BASE_URL` | (없음) | ML Server 주소 (예: `http://<ml-server-host>:<port>`) |
+| `ML_SERVER_TIMEOUT_MS` | `3000` | ML Server read timeout (ms) |
+
+실제 ML Server host / port는 환경 변수로만 주입하고, 코드나 문서에 직접 기재하지 않습니다.
+
+### 요청 스키마
+
+ML Server 호출 URL: `POST {ML_SERVER_BASE_URL}/anomaly-score`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `domain` | String | `SEAT` 또는 `JUDGE` (대문자) |
+| `metricName` | String | `failure_rate` 또는 `p95_duration` |
+| `value` | double | Prometheus에서 조회한 실제 관측값 |
+| `hourOfDay` | int | 탐지 시점 기준 0~23 |
+| `dayOfWeek` | int | 탐지 시점 기준 1(월)~7(일) |
+
+### Fallback 정책
+
+ML Server 호출이 실패하거나 비활성화된 경우에도 Spring 이상 탐지는 계속 동작합니다.
+
+- `enabled=false` 또는 `baseUrl`이 비어 있으면 ML 호출 자체를 건너뜁니다.
+- HTTP 오류, timeout, `modelLoaded=false`, `anomalyScore=null`, 유효하지 않은 `predictedLabel`은 모두 ML 결과 없음으로 처리합니다.
+- ML 결과가 없으면 `anomalyScore`, `modelVersion`, `predictedLabel`은 `null`로 저장됩니다.
+- ML 결과가 없어도 rule-based `anomaly_event` 저장과 Discord 알림은 정상 진행됩니다.
+
+### Discord 알림 예시
+
+ML 결과 있음:
+```
+🚫 [seat] failure_rate 이상: 7.20% >= 5.00%
+(좌석 예매 실패율이 기준치를 초과했습니다.)
+ML Score: 0.0794 (anomaly)
+Model Version: iforest-v1
+```
+
+ML 결과 없음:
+```
+🚫 [seat] failure_rate 이상: 7.20% >= 5.00%
+(좌석 예매 실패율이 기준치를 초과했습니다.)
+ML: Rule-based only
+```
+
 ## Dataset Export
 
 anomaly_event + incident_feedback 데이터를 Prometheus 시계열과 결합하여 ML 학습용 CSV 데이터셋을 생성합니다.

--- a/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
@@ -7,6 +7,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import team.startup.gwangjutalentfestival.domain.monitoring.properties.DatasetProperties;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.MlProperties;
 import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
 import team.startup.gwangjutalentfestival.domain.slogan.properties.SloganSubmissionProperties;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProperties;
@@ -21,7 +22,7 @@ import team.startup.gwangjutalentfestival.global.sms.properties.SolapiProperties
 @EnableFeignClients
 @EnableAsync
 @EnableScheduling
-@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class, SolapiProperties.class, SmsVerifyProperties.class, SloganSubmissionProperties.class, MonitoringProperties.class, DatasetProperties.class})
+@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class, SolapiProperties.class, SmsVerifyProperties.class, SloganSubmissionProperties.class, MonitoringProperties.class, DatasetProperties.class, MlProperties.class})
 @SpringBootApplication
 public class GwangjutalentfestivalApplication {
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/MlServerClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/MlServerClient.java
@@ -1,0 +1,76 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.MlProperties;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Slf4j
+@Component
+public class MlServerClient {
+
+    private static final Set<String> VALID_LABELS = Set.of("anomaly", "normal");
+
+    private final RestClient mlRestClient;
+    private final MlProperties mlProperties;
+
+    public MlServerClient(
+            @Qualifier("mlRestClient") RestClient mlRestClient,
+            MlProperties mlProperties
+    ) {
+        this.mlRestClient = mlRestClient;
+        this.mlProperties = mlProperties;
+    }
+
+    public Optional<MlAnomalyScoreResponse> call(MlAnomalyScoreRequest request) {
+        if (!mlProperties.enabled() || mlProperties.baseUrl().isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            MlAnomalyScoreResponse response = mlRestClient.post()
+                    .uri(normalizeBaseUrl(mlProperties.baseUrl()) + "/anomaly-score")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .body(MlAnomalyScoreResponse.class);
+
+            return validate(response);
+        } catch (Exception e) {
+            log.warn("ML Server 호출 실패 — rule-based 탐지는 계속 진행. error={}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<MlAnomalyScoreResponse> validate(MlAnomalyScoreResponse response) {
+        if (response == null) {
+            return Optional.empty();
+        }
+        if (!response.modelLoaded()) {
+            return Optional.empty();
+        }
+        if (response.anomalyScore() == null) {
+            return Optional.empty();
+        }
+        if (!VALID_LABELS.contains(response.predictedLabel())) {
+            log.warn("ML Server 응답의 predictedLabel이 유효하지 않음. predictedLabel={}", response.predictedLabel());
+            return Optional.empty();
+        }
+        if (response.modelVersion() == null) {
+            log.warn("ML Server 응답의 modelVersion이 null입니다.");
+        }
+        return Optional.of(response);
+    }
+
+    private String normalizeBaseUrl(String baseUrl) {
+        String trimmed = baseUrl.strip();
+        return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/MlServerClient.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/MlServerClient.java
@@ -59,7 +59,7 @@ public class MlServerClient {
         if (response.anomalyScore() == null) {
             return Optional.empty();
         }
-        if (!VALID_LABELS.contains(response.predictedLabel())) {
+        if (response.predictedLabel() == null || !VALID_LABELS.contains(response.predictedLabel())) {
             log.warn("ML Server 응답의 predictedLabel이 유효하지 않음. predictedLabel={}", response.predictedLabel());
             return Optional.empty();
         }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/dto/MlAnomalyScoreRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/dto/MlAnomalyScoreRequest.java
@@ -1,0 +1,9 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client.dto;
+
+public record MlAnomalyScoreRequest(
+        String domain,
+        String metricName,
+        double value,
+        int hourOfDay,
+        int dayOfWeek
+) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/dto/MlAnomalyScoreResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/client/dto/MlAnomalyScoreResponse.java
@@ -1,0 +1,8 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client.dto;
+
+public record MlAnomalyScoreResponse(
+        Double anomalyScore,
+        String predictedLabel,
+        String modelVersion,
+        boolean modelLoaded
+) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetector.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetector.java
@@ -2,10 +2,15 @@ package team.startup.gwangjutalentfestival.domain.monitoring.detector;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import team.startup.gwangjutalentfestival.domain.monitoring.client.DiscordWebhookClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.MlServerClient;
 import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreRequest;
 
+import java.time.LocalDateTime;
+import java.util.Locale;
 import java.util.Optional;
 
 @Slf4j
@@ -16,6 +21,7 @@ public class AnomalyDetector {
     private final PrometheusClient prometheusClient;
     private final DiscordWebhookClient discordWebhookClient;
     private final AnomalyEventAppender anomalyEventAppender;
+    private final MlServerClient mlServerClient;
 
     public void detectAll() {
         for (AnomalyRule rule : AnomalyRule.ALL) {
@@ -27,38 +33,84 @@ public class AnomalyDetector {
 
             double value = result.get();
             if (value >= rule.threshold()) {
+                MlScoreResult mlScoreResult = callMlServer(rule, value);
+
                 boolean saved;
                 try {
-                    saved = anomalyEventAppender.appendIfNotDuplicate(rule, value);
+                    saved = anomalyEventAppender.appendIfNotDuplicate(rule, value, mlScoreResult);
                 } catch (Exception e) {
                     log.warn("이상 이벤트 저장 실패. domain={}, metric={}, error={}", rule.domain(), rule.metricName(), e.getMessage());
                     continue;
                 }
 
                 if (saved) {
-                    String message = buildMessage(rule, value);
+                    String message = buildMessage(rule, value, mlScoreResult);
                     discordWebhookClient.send(message);
                 }
             }
         }
     }
 
-    private String buildMessage(AnomalyRule rule, double value) {
+    @Nullable
+    private MlScoreResult callMlServer(AnomalyRule rule, double value) {
+        Optional<String> mlMetricName = toMlMetricName(rule.metricName());
+        if (mlMetricName.isEmpty()) {
+            return null;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        MlAnomalyScoreRequest mlRequest = new MlAnomalyScoreRequest(
+                rule.domain().toUpperCase(Locale.ROOT),
+                mlMetricName.get(),
+                value,
+                now.getHour(),
+                now.getDayOfWeek().getValue()
+        );
+
+        return mlServerClient.call(mlRequest)
+                .map(r -> new MlScoreResult(r.anomalyScore(), r.modelVersion(), r.predictedLabel()))
+                .orElse(null);
+    }
+
+    private Optional<String> toMlMetricName(String metricName) {
+        return switch (metricName) {
+            case "failure_rate", "p95_duration" -> Optional.of(metricName);
+            default -> {
+                log.warn("알 수 없는 metricName, ML 호출 skip. metricName={}", metricName);
+                yield Optional.empty();
+            }
+        };
+    }
+
+    private String buildMessage(AnomalyRule rule, double value, @Nullable MlScoreResult mlResult) {
+        String base;
         if ("failure_rate".equals(rule.metricName())) {
-            return "🚫 [%s] %s 이상: %.2f%% >= %.2f%%\n(%s)".formatted(
+            base = "🚫 [%s] %s 이상: %.2f%% >= %.2f%%\n(%s)".formatted(
                     rule.domain(),
                     rule.metricName(),
                     value * 100,
                     rule.threshold() * 100,
                     rule.reason()
             );
+        } else {
+            base = "🚫 [%s] %s 이상: %.2fs >= %.2fs\n(%s)".formatted(
+                    rule.domain(),
+                    rule.metricName(),
+                    value,
+                    rule.threshold(),
+                    rule.reason()
+            );
         }
-        return "🚫 [%s] %s 이상: %.2fs >= %.2fs\n(%s)".formatted(
-                rule.domain(),
-                rule.metricName(),
-                value,
-                rule.threshold(),
-                rule.reason()
-        );
+
+        if (mlResult == null) {
+            return base + "\nML: Rule-based only";
+        }
+
+        StringBuilder ml = new StringBuilder();
+        ml.append("\nML Score: %.4f (%s)".formatted(mlResult.anomalyScore(), mlResult.predictedLabel()));
+        if (mlResult.modelVersion() != null) {
+            ml.append("\nModel Version: %s".formatted(mlResult.modelVersion()));
+        }
+        return base + ml;
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetector.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetector.java
@@ -10,6 +10,7 @@ import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusCli
 import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreRequest;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -17,6 +18,8 @@ import java.util.Optional;
 @Component
 @RequiredArgsConstructor
 public class AnomalyDetector {
+
+    private static final ZoneId ZONE_SEOUL = ZoneId.of("Asia/Seoul");
 
     private final PrometheusClient prometheusClient;
     private final DiscordWebhookClient discordWebhookClient;
@@ -33,6 +36,10 @@ public class AnomalyDetector {
 
             double value = result.get();
             if (value >= rule.threshold()) {
+                if (anomalyEventAppender.hasOpenEvent(rule)) {
+                    continue;
+                }
+
                 MlScoreResult mlScoreResult = callMlServer(rule, value);
 
                 boolean saved;
@@ -58,7 +65,7 @@ public class AnomalyDetector {
             return null;
         }
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(ZONE_SEOUL);
         MlAnomalyScoreRequest mlRequest = new MlAnomalyScoreRequest(
                 rule.domain().toUpperCase(Locale.ROOT),
                 mlMetricName.get(),

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppender.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppender.java
@@ -14,6 +14,11 @@ public class AnomalyEventAppender {
 
     private final AnomalyEventRepository anomalyEventRepository;
 
+    public boolean hasOpenEvent(AnomalyRule rule) {
+        return anomalyEventRepository.existsByDomainAndMetricNameAndStatus(
+                rule.domain(), rule.metricName(), AnomalyEventStatus.OPEN);
+    }
+
     @Transactional
     public boolean appendIfNotDuplicate(AnomalyRule rule, double detectedValue, @Nullable MlScoreResult mlResult) {
         if (anomalyEventRepository.existsByDomainAndMetricNameAndStatus(

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppender.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppender.java
@@ -1,6 +1,7 @@
 package team.startup.gwangjutalentfestival.domain.monitoring.detector;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
@@ -14,7 +15,7 @@ public class AnomalyEventAppender {
     private final AnomalyEventRepository anomalyEventRepository;
 
     @Transactional
-    public boolean appendIfNotDuplicate(AnomalyRule rule, double detectedValue) {
+    public boolean appendIfNotDuplicate(AnomalyRule rule, double detectedValue, @Nullable MlScoreResult mlResult) {
         if (anomalyEventRepository.existsByDomainAndMetricNameAndStatus(
                 rule.domain(), rule.metricName(), AnomalyEventStatus.OPEN)) {
             return false;
@@ -28,6 +29,9 @@ public class AnomalyEventAppender {
                         .detectedValue(detectedValue)
                         .thresholdValue(rule.threshold())
                         .reason(rule.reason())
+                        .anomalyScore(mlResult != null ? mlResult.anomalyScore() : null)
+                        .modelVersion(mlResult != null ? mlResult.modelVersion() : null)
+                        .predictedLabel(mlResult != null ? mlResult.predictedLabel() : null)
                         .build()
         );
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/MlScoreResult.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/MlScoreResult.java
@@ -1,0 +1,3 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.detector;
+
+public record MlScoreResult(Double anomalyScore, String modelVersion, String predictedLabel) {}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/entity/AnomalyEventEntity.java
@@ -55,6 +55,15 @@ public class AnomalyEventEntity {
     @Column(name = "resolved_at", nullable = true)
     private LocalDateTime resolvedAt;
 
+    @Column(name = "anomaly_score")
+    private Double anomalyScore;
+
+    @Column(name = "model_version", length = 50)
+    private String modelVersion;
+
+    @Column(name = "predicted_label", length = 20)
+    private String predictedLabel;
+
     public void resolve(LocalDateTime resolvedAt) {
         this.status = AnomalyEventStatus.RESOLVED;
         this.resolvedAt = resolvedAt;

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/properties/MlProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/properties/MlProperties.java
@@ -1,0 +1,18 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "monitoring.ml")
+public record MlProperties(boolean enabled, String baseUrl, long timeoutMs) {
+
+    private static final long DEFAULT_TIMEOUT_MS = 3000L;
+
+    public MlProperties {
+        if (baseUrl == null) {
+            baseUrl = "";
+        }
+        if (timeoutMs <= 0) {
+            timeoutMs = DEFAULT_TIMEOUT_MS;
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/MonitoringClientConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/MonitoringClientConfig.java
@@ -4,7 +4,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.MlProperties;
 import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
+
+import java.time.Duration;
 
 @Configuration
 public class MonitoringClientConfig {
@@ -25,6 +28,16 @@ public class MonitoringClientConfig {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(3000);
         factory.setReadTimeout(5000);
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+
+    @Bean
+    public RestClient mlRestClient(MlProperties mlProperties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofMillis(1000));
+        factory.setReadTimeout(Duration.ofMillis(mlProperties.timeoutMs()));
         return RestClient.builder()
                 .requestFactory(factory)
                 .build();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,5 +104,9 @@ monitoring:
     enabled: ${ANOMALY_DETECTOR_ENABLED:false}
     prometheus-base-url: ${PROMETHEUS_BASE_URL:http://localhost:9090}
     discord-webhook-url: ${DISCORD_WEBHOOK_URL:}
+  ml:
+    enabled: ${ML_ANOMALY_SCORE_ENABLED:false}
+    base-url: ${ML_SERVER_BASE_URL:}
+    timeout-ms: ${ML_SERVER_TIMEOUT_MS:3000}
   dataset:
     export-path: ${MONITORING_DATASET_EXPORT_PATH:./exports}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/client/MlServerClientTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/client/MlServerClientTest.java
@@ -1,0 +1,146 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.MlProperties;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MlServerClientTest {
+
+    @Mock
+    private RestClient mlRestClient;
+
+    private MlAnomalyScoreRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = new MlAnomalyScoreRequest("SEAT", "failure_rate", 0.08, 10, 3);
+    }
+
+    @Test
+    void enabled가_false이면_HTTP_호출_없이_Optional_empty_반환() {
+        MlServerClient client = new MlServerClient(mlRestClient, new MlProperties(false, "http://localhost:8000", 3000));
+
+        Optional<MlAnomalyScoreResponse> result = client.call(request);
+
+        assertThat(result).isEmpty();
+        verify(mlRestClient, never()).post();
+    }
+
+    @Test
+    void baseUrl이_blank이면_HTTP_호출_없이_Optional_empty_반환() {
+        MlServerClient client = new MlServerClient(mlRestClient, new MlProperties(true, "", 3000));
+
+        Optional<MlAnomalyScoreResponse> result = client.call(request);
+
+        assertThat(result).isEmpty();
+        verify(mlRestClient, never()).post();
+    }
+
+    @Test
+    void modelLoaded가_false이면_Optional_empty_반환() {
+        MlAnomalyScoreResponse response = new MlAnomalyScoreResponse(0.08, "anomaly", "v1", false);
+        RestClient deepMock = stubChain("http://localhost:8000", response);
+        MlServerClient client = new MlServerClient(deepMock, new MlProperties(true, "http://localhost:8000", 3000));
+
+        assertThat(client.call(request)).isEmpty();
+    }
+
+    @Test
+    void anomalyScore가_null이면_Optional_empty_반환() {
+        MlAnomalyScoreResponse response = new MlAnomalyScoreResponse(null, "anomaly", "v1", true);
+        RestClient deepMock = stubChain("http://localhost:8000", response);
+        MlServerClient client = new MlServerClient(deepMock, new MlProperties(true, "http://localhost:8000", 3000));
+
+        assertThat(client.call(request)).isEmpty();
+    }
+
+    @Test
+    void predictedLabel이_유효하지_않으면_Optional_empty_반환() {
+        MlAnomalyScoreResponse response = new MlAnomalyScoreResponse(0.08, "invalid", "v1", true);
+        RestClient deepMock = stubChain("http://localhost:8000", response);
+        MlServerClient client = new MlServerClient(deepMock, new MlProperties(true, "http://localhost:8000", 3000));
+
+        assertThat(client.call(request)).isEmpty();
+    }
+
+    @Test
+    void 정상_응답이면_Optional_of_response_반환() {
+        MlAnomalyScoreResponse response = new MlAnomalyScoreResponse(0.0794, "anomaly", "iforest-v1", true);
+        RestClient deepMock = stubChain("http://localhost:8000", response);
+        MlServerClient client = new MlServerClient(deepMock, new MlProperties(true, "http://localhost:8000", 3000));
+
+        Optional<MlAnomalyScoreResponse> result = client.call(request);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().anomalyScore()).isEqualTo(0.0794);
+        assertThat(result.get().predictedLabel()).isEqualTo("anomaly");
+        assertThat(result.get().modelVersion()).isEqualTo("iforest-v1");
+    }
+
+    @Test
+    void HTTP_예외_발생시_Optional_empty_반환() {
+        RestClient deepMock = mock(RestClient.class, RETURNS_DEEP_STUBS);
+        given(deepMock.post()
+                .uri("http://localhost:8000/anomaly-score")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(MlAnomalyScoreResponse.class))
+                .willThrow(new RuntimeException("connection refused"));
+        MlServerClient client = new MlServerClient(deepMock, new MlProperties(true, "http://localhost:8000", 3000));
+
+        assertThat(client.call(request)).isEmpty();
+    }
+
+    @Test
+    void baseUrl에_trailing_slash가_있어도_double_slash_없이_정상_호출됨() {
+        MlAnomalyScoreResponse response = new MlAnomalyScoreResponse(0.05, "normal", "v1", true);
+        RestClient deepMock = stubChain("http://localhost:8000", response);
+        MlServerClient client = new MlServerClient(deepMock, new MlProperties(true, "http://localhost:8000/", 3000));
+
+        Optional<MlAnomalyScoreResponse> result = client.call(request);
+
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    void timeoutMs가_0이하이면_3000으로_보정됨() {
+        MlProperties props = new MlProperties(true, "http://localhost:8000", 0);
+        assertThat(props.timeoutMs()).isEqualTo(3000L);
+    }
+
+    @Test
+    void timeoutMs가_음수이면_3000으로_보정됨() {
+        MlProperties props = new MlProperties(true, "http://localhost:8000", -1);
+        assertThat(props.timeoutMs()).isEqualTo(3000L);
+    }
+
+    private RestClient stubChain(String baseUrl, MlAnomalyScoreResponse response) {
+        RestClient deepMock = mock(RestClient.class, RETURNS_DEEP_STUBS);
+        given(deepMock.post()
+                .uri(baseUrl + "/anomaly-score")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(MlAnomalyScoreResponse.class))
+                .willReturn(response);
+        return deepMock;
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetectorTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetectorTest.java
@@ -1,0 +1,114 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.detector;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.DiscordWebhookClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.MlServerClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreResponse;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AnomalyDetectorTest {
+
+    @Mock
+    private PrometheusClient prometheusClient;
+
+    @Mock
+    private DiscordWebhookClient discordWebhookClient;
+
+    @Mock
+    private AnomalyEventAppender anomalyEventAppender;
+
+    @Mock
+    private MlServerClient mlServerClient;
+
+    @InjectMocks
+    private AnomalyDetector anomalyDetector;
+
+    private final AnomalyRule seatFailureRule = AnomalyRule.ALL.stream()
+            .filter(r -> "seat".equals(r.domain()) && "failure_rate".equals(r.metricName()))
+            .findFirst()
+            .orElseThrow();
+
+    @Test
+    void ML_응답_성공시_MlScoreResult가_Appender에_전달됨() {
+        double detectedValue = 0.08;
+        MlAnomalyScoreResponse mlResponse = new MlAnomalyScoreResponse(0.0794, "anomaly", "iforest-v1", true);
+
+        given(prometheusClient.query(seatFailureRule.promql())).willReturn(Optional.of(detectedValue));
+        given(mlServerClient.call(any(MlAnomalyScoreRequest.class))).willReturn(Optional.of(mlResponse));
+        given(anomalyEventAppender.appendIfNotDuplicate(eq(seatFailureRule), eq(detectedValue), any(MlScoreResult.class))).willReturn(true);
+
+        anomalyDetector.detectAll();
+
+        ArgumentCaptor<MlScoreResult> mlCaptor = ArgumentCaptor.forClass(MlScoreResult.class);
+        verify(anomalyEventAppender).appendIfNotDuplicate(eq(seatFailureRule), eq(detectedValue), mlCaptor.capture());
+
+        MlScoreResult captured = mlCaptor.getValue();
+        assertThat(captured).isNotNull();
+        assertThat(captured.anomalyScore()).isEqualTo(0.0794);
+        assertThat(captured.modelVersion()).isEqualTo("iforest-v1");
+        assertThat(captured.predictedLabel()).isEqualTo("anomaly");
+    }
+
+    @Test
+    void ML_Optional_empty여도_rule_based_이벤트_저장과_Discord_알림_유지() {
+        double detectedValue = 0.08;
+
+        given(prometheusClient.query(seatFailureRule.promql())).willReturn(Optional.of(detectedValue));
+        given(mlServerClient.call(any(MlAnomalyScoreRequest.class))).willReturn(Optional.empty());
+        given(anomalyEventAppender.appendIfNotDuplicate(eq(seatFailureRule), eq(detectedValue), eq(null))).willReturn(true);
+
+        anomalyDetector.detectAll();
+
+        verify(anomalyEventAppender).appendIfNotDuplicate(eq(seatFailureRule), eq(detectedValue), eq(null));
+        verify(discordWebhookClient).send(any(String.class));
+    }
+
+    @Test
+    void Discord_메시지에_ML_결과_없으면_Rule_based_only_포함됨() {
+        double detectedValue = 0.08;
+
+        given(prometheusClient.query(seatFailureRule.promql())).willReturn(Optional.of(detectedValue));
+        given(mlServerClient.call(any(MlAnomalyScoreRequest.class))).willReturn(Optional.empty());
+        given(anomalyEventAppender.appendIfNotDuplicate(any(AnomalyRule.class), anyDouble(), eq(null))).willReturn(true);
+
+        anomalyDetector.detectAll();
+
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(discordWebhookClient).send(messageCaptor.capture());
+        assertThat(messageCaptor.getValue()).contains("ML: Rule-based only");
+    }
+
+    @Test
+    void Discord_메시지에_ML_결과_있으면_score와_modelVersion_포함됨() {
+        double detectedValue = 0.08;
+        MlAnomalyScoreResponse mlResponse = new MlAnomalyScoreResponse(0.0794, "anomaly", "iforest-v1", true);
+
+        given(prometheusClient.query(seatFailureRule.promql())).willReturn(Optional.of(detectedValue));
+        given(mlServerClient.call(any(MlAnomalyScoreRequest.class))).willReturn(Optional.of(mlResponse));
+        given(anomalyEventAppender.appendIfNotDuplicate(any(AnomalyRule.class), anyDouble(), any(MlScoreResult.class))).willReturn(true);
+
+        anomalyDetector.detectAll();
+
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(discordWebhookClient).send(messageCaptor.capture());
+        String message = messageCaptor.getValue();
+        assertThat(message).contains("ML Score: 0.0794 (anomaly)");
+        assertThat(message).contains("Model Version: iforest-v1");
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppenderTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyEventAppenderTest.java
@@ -1,0 +1,75 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.detector;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AnomalyEventAppenderTest {
+
+    @Mock
+    private AnomalyEventRepository anomalyEventRepository;
+
+    @InjectMocks
+    private AnomalyEventAppender anomalyEventAppender;
+
+    private final AnomalyRule rule = AnomalyRule.ALL.stream()
+            .filter(r -> "seat".equals(r.domain()) && "failure_rate".equals(r.metricName()))
+            .findFirst()
+            .orElseThrow();
+
+    @Test
+    void ML_결과_있으면_anomalyScore_modelVersion_predictedLabel_저장() {
+        given(anomalyEventRepository.existsByDomainAndMetricNameAndStatus("seat", "failure_rate", AnomalyEventStatus.OPEN))
+                .willReturn(false);
+        MlScoreResult mlResult = new MlScoreResult(0.0794, "iforest-v1", "anomaly");
+
+        boolean saved = anomalyEventAppender.appendIfNotDuplicate(rule, 0.08, mlResult);
+
+        assertThat(saved).isTrue();
+        ArgumentCaptor<AnomalyEventEntity> entityCaptor = ArgumentCaptor.forClass(AnomalyEventEntity.class);
+        verify(anomalyEventRepository).save(entityCaptor.capture());
+
+        AnomalyEventEntity entity = entityCaptor.getValue();
+        assertThat(entity.getAnomalyScore()).isEqualTo(0.0794);
+        assertThat(entity.getModelVersion()).isEqualTo("iforest-v1");
+        assertThat(entity.getPredictedLabel()).isEqualTo("anomaly");
+    }
+
+    @Test
+    void ML_결과_없으면_세_필드_null_저장() {
+        given(anomalyEventRepository.existsByDomainAndMetricNameAndStatus("seat", "failure_rate", AnomalyEventStatus.OPEN))
+                .willReturn(false);
+
+        boolean saved = anomalyEventAppender.appendIfNotDuplicate(rule, 0.08, null);
+
+        assertThat(saved).isTrue();
+        ArgumentCaptor<AnomalyEventEntity> entityCaptor = ArgumentCaptor.forClass(AnomalyEventEntity.class);
+        verify(anomalyEventRepository).save(entityCaptor.capture());
+
+        AnomalyEventEntity entity = entityCaptor.getValue();
+        assertThat(entity.getAnomalyScore()).isNull();
+        assertThat(entity.getModelVersion()).isNull();
+        assertThat(entity.getPredictedLabel()).isNull();
+    }
+
+    @Test
+    void 동일_domain_metric_OPEN_이벤트가_있으면_저장_안_함() {
+        given(anomalyEventRepository.existsByDomainAndMetricNameAndStatus("seat", "failure_rate", AnomalyEventStatus.OPEN))
+                .willReturn(true);
+
+        boolean saved = anomalyEventAppender.appendIfNotDuplicate(rule, 0.08, null);
+
+        assertThat(saved).isFalse();
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
Spring Anomaly Detector에서 ML Server의 `/anomaly-score` API를 호출하여 이상 탐지 이벤트에 ML 점수를 함께 저장하는 기능을 추가하였습니다.

- `MlServerClient` 추가: RestClient 기반 ML Server HTTP 클라이언트
- `MlProperties` 추가: `monitoring.ml.*` 설정 프로퍼티 (`enabled`, `baseUrl`, `timeoutMs`)
- `AnomalyEventEntity`에 `anomalyScore`, `modelVersion`, `predictedLabel` 컬럼 추가
- `AnomalyDetector`: rule threshold 초과 시 ML Server 호출 후 결과를 이벤트에 반영
- Discord 알림 메시지에 ML Score 및 Model Version 포함

---

## 🔍 리뷰 시 참고사항
- Rule-based threshold 초과가 `anomaly_event` 생성 트리거이며, ML `predictedLabel`은 이벤트 생성 여부를 결정하지 않습니다. ML이 `normal`을 반환하더라도 rule threshold를 초과하였다면 이벤트는 저장됩니다.
- ML Server 호출 실패, timeout, `modelLoaded=false`, `anomalyScore=null`, 유효하지 않은 `predictedLabel`은 모두 `Optional.empty()`로 처리되어 Spring 서비스 장애로 전파되지 않습니다.
- `ML_ANOMALY_SCORE_ENABLED=false`(기본값)로 먼저 배포하면 ML 호출 없이 기존과 동일하게 동작합니다. ML Server 준비 완료 후 환경 변수를 전환하여 점진적 활성화가 가능합니다.
- 신규 환경 변수 3개: `ML_ANOMALY_SCORE_ENABLED`, `ML_SERVER_BASE_URL`, `ML_SERVER_TIMEOUT_MS`

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #116