### PR TITLE
업로드 파일 용량 제한 환경변수로 설정 가능하도록 변경

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,7 @@ GOOGLE_EXCEL_SUMMARY_PAGE=String
 # Slogan Submission Period
 START_AT=LocalDateTime
 END_AT=LocalDateTime
+
+# Multipart Upload Limit (Optional, default 500MB)
+MAX_FILE_SIZE=String
+MAX_REQUEST_SIZE=String

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,8 +8,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 500MB
-      max-request-size: 500MB
+      max-file-size: ${MAX_FILE_SIZE:500MB}
+      max-request-size: ${MAX_REQUEST_SIZE:500MB}
 
   datasource:
     url: ${DB_URL:jdbc:mysql://localhost:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

- 멀티파트 업로드 용량 제한(`max-file-size`, `max-request-size`)을 환경변수(`MAX_FILE_SIZE`, `MAX_REQUEST_SIZE`)로 오버라이드할 수 있도록 변경하였습니다. 기본값은 기존과 동일하게 500MB로 유지하였습니다.
- 새 환경변수를 `.env.example`에 문서화하였습니다.

---

## 🔍 리뷰 시 참고사항
- 영상 업로드 시 클라이언트에서 413(Payload Too Large)이 발생하여 용량 제한을 점검하는 과정에서, 운영 환경별로 업로드 용량을 코드 수정 없이 조정할 수 있도록 환경변수화하였습니다.
- 환경변수를 설정하지 않으면 기존(500MB)과 동일하게 동작하므로 별도 인프라 변경은 필요하지 않습니다.
- 참고로 413 자체는 앱이 아닌 배포 서버 앞단 프록시(nginx)의 `client_max_body_size` 기본값(1MB)이 원인일 가능성이 높아, 서버 측 nginx 설정 변경이 별도로 필요합니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- 없음
