### PR TITLE
좌석 예약 트랜잭션 격리 수준을 READ_COMMITTED로 변경

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -6,7 +6,6 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
@@ -31,7 +30,7 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
     private final OperationMetricRecorder metricRecorder;
 
     @Override
-    @Transactional(isolation = Isolation.READ_COMMITTED)
+    @Transactional
     @Caching(evict = {
             @CacheEvict(value = CacheConfig.SEATS_ALL, allEntries = true),
             @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
@@ -46,8 +45,8 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
                     Integer seatNumber = request.seatNumber();
 
                     seatReservationValidator.validateSeatRange(seatNumber, seatUtil.getMaxSeats(seatSection));
-                    seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
                     seatReservationValidator.validateReservationLimit();
+                    seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
 
                     SeatEntity seat = SeatEntity.builder()
                             .seatNumber(seatNumber)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
@@ -30,7 +31,7 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
     private final OperationMetricRecorder metricRecorder;
 
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     @Caching(evict = {
             @CacheEvict(value = CacheConfig.SEATS_ALL, allEntries = true),
             @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)


### PR DESCRIPTION
## ✨ 작업 내용
MySQL의 기본 격리 수준인 REPEATABLE READ에서 `countByUserId()`가 트랜잭션 시작 시점의 MVCC 스냅샷을 읽어, Pessimistic Lock 획득 이후에도 T1 커밋 결과를 반영하지 못해 동시 요청 시 1인 예약 한도를 초과할 수 있었습니다.
`ReservationSeatServiceImpl.execute()`의 트랜잭션 격리 수준을 `READ_COMMITTED`로 변경하여, 매 읽기마다 최신 커밋 데이터를 조회하도록 수정하였습니다.

---

## 🔍 리뷰 시 참고사항
- `READ_COMMITTED`는 매 읽기마다 최신 커밋 데이터를 반환하므로, T1 커밋 후 T2의 `countByUserId()`가 `count=1`을 올바르게 반환하여 한도 초과를 차단합니다.
- Pessimistic Lock(`findByIdForUpdate`)은 쓰기 경합을 막지만, MVCC 스냅샷 읽기는 락과 무관하게 동작하기 때문에 격리 수준 변경이 근본적인 해결책입니다.
- 변경 범위는 `ReservationSeatServiceImpl.java` 단 하나의 어노테이션으로 최소화하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #137
