### PR TITLE
신청 영상 다운로드 링크 조회 API 인증 제거

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
@@ -20,6 +20,7 @@ public final class PublicEndpointMatcher {
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/v3/api-docs(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(HttpMethod.GET, withOptionalQuery("^/team")),
             RegexRequestMatcher.regexMatcher(HttpMethod.POST, withOptionalQuery("^/apply")),
+            RegexRequestMatcher.regexMatcher(HttpMethod.GET, withOptionalQuery("^/apply/[^/]+/video")),
             RegexRequestMatcher.regexMatcher(HttpMethod.POST, withOptionalQuery("^/slogan"))
     );
 


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

- 신청 영상 다운로드 링크 조회 API(`GET /apply/{applyId}/video`)를 공개 엔드포인트로 전환하여 JWT 인증 없이 호출할 수 있도록 변경하였습니다.
- `PublicEndpointMatcher`에 해당 경로를 추가하여 `JwtFilter` 스킵과 `permitAll`이 함께 적용되도록 하였습니다.

---

## 🔍 리뷰 시 참고사항
- 프론트에서 별도 로그인 없이 신청 영상 링크를 조회할 수 있어야 하여 인증을 제거하였습니다. 업로드(`POST /apply`)가 이미 공개 엔드포인트인 것과 동일한 맥락입니다.
- 반환되는 Presigned URL은 10분 후 만료되는 일회성 링크이므로 링크 자체의 유출 위험은 제한적입니다.
- 다만 `applyId`가 순번이라 ID를 순회하며 모든 신청 영상에 접근할 수 있게 됩니다. 영상이 비공개여야 한다면 식별자를 UUID로 전환하는 후속 작업이 필요합니다.
- 로컬에서 토큰 없이 200(링크 발급), 존재하지 않는 ID로 404 응답을 직접 확인하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- 없음
