### PR TITLE
좌석 예약 한도 초과 레이스 컨디션 및 관계 어노테이션 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/entity/SeatEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/entity/SeatEntity.java
@@ -38,7 +38,7 @@ public class SeatEntity {
     @Column(nullable = false, name = "seat_number")
     private Integer seatNumber;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id")
     private UserEntity user;

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatReservationRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatReservationRepository.java
@@ -1,10 +1,6 @@
 package team.startup.gwangjutalentfestival.domain.seat.repository;
 
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
@@ -66,8 +62,4 @@ public interface SeatReservationRepository extends JpaRepository<SeatEntity, Lon
      * @return 예약 좌석 목록
      */
     List<SeatEntity> findAllByUserId(Long userId);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT s FROM SeatEntity s WHERE s.user.id = :userId")
-    List<SeatEntity> findAllByUserIdForUpdate(@Param("userId") Long userId);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatReservationRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatReservationRepository.java
@@ -1,6 +1,10 @@
 package team.startup.gwangjutalentfestival.domain.seat.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
@@ -62,4 +66,8 @@ public interface SeatReservationRepository extends JpaRepository<SeatEntity, Lon
      * @return 예약 좌석 목록
      */
     List<SeatEntity> findAllByUserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM SeatEntity s WHERE s.user.id = :userId")
+    List<SeatEntity> findAllByUserIdForUpdate(@Param("userId") Long userId);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
@@ -35,9 +35,8 @@ public class SeatReservationValidator {
 
     public void validateReservationLimit() {
         long userId = UserUtil.getCurrentUserId();
-        long reserveCount = seatReservationRepository.countByUserId(userId);
         int limit = UserUtil.getCurrentUserRole() == PERFORMER ? PERFORMER_SEAT_LIMIT : DEFAULT_SEAT_LIMIT;
-        if (reserveCount >= limit) {
+        if (seatReservationRepository.findAllByUserIdForUpdate(userId).size() >= limit) {
             throw new SeatReservationLimitExceededException();
         }
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
@@ -8,6 +8,7 @@ import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotExistsInS
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationLimitExceededException;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import static team.startup.gwangjutalentfestival.domain.user.enums.Role.PERFORMER;
@@ -18,6 +19,7 @@ public class SeatReservationValidator {
 
     private final SeatReservationRepository seatReservationRepository;
     private final SeatBanRepository seatBanRepository;
+    private final UserRepository userRepository;
 
     private static final int PERFORMER_SEAT_LIMIT = 3;
     private static final int DEFAULT_SEAT_LIMIT = 1;
@@ -35,8 +37,9 @@ public class SeatReservationValidator {
 
     public void validateReservationLimit() {
         long userId = UserUtil.getCurrentUserId();
+        userRepository.findByIdForUpdate(userId);
         int limit = UserUtil.getCurrentUserRole() == PERFORMER ? PERFORMER_SEAT_LIMIT : DEFAULT_SEAT_LIMIT;
-        if (seatReservationRepository.findAllByUserIdForUpdate(userId).size() >= limit) {
+        if (seatReservationRepository.countByUserId(userId) >= limit) {
             throw new SeatReservationLimitExceededException();
         }
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/user/repository/UserRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/user/repository/UserRepository.java
@@ -1,6 +1,10 @@
 package team.startup.gwangjutalentfestival.domain.user.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
 import java.util.Optional;
@@ -25,4 +29,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
      * @return 사용자가 존재하면 {@code true}
      */
     boolean existsByPhoneNumber(String phoneNumber);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM UserEntity u WHERE u.id = :id")
+    Optional<UserEntity> findByIdForUpdate(@Param("id") Long id);
 }


### PR DESCRIPTION
## ✨ 작업 내용
좌석 예매 동시성 제어와 관련된 두 가지 문제를 수정하였습니다.

1. **`SeatEntity` `@OneToOne` → `@ManyToOne` 수정**: PERFORMER는 최대 3석 예약이 가능하므로 한 유저가 여러 `SeatEntity`를 가질 수 있습니다. `@OneToOne`은 의미적으로 부정확하며, Hibernate가 owning side FK에 UNIQUE 제약을 생성하려 해 스키마 의도와 불일치가 발생하였습니다.

2. **1인 예약 한도 초과 레이스 컨디션 수정**: `validateReservationLimit()`이 `countByUserId()` 조회 후 저장하는 Check-Then-Act 패턴을 사용해, 동일 유저가 동시에 요청을 보낼 경우 한도를 초과해 예약이 가능한 버그가 있었습니다. `SELECT ... FOR UPDATE`(Pessimistic Lock)를 적용하여 첫 번째 트랜잭션이 커밋될 때까지 두 번째 트랜잭션이 대기하도록 수정하였습니다.

---

## 🔍 리뷰 시 참고사항
- `findAllByUserIdForUpdate()`는 `@Transactional`이 걸린 `ReservationSeatServiceImpl.execute()` 내부에서 호출되므로 X락이 `saveAndFlush()` 완료 시점까지 유지됩니다.
- 기존 `findAllByUserId()`(락 없는 버전)는 조회 전용 컨텍스트에서 그대로 사용됩니다.
- 좌석 중복 예약(동일 seat_section + seat_number)은 DB UNIQUE 제약 + `DataIntegrityViolationException` 캐치로 이미 방어되어 있어 별도 락 처리를 하지 않았습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #124
