### PR TITLE
실제 공연장 좌석 구역 및 최대 좌석 수 업데이트

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/BanSeatRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/BanSeatRequest.java
@@ -9,20 +9,20 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 /**
  * 좌석 차단 요청 DTO.
  *
- * @param seatSection 차단할 좌석 구역 (A~J)
- * @param seatNumber  차단할 좌석 번호 (1~154)
+ * @param seatSection 차단할 좌석 구역 (A, B, C, D, E, F, W 중 하나)
+ * @param seatNumber  차단할 좌석 번호 (1~132)
  * @param role        차단을 적용할 사용자 역할
  */
 public record BanSeatRequest(
         @Pattern(
-                regexp = "^[A-J]$",
-                message = "좌석 섹션은 A부터 J까지 존재합니다."
+                regexp = "^[ABCDEFW]$",
+                message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
         )
         @Size(max = 1)
         String seatSection,
 
         @Min(value = 1, message = "좌석 번호는 최소 1번부터 존재합니다.")
-        @Max(value = 154, message = "좌석 번호는 최대 154번까지 존재합니다.")
+        @Max(value = 132, message = "좌석 번호는 최대 132번까지 존재합니다.")
         Integer seatNumber,
 
         Role role

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/BanSeatRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/BanSeatRequest.java
@@ -3,8 +3,8 @@ package team.startup.gwangjutalentfestival.domain.seat.presentation.data.request
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 
 /**
  * 좌석 차단 요청 DTO.
@@ -18,11 +18,10 @@ public record BanSeatRequest(
                 regexp = "^[ABCDEFW]$",
                 message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
         )
-        @Size(max = 1)
         String seatSection,
 
         @Min(value = 1, message = "좌석 번호는 최소 1번부터 존재합니다.")
-        @Max(value = 132, message = "좌석 번호는 최대 132번까지 존재합니다.")
+        @Max(value = SeatUtil.MAX_SEAT_NUMBER, message = "좌석 번호는 최대 132번까지 존재합니다.")
         Integer seatNumber,
 
         Role role

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/CancelSeatBanRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/CancelSeatBanRequest.java
@@ -8,19 +8,19 @@ import jakarta.validation.constraints.Size;
 /**
  * 좌석 차단 취소 요청 DTO.
  *
- * @param seatSection 차단을 해제할 좌석 구역 (A~J)
- * @param seatNumber  차단을 해제할 좌석 번호 (1~154)
+ * @param seatSection 차단을 해제할 좌석 구역 (A, B, C, D, E, F, W 중 하나)
+ * @param seatNumber  차단을 해제할 좌석 번호 (1~132)
  */
 public record CancelSeatBanRequest(
         @Pattern(
-                regexp = "^[A-J]$",
-                message = "좌석 섹션은 A부터 J까지 존재합니다."
+                regexp = "^[ABCDEFW]$",
+                message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
         )
         @Size(max = 1)
         String seatSection,
 
         @Min(value = 1, message = "좌석 번호는 최소 1번부터 존재합니다.")
-        @Max(value = 154, message = "좌석 번호는 최대 154번까지 존재합니다.")
+        @Max(value = 132, message = "좌석 번호는 최대 132번까지 존재합니다.")
         Integer seatNumber
 ) {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/CancelSeatBanRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/CancelSeatBanRequest.java
@@ -3,7 +3,7 @@ package team.startup.gwangjutalentfestival.domain.seat.presentation.data.request
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 
 /**
  * 좌석 차단 취소 요청 DTO.
@@ -16,11 +16,10 @@ public record CancelSeatBanRequest(
                 regexp = "^[ABCDEFW]$",
                 message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
         )
-        @Size(max = 1)
         String seatSection,
 
         @Min(value = 1, message = "좌석 번호는 최소 1번부터 존재합니다.")
-        @Max(value = 132, message = "좌석 번호는 최대 132번까지 존재합니다.")
+        @Max(value = SeatUtil.MAX_SEAT_NUMBER, message = "좌석 번호는 최대 132번까지 존재합니다.")
         Integer seatNumber
 ) {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/PerformerCancelSeatReservationRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/PerformerCancelSeatReservationRequest.java
@@ -8,19 +8,19 @@ import jakarta.validation.constraints.Size;
 /**
  * 공연자의 좌석 예약 취소 요청 DTO.
  *
- * @param seatSection 취소할 좌석 구역 (A~J)
- * @param seatNumber  취소할 좌석 번호 (1~154)
+ * @param seatSection 취소할 좌석 구역 (A, B, C, D, E, F, W 중 하나)
+ * @param seatNumber  취소할 좌석 번호 (1~132)
  */
 public record PerformerCancelSeatReservationRequest(
         @Pattern(
-                regexp = "^[A-J]$",
-                message = "좌석 섹션은 A부터 J까지 존재합니다."
+                regexp = "^[ABCDEFW]$",
+                message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
         )
         @Size(max = 1)
         String seatSection,
 
         @Min(value = 1, message = "좌석 번호는 최소 1번부터 존재합니다.")
-        @Max(value = 154, message = "좌석 번호는 최대 154번까지 존재합니다.")
+        @Max(value = 132, message = "좌석 번호는 최대 132번까지 존재합니다.")
         Integer seatNumber
 ) {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/PerformerCancelSeatReservationRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/PerformerCancelSeatReservationRequest.java
@@ -3,7 +3,7 @@ package team.startup.gwangjutalentfestival.domain.seat.presentation.data.request
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 
 /**
  * 공연자의 좌석 예약 취소 요청 DTO.
@@ -16,11 +16,10 @@ public record PerformerCancelSeatReservationRequest(
                 regexp = "^[ABCDEFW]$",
                 message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
         )
-        @Size(max = 1)
         String seatSection,
 
         @Min(value = 1, message = "좌석 번호는 최소 1번부터 존재합니다.")
-        @Max(value = 132, message = "좌석 번호는 최대 132번까지 존재합니다.")
+        @Max(value = SeatUtil.MAX_SEAT_NUMBER, message = "좌석 번호는 최대 132번까지 존재합니다.")
         Integer seatNumber
 ) {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/ReservationSeatRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/ReservationSeatRequest.java
@@ -3,7 +3,7 @@ package team.startup.gwangjutalentfestival.domain.seat.presentation.data.request
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 
 /**
  * 좌석 예약 요청 DTO.
@@ -16,11 +16,10 @@ public record ReservationSeatRequest(
                 regexp = "^[ABCDEFW]$",
                 message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
         )
-        @Size(max = 1)
         String seatSection,
 
         @Min(value = 1, message = "좌석 번호는 최소 1번부터 존재합니다.")
-        @Max(value = 132, message = "좌석 번호는 최대 132번까지 존재합니다.")
+        @Max(value = SeatUtil.MAX_SEAT_NUMBER, message = "좌석 번호는 최대 132번까지 존재합니다.")
         Integer seatNumber
 ) {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/ReservationSeatRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/ReservationSeatRequest.java
@@ -8,19 +8,19 @@ import jakarta.validation.constraints.Size;
 /**
  * 좌석 예약 요청 DTO.
  *
- * @param seatSection 예약할 좌석 구역 (A~J)
- * @param seatNumber  예약할 좌석 번호 (1~154)
+ * @param seatSection 예약할 좌석 구역 (A, B, C, D, E, F, W 중 하나)
+ * @param seatNumber  예약할 좌석 번호 (1~132)
  */
 public record ReservationSeatRequest(
         @Pattern(
-                regexp = "^[A-J]$",
-                message = "좌석 섹션은 A부터 J까지 존재합니다."
+                regexp = "^[ABCDEFW]$",
+                message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
         )
         @Size(max = 1)
         String seatSection,
 
         @Min(value = 1, message = "좌석 번호는 최소 1번부터 존재합니다.")
-        @Max(value = 154, message = "좌석 번호는 최대 154번까지 존재합니다.")
+        @Max(value = 132, message = "좌석 번호는 최대 132번까지 존재합니다.")
         Integer seatNumber
 ) {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
@@ -15,6 +15,8 @@ import java.util.stream.IntStream;
  */
 @Component
 public class SeatUtil {
+    public static final int MAX_SEAT_NUMBER = 132;
+
     private static final Map<String, Integer> SEAT_MAP = Map.of(
             "A", 101, "B", 132, "C", 101, "D", 89, "E", 96,
             "F", 89, "W", 6

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
@@ -16,8 +16,8 @@ import java.util.stream.IntStream;
 @Component
 public class SeatUtil {
     private static final Map<String, Integer> SEAT_MAP = Map.of(
-            "A", 77, "B", 130, "C", 154, "D", 130, "E", 77,
-            "F", 54, "G", 100, "H", 119, "I", 100, "J", 54
+            "A", 101, "B", 132, "C", 101, "D", 89, "E", 96,
+            "F", 89, "W", 6
     );
 
     /**

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
@@ -86,6 +86,34 @@ class GetSeatsBySectionServiceImplTest {
     }
 
     @Test
+    void W구역_전체_좌석_예약_가능() {
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            given(seatReservationCustomRepository.findSeatNumbersBySeatSection("W")).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole("W", Role.USER)).willReturn(Set.of());
+
+            GetSeatsBySectionResponse response = getSeatsBySectionService.execute("W");
+
+            assertThat(response.seats()).hasSize(6);
+            assertThat(response.seats()).containsOnly(true);
+        }
+    }
+
+    @Test
+    void B구역_전체_좌석_예약_가능() {
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            given(seatReservationCustomRepository.findSeatNumbersBySeatSection("B")).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole("B", Role.USER)).willReturn(Set.of());
+
+            GetSeatsBySectionResponse response = getSeatsBySectionService.execute("B");
+
+            assertThat(response.seats()).hasSize(132);
+            assertThat(response.seats()).containsOnly(true);
+        }
+    }
+
+    @Test
     void 잘못된_구역_예외() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
@@ -48,7 +48,7 @@ class GetSeatsBySectionServiceImplTest {
 
             GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
-            assertThat(response.seats()).hasSize(77);
+            assertThat(response.seats()).hasSize(101);
             assertThat(response.seats()).containsOnly(true);
         }
     }


### PR DESCRIPTION
## ✨ 작업 내용
광주교대 풍향문화관 실제 좌석 배치에 맞게 `SeatUtil`의 구역별 좌석 수를 수정하였습니다.
기존 A~J 10개 구역에서 A, B, C, D, E, F, W 7개 구역으로 변경되었으며, Request DTO의 구역 검증 패턴과 최대 좌석 수 제약도 함께 동기화하였습니다.

---

## 🔍 리뷰 시 참고사항
- `SeatUtil.SEAT_MAP` 변경 사항: A(101), B(132), C(101), D(89), E(96), F(89), W(6)
- 최대 좌석 수가 154 → 132(B구역 기준)로 변경되어 Request DTO 4개의 `@Max` 값을 일괄 수정하였습니다.
- `@Pattern` regexp도 `^[A-J]$`에서 `^[ABCDEFW]$`로 변경하여 실제 존재하는 구역만 허용하도록 수정하였습니다.
- `GetSeatsBySectionServiceImplTest`에서 A구역 좌석 수를 검증하는 `hasSize(77)` → `hasSize(101)`로 수정하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #136
