### PR TITLE
detector 패키지 트랜잭션 레이어 컨벤션 위반 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,30 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: "1234"
+          MYSQL_DATABASE: gwangjutalentfestival
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -p1234"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -25,4 +49,16 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
+        env:
+          SPRING_DOCKER_COMPOSE_ENABLED: "false"
+          JWT_SECRET: "ci-test-secret-key-minimum-256bits-long-enough-for-hmac-sha256-algorithm"
+          COOL_SMS_KEY: "test"
+          COOL_SMS_SECRET: "test"
+          COOL_SMS_PHONENUMBER: "01000000000"
+          GOOGLE_ACCOUNT_CREDENTIAL: "{}"
+          GOOGLE_SHEET_ID: "test"
+          GOOGLE_ENROLLED_SHEET_PAGE: "0"
+          GOOGLE_OUT_OF_SCHOOL_SHEET_PAGE: "0"
+          GOOGLE_EXCEL_TEMPLATE_SHEET_ID: "test"
+          GOOGLE_EXCEL_SUMMARY_PAGE: "0"
         run: ./gradlew clean build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetector.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetector.java
@@ -8,6 +8,9 @@ import team.startup.gwangjutalentfestival.domain.monitoring.client.DiscordWebhoo
 import team.startup.gwangjutalentfestival.domain.monitoring.client.MlServerClient;
 import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusClient;
 import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreRequest;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.AppendAnomalyEventService;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -23,7 +26,8 @@ public class AnomalyDetector {
 
     private final PrometheusClient prometheusClient;
     private final DiscordWebhookClient discordWebhookClient;
-    private final AnomalyEventAppender anomalyEventAppender;
+    private final AppendAnomalyEventService appendAnomalyEventService;
+    private final AnomalyEventRepository anomalyEventRepository;
     private final MlServerClient mlServerClient;
 
     public void detectAll() {
@@ -36,7 +40,8 @@ public class AnomalyDetector {
 
             double value = result.get();
             if (value >= rule.threshold()) {
-                if (anomalyEventAppender.hasOpenEvent(rule)) {
+                if (anomalyEventRepository.existsByDomainAndMetricNameAndStatus(
+                        rule.domain(), rule.metricName(), AnomalyEventStatus.OPEN)) {
                     continue;
                 }
 
@@ -44,7 +49,7 @@ public class AnomalyDetector {
 
                 boolean saved;
                 try {
-                    saved = anomalyEventAppender.appendIfNotDuplicate(rule, value, mlScoreResult);
+                    saved = appendAnomalyEventService.execute(rule, value, mlScoreResult);
                 } catch (Exception e) {
                     log.warn("이상 이벤트 저장 실패. domain={}, metric={}, error={}", rule.domain(), rule.metricName(), e.getMessage());
                     continue;

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/AppendAnomalyEventService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/AppendAnomalyEventService.java
@@ -1,0 +1,9 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.service;
+
+import org.springframework.lang.Nullable;
+import team.startup.gwangjutalentfestival.domain.monitoring.detector.AnomalyRule;
+import team.startup.gwangjutalentfestival.domain.monitoring.detector.MlScoreResult;
+
+public interface AppendAnomalyEventService {
+    boolean execute(AnomalyRule rule, double detectedValue, @Nullable MlScoreResult mlResult);
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/AppendAnomalyEventServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/AppendAnomalyEventServiceImpl.java
@@ -1,26 +1,25 @@
-package team.startup.gwangjutalentfestival.domain.monitoring.detector;
+package team.startup.gwangjutalentfestival.domain.monitoring.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.monitoring.detector.AnomalyRule;
+import team.startup.gwangjutalentfestival.domain.monitoring.detector.MlScoreResult;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
 import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.AppendAnomalyEventService;
 
 @Service
 @RequiredArgsConstructor
-public class AnomalyEventAppender {
+public class AppendAnomalyEventServiceImpl implements AppendAnomalyEventService {
 
     private final AnomalyEventRepository anomalyEventRepository;
 
-    public boolean hasOpenEvent(AnomalyRule rule) {
-        return anomalyEventRepository.existsByDomainAndMetricNameAndStatus(
-                rule.domain(), rule.metricName(), AnomalyEventStatus.OPEN);
-    }
-
+    @Override
     @Transactional
-    public boolean appendIfNotDuplicate(AnomalyRule rule, double detectedValue, @Nullable MlScoreResult mlResult) {
+    public boolean execute(AnomalyRule rule, double detectedValue, @Nullable MlScoreResult mlResult) {
         if (anomalyEventRepository.existsByDomainAndMetricNameAndStatus(
                 rule.domain(), rule.metricName(), AnomalyEventStatus.OPEN)) {
             return false;

--- a/src/test/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplicationTests.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplicationTests.java
@@ -1,10 +1,19 @@
 package team.startup.gwangjutalentfestival;
 
+import com.google.api.services.drive.Drive;
+import com.google.api.services.sheets.v4.Sheets;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 class GwangjutalentfestivalApplicationTests {
+
+	@MockBean
+	Sheets sheets;
+
+	@MockBean
+	Drive drive;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetectorTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/detector/AnomalyDetectorTest.java
@@ -11,6 +11,9 @@ import team.startup.gwangjutalentfestival.domain.monitoring.client.MlServerClien
 import team.startup.gwangjutalentfestival.domain.monitoring.client.PrometheusClient;
 import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreRequest;
 import team.startup.gwangjutalentfestival.domain.monitoring.client.dto.MlAnomalyScoreResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
+import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.AppendAnomalyEventService;
 
 import java.util.Optional;
 
@@ -31,7 +34,10 @@ class AnomalyDetectorTest {
     private DiscordWebhookClient discordWebhookClient;
 
     @Mock
-    private AnomalyEventAppender anomalyEventAppender;
+    private AppendAnomalyEventService appendAnomalyEventService;
+
+    @Mock
+    private AnomalyEventRepository anomalyEventRepository;
 
     @Mock
     private MlServerClient mlServerClient;
@@ -51,12 +57,12 @@ class AnomalyDetectorTest {
 
         given(prometheusClient.query(seatFailureRule.promql())).willReturn(Optional.of(detectedValue));
         given(mlServerClient.call(any(MlAnomalyScoreRequest.class))).willReturn(Optional.of(mlResponse));
-        given(anomalyEventAppender.appendIfNotDuplicate(eq(seatFailureRule), eq(detectedValue), any(MlScoreResult.class))).willReturn(true);
+        given(appendAnomalyEventService.execute(eq(seatFailureRule), eq(detectedValue), any(MlScoreResult.class))).willReturn(true);
 
         anomalyDetector.detectAll();
 
         ArgumentCaptor<MlScoreResult> mlCaptor = ArgumentCaptor.forClass(MlScoreResult.class);
-        verify(anomalyEventAppender).appendIfNotDuplicate(eq(seatFailureRule), eq(detectedValue), mlCaptor.capture());
+        verify(appendAnomalyEventService).execute(eq(seatFailureRule), eq(detectedValue), mlCaptor.capture());
 
         MlScoreResult captured = mlCaptor.getValue();
         assertThat(captured).isNotNull();
@@ -71,11 +77,11 @@ class AnomalyDetectorTest {
 
         given(prometheusClient.query(seatFailureRule.promql())).willReturn(Optional.of(detectedValue));
         given(mlServerClient.call(any(MlAnomalyScoreRequest.class))).willReturn(Optional.empty());
-        given(anomalyEventAppender.appendIfNotDuplicate(eq(seatFailureRule), eq(detectedValue), eq(null))).willReturn(true);
+        given(appendAnomalyEventService.execute(eq(seatFailureRule), eq(detectedValue), eq(null))).willReturn(true);
 
         anomalyDetector.detectAll();
 
-        verify(anomalyEventAppender).appendIfNotDuplicate(eq(seatFailureRule), eq(detectedValue), eq(null));
+        verify(appendAnomalyEventService).execute(eq(seatFailureRule), eq(detectedValue), eq(null));
         verify(discordWebhookClient).send(any(String.class));
     }
 
@@ -85,7 +91,7 @@ class AnomalyDetectorTest {
 
         given(prometheusClient.query(seatFailureRule.promql())).willReturn(Optional.of(detectedValue));
         given(mlServerClient.call(any(MlAnomalyScoreRequest.class))).willReturn(Optional.empty());
-        given(anomalyEventAppender.appendIfNotDuplicate(any(AnomalyRule.class), anyDouble(), eq(null))).willReturn(true);
+        given(appendAnomalyEventService.execute(any(AnomalyRule.class), anyDouble(), eq(null))).willReturn(true);
 
         anomalyDetector.detectAll();
 
@@ -101,7 +107,7 @@ class AnomalyDetectorTest {
 
         given(prometheusClient.query(seatFailureRule.promql())).willReturn(Optional.of(detectedValue));
         given(mlServerClient.call(any(MlAnomalyScoreRequest.class))).willReturn(Optional.of(mlResponse));
-        given(anomalyEventAppender.appendIfNotDuplicate(any(AnomalyRule.class), anyDouble(), any(MlScoreResult.class))).willReturn(true);
+        given(appendAnomalyEventService.execute(any(AnomalyRule.class), anyDouble(), any(MlScoreResult.class))).willReturn(true);
 
         anomalyDetector.detectAll();
 

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/AppendAnomalyEventServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/service/impl/AppendAnomalyEventServiceImplTest.java
@@ -1,4 +1,4 @@
-package team.startup.gwangjutalentfestival.domain.monitoring.detector;
+package team.startup.gwangjutalentfestival.domain.monitoring.service.impl;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -6,6 +6,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.monitoring.detector.AnomalyRule;
+import team.startup.gwangjutalentfestival.domain.monitoring.detector.MlScoreResult;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventEntity;
 import team.startup.gwangjutalentfestival.domain.monitoring.entity.AnomalyEventStatus;
 import team.startup.gwangjutalentfestival.domain.monitoring.repository.AnomalyEventRepository;
@@ -15,13 +17,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class AnomalyEventAppenderTest {
+class AppendAnomalyEventServiceImplTest {
 
     @Mock
     private AnomalyEventRepository anomalyEventRepository;
 
     @InjectMocks
-    private AnomalyEventAppender anomalyEventAppender;
+    private AppendAnomalyEventServiceImpl appendAnomalyEventService;
 
     private final AnomalyRule rule = AnomalyRule.ALL.stream()
             .filter(r -> "seat".equals(r.domain()) && "failure_rate".equals(r.metricName()))
@@ -34,7 +36,7 @@ class AnomalyEventAppenderTest {
                 .willReturn(false);
         MlScoreResult mlResult = new MlScoreResult(0.0794, "iforest-v1", "anomaly");
 
-        boolean saved = anomalyEventAppender.appendIfNotDuplicate(rule, 0.08, mlResult);
+        boolean saved = appendAnomalyEventService.execute(rule, 0.08, mlResult);
 
         assertThat(saved).isTrue();
         ArgumentCaptor<AnomalyEventEntity> entityCaptor = ArgumentCaptor.forClass(AnomalyEventEntity.class);
@@ -51,7 +53,7 @@ class AnomalyEventAppenderTest {
         given(anomalyEventRepository.existsByDomainAndMetricNameAndStatus("seat", "failure_rate", AnomalyEventStatus.OPEN))
                 .willReturn(false);
 
-        boolean saved = anomalyEventAppender.appendIfNotDuplicate(rule, 0.08, null);
+        boolean saved = appendAnomalyEventService.execute(rule, 0.08, null);
 
         assertThat(saved).isTrue();
         ArgumentCaptor<AnomalyEventEntity> entityCaptor = ArgumentCaptor.forClass(AnomalyEventEntity.class);
@@ -68,7 +70,7 @@ class AnomalyEventAppenderTest {
         given(anomalyEventRepository.existsByDomainAndMetricNameAndStatus("seat", "failure_rate", AnomalyEventStatus.OPEN))
                 .willReturn(true);
 
-        boolean saved = anomalyEventAppender.appendIfNotDuplicate(rule, 0.08, null);
+        boolean saved = appendAnomalyEventService.execute(rule, 0.08, null);
 
         assertThat(saved).isFalse();
     }


### PR DESCRIPTION
## ✨ 작업 내용
`detector` 패키지에 위치한 `AnomalyEventAppender`에 선언되어 있던 `@Transactional`을 프로젝트 컨벤션에 맞게 `service` 레이어로 이동하였습니다.

- `AppendAnomalyEventService` 인터페이스를 생성하였습니다 (`execute()` 단일 메서드)
- `AppendAnomalyEventServiceImpl`을 `service/impl` 패키지에 생성하고 `@Transactional`을 적용하였습니다
- `AnomalyEventAppender`를 삭제하고, `AnomalyDetector`에서 새 서비스와 `AnomalyEventRepository`를 직접 주입하도록 수정하였습니다

---

## 🔍 리뷰 시 참고사항
- 기존 `AnomalyEventAppender.hasOpenEvent()`는 단순 read 쿼리였으므로, `AnomalyDetector`에서 `AnomalyEventRepository`를 직접 호출하는 방식으로 대체하였습니다
- `execute()` 내부에도 중복 체크 로직이 존재하여, 기존 동작과 동일하게 유지됩니다
- 트랜잭션 범위와 실제 동작에는 변화가 없으며, 레이어 컨벤션 위반만 수정되었습니다

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #118
