### PR TITLE
Cloudflare R2 마이그레이션 및 S3 호환 엔드포인트 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ out/
 
 ### ENVIRONMENT ###
 .env
+
+### TERRAFORM ###
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example

--- a/docs/specs/r2-migration-spec.md
+++ b/docs/specs/r2-migration-spec.md
@@ -1,0 +1,242 @@
+# S3 → Cloudflare R2 마이그레이션 구현 명세 (Spec)
+
+> 작성: plan-deep-dive 인터뷰 기반 / 대상 브랜치: develop
+
+## 1. Context (배경 · 목적)
+
+영상 업로드는 현재 AWS S3(`ap-northeast-2`)를 사용하며, `AwsS3Adapter`에 멀티파트 업로드 + presigned URL(PUT 파트 업로드 / GET 다운로드)이 구현되어 있다. **S3 egress(전송 OUT) 요금 절감**을 위해 egress 무료인 **Cloudflare R2**로 전환한다. R2는 S3 호환 API를 제공하므로 **`AwsS3Adapter`의 비즈니스 로직은 변경하지 않고**, 엔드포인트·자격증명·리전 설정만 R2용으로 전환한다.
+
+### 결정 사항 요약 (인터뷰 결과)
+| 항목 | 결정 |
+|------|------|
+| 설정 방식 | 기존 `aws.s3` prefix에 `endpoint` 필드 추가 (조건부 override, 하위호환) |
+| 기존 데이터 | **전수 마이그레이션** (S3→R2 전체 복사), 재현 가능한 스크립트로 자동화 |
+| 다운로드 URL | presigned GET 유지 (코드 변경 최소) |
+| CORS | Terraform으로 R2 버킷 CORS 선언적 관리 |
+| 전환 절차 | 검증 환경에서 E2E 확인 후 운영 전환 |
+| Terraform state | R2 자체를 원격 backend(S3 호환)로 |
+| 버킷 location | APAC |
+| 미완료 멀티파트 정리(lifecycle) | **이번 범위 제외** (추후) |
+| 기존 S3 버킷 정리 | **이번 범위 제외** (별도 작업) |
+| Cloudflare 자격증명 | **분리**: TF용 계정 토큰 / 앱용 버킷 범위 R2 Access Key·Secret |
+| CI Secrets 갱신 | 체크리스트로 명시 (수동 적용) |
+
+### 사전 검증된 중요 사실
+- **AWS SDK 버전 `2.28.0`** (build.gradle:95). R2 presigned 업로드를 깨뜨리는 기본 체크섬(CRC32) 강제는 SDK **2.30.0부터** 발생하므로 현재 버전은 **안전**. ⚠️ SDK를 2.30+로 올릴 경우 `requestChecksumCalculation(WHEN_REQUIRED)` 미설정 시 파트 업로드가 깨짐 → **이번 작업에서 SDK 버전 고정 유지**.
+- 설정 prefix는 `aws.s3` (코드/yaml 일치), 단일 `application.yaml` + 환경변수 주입 구조.
+- 기존 Terraform 코드 **없음** → 신규 작성.
+- 배포는 `cd.yml`에서 `secrets.APPLICATION_YML` → `application.yml`, `secrets.ENV_FILE` → `.env`로 주입. **레포 파일 변경만으로는 운영 미반영** → Secret 갱신 필수.
+
+---
+
+## 2. 코드 변경
+
+### 2.1 `AwsS3Properties` — `endpoint` 필드 추가
+`src/main/java/team/startup/gwangjutalentfestival/global/s3/properties/AwsS3Properties.java`
+
+`@AllArgsConstructor` 생성자 바인딩이므로 필드 추가만으로 충분.
+
+```java
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "aws.s3")
+public class AwsS3Properties {
+    private String accessKey;
+    private String secretKey;
+    private String region;
+    private String bucket;
+    private String endpoint;   // R2 엔드포인트. 비어있으면 실제 AWS S3 사용
+}
+```
+
+### 2.2 `AwsS3Config` — endpoint 조건부 적용
+`src/main/java/team/startup/gwangjutalentfestival/global/s3/config/AwsS3Config.java`
+
+`endpoint`가 설정된 경우에만 `S3Client`/`S3Presigner` 양쪽에 `endpointOverride()` 적용. 빈 값이면 기존 AWS S3 동작 유지(하위호환 + env 롤백 가능).
+
+```java
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import org.springframework.util.StringUtils;
+import java.net.URI;
+
+@Bean
+public S3Client s3Client(AwsCredentialsProvider provider) {
+    S3ClientBuilder builder = S3Client.builder()
+            .region(Region.of(awsS3Properties.getRegion()))
+            .credentialsProvider(provider);
+    if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
+        builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()));
+    }
+    return builder.build();
+}
+
+@Bean
+public S3Presigner s3Presigner(AwsCredentialsProvider provider) {
+    S3Presigner.Builder builder = S3Presigner.builder()
+            .region(Region.of(awsS3Properties.getRegion()))
+            .credentialsProvider(provider);
+    if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
+        builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()));
+    }
+    return builder.build();
+}
+```
+
+> **path-style fallback**: R2는 가상호스팅(`https://<bucket>.<account>.r2.cloudflarestorage.com`)을 기본 지원하므로 별도 설정 불필요. 만약 호스트 해석 문제 발생 시 양쪽 builder에 `.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())` 추가.
+
+### 2.3 `application.yaml`
+`src/main/resources/application.yaml` (`aws.s3` 블록)
+
+```yaml
+aws:
+  s3:
+    access-key: ${AWS_ACCESS_KEY}      # R2 Access Key ID로 교체
+    secret-key: ${AWS_SECRET_KEY}      # R2 Secret Access Key로 교체
+    region: ${AWS_REGION:auto}         # R2는 'auto' (기본값 변경)
+    bucket: ${AWS_S3_BUCKET}
+    endpoint: ${AWS_S3_ENDPOINT:}      # https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+```
+
+### 2.4 변경하지 않는 것
+- **`AwsS3Adapter`** 전체 (멀티파트/presigned 로직) — S3 호환 API 그대로.
+- 호출 서비스 구현체들(`InitiateApplyUploadServiceImpl`, `GetApplyPartUrlsServiceImpl`, `ApplyServiceImpl`, `AbortApplyUploadServiceImpl`, `GetApplyVideoUrlServiceImpl`).
+- AWS SDK 의존성 버전 `2.28.0` (의도적 고정 — 체크섬 이슈 회피).
+
+---
+
+## 3. Terraform (Cloudflare R2)
+
+신규 디렉토리 `terraform/`:
+```
+terraform/
+  backend.tf      # R2를 S3 호환 원격 state backend로
+  main.tf         # cloudflare provider + r2 bucket + CORS
+  variables.tf    # api_token, account_id, bucket_name, allowed_origins
+  outputs.tf      # endpoint, bucket name
+  terraform.tfvars.example
+```
+
+### 3.1 자격증명 분리 (중요)
+- **Terraform용**: Cloudflare 대시보드에서 **계정 레벨 R2 관리 권한** API 토큰 발급 → `var.cloudflare_api_token`.
+- **앱 런타임용**: R2 → "Manage R2 API Tokens"에서 **버킷 범위(Object Read & Write)** 토큰 발급 → Access Key ID / Secret을 앱 `AWS_ACCESS_KEY`/`AWS_SECRET_KEY`로 사용. (Terraform 토큰과 별개)
+
+### 3.2 `main.tf` 골자
+```hcl
+terraform {
+  required_providers {
+    cloudflare = { source = "cloudflare/cloudflare", version = "~> 4" }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+resource "cloudflare_r2_bucket" "video" {
+  account_id = var.account_id
+  name       = var.bucket_name
+  location   = "APAC"
+}
+
+# 브라우저 직접 PUT 업로드를 위한 CORS (프론트 출처와 동기화)
+resource "cloudflare_r2_bucket_cors_configuration" "video" {
+  account_id  = var.account_id
+  bucket_name = cloudflare_r2_bucket.video.name
+  rules {
+    allowed { methods = ["GET", "PUT"], origins = var.allowed_origins, headers = ["*"] }
+    expose_headers  = ["ETag"]   # completeMultipartUpload는 파트 ETag가 필요
+    max_age_seconds = 3600
+  }
+}
+```
+> CORS 리소스명/스키마는 사용 중인 cloudflare provider 4.x 실제 버전에 맞춰 확정한다(provider 메이저에 따라 R2 CORS 지원 여부·형식이 다를 수 있어, 미지원 시 R2 대시보드 수동 설정으로 대체하고 그 사실을 문서화).
+> `allowed_origins`는 application.yaml의 `cors.allowed-origins`(현재 localhost 및 운영 프론트 도메인)와 일치시킨다. **ETag expose 필수** — 미설정 시 브라우저가 파트 ETag를 못 읽어 `completeMultipartUpload`가 실패.
+
+### 3.3 `backend.tf` — R2를 원격 state backend로
+R2는 S3 호환이므로 terraform `s3` backend로 사용 가능. R2 특성상 다음 skip 옵션과 **`skip_s3_checksum = true`(terraform 1.6.3+ 필요)**가 필수.
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket = "<state-bucket>"     # 상태 전용 R2 버킷
+    key    = "r2-migration/terraform.tfstate"
+    region = "auto"
+    endpoints = { s3 = "https://<ACCOUNT_ID>.r2.cloudflarestorage.com" }
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+  }
+}
+```
+> **부트스트랩 주의(chicken-and-egg)**: state용 R2 버킷은 `terraform init` 전에 **먼저 존재**해야 한다 → state 버킷은 R2 대시보드에서 수동 생성(또는 별도 부트스트랩). backend 자격증명은 `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` 환경변수로 R2 토큰 주입.
+
+### 3.4 `.gitignore`
+`*.tfvars`(단 `*.example` 제외), `.terraform/`, `*.tfstate*` 추가.
+
+---
+
+## 4. 데이터 마이그레이션 (전수 복사, 자동화)
+
+S3→R2 전체 객체 복사를 **재현 가능한 스크립트**로 작성 (예: `terraform/`와 분리된 `scripts/migrate-s3-to-r2.sh`). rclone 사용.
+
+```bash
+# rclone.conf: [s3] 와 [r2](provider=Cloudflare, endpoint=https://<ACCOUNT_ID>.r2.cloudflarestorage.com) 정의
+rclone copy s3:<SOURCE_BUCKET> r2:<DEST_BUCKET> \
+  --transfers 16 --checkers 16 --progress
+# 검증: 개수/크기 대조
+rclone check s3:<SOURCE_BUCKET> r2:<DEST_BUCKET> --one-way
+```
+> 재실행 안전(idempotent): `rclone copy`는 동일 객체를 건너뜀. 운영 전환 직전 **증분 재동기화**(delta) 1회 더 수행 권장.
+
+---
+
+## 5. 전환 절차 (검증 환경 우선)
+
+1. Terraform으로 R2 버킷 + CORS 생성 (`terraform apply`).
+2. 데이터 전수 마이그레이션 스크립트 실행 + `rclone check` 통과 확인.
+3. **검증 환경**에 R2 자격증명 / `AWS_S3_ENDPOINT` / `AWS_REGION=auto` / `AWS_S3_BUCKET` 주입 → 아래 §6 E2E 수행.
+4. E2E 통과 시 **운영 전환**: GitHub Secrets 갱신(§7) 후 배포.
+5. 문제 발생 시 **즉시 롤백**: `AWS_S3_ENDPOINT`를 비우고(또는 S3 자격증명 복원) 재배포 → 코드가 조건부라 S3로 자동 복귀.
+
+---
+
+## 6. 검증 (E2E)
+
+1. **빌드/단위 테스트**: `./gradlew build` — Config/Properties 변경 컴파일·기존 테스트 통과.
+2. **하위호환(S3 모드)**: `AWS_S3_ENDPOINT` 빈 값 + 기존 S3 자격증명으로 업로드/다운로드 정상 → 롤백 경로 보증.
+3. **R2 모드 업로드 플로우**:
+   - `createMultipartUpload` → `generatePartUploadUrl` presigned PUT으로 브라우저(또는 curl)에서 파트 업로드 → 응답 `ETag` 수신 확인 (CORS expose-headers 검증 포함) → `completeMultipartUpload`.
+   - 잘못된 uploadId/ETag 시 4xx → `InvalidVideoFileException` 매핑 정상 확인.
+4. **R2 모드 다운로드**: `generateVideoDownloadUrl` presigned GET으로 다운로드 + `Content-Disposition` 한글 파일명(UTF-8) 정상 확인. ← **R2의 `responseContentDisposition` 쿼리 파라미터 지원 여부 핵심 검증 포인트**.
+5. **Range 검증**: `readObjectHead`의 `bytes=0-N` Range 요청으로 파일 시그니처 검증 정상 동작.
+6. **Terraform**: `terraform init && terraform plan`으로 R2 버킷·CORS 리소스 계획 확인 (apply는 운영자 판단).
+7. **CORS**: 브라우저 실제 출처에서 preflight(OPTIONS) 통과 확인.
+
+---
+
+## 7. 운영 작업 체크리스트 (코드 외 · 필수)
+
+배포 반영을 위해 **레포 파일 변경과 별개로** 아래를 수동 적용:
+
+- [ ] GitHub Secret **`APPLICATION_YML`** 갱신: `aws.s3.endpoint` 추가된 yaml 내용 반영 (워크플로가 `application.yml`로 생성 → 이 secret이 우선 적용됨).
+- [ ] GitHub Secret **`ENV_FILE`** 갱신:
+  - [ ] `AWS_ACCESS_KEY` / `AWS_SECRET_KEY` → R2 **버킷 범위** Access Key·Secret
+  - [ ] `AWS_REGION=auto`
+  - [ ] `AWS_S3_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com`
+  - [ ] `AWS_S3_BUCKET` → R2 버킷명
+- [ ] Cloudflare API 토큰 2종 발급·보관 (TF용 계정 토큰 / 앱용 버킷 토큰).
+- [ ] Terraform backend용 state 전용 R2 버킷 사전 생성.
+- [ ] (검증 환경) 동일 env 세트 별도 구성.
+
+---
+
+## 8. 명시적 범위 제외 (추후 별도 작업)
+
+- 미완료 멀티파트 업로드 자동 정리(R2 lifecycle 규칙).
+- 기존 AWS S3 버킷 비우기/삭제(decommission).
+- R2 Custom Domain/CDN 기반 공개 다운로드(현재는 presigned GET 유지).
+- AWS SDK 2.30+ 업그레이드(체크섬 대응 필요).

--- a/docs/specs/r2-migration-spec.md
+++ b/docs/specs/r2-migration-spec.md
@@ -127,11 +127,11 @@ terraform/
 - **Terraform용**: Cloudflare 대시보드에서 **계정 레벨 R2 관리 권한** API 토큰 발급 → `var.cloudflare_api_token`.
 - **앱 런타임용**: R2 → "Manage R2 API Tokens"에서 **버킷 범위(Object Read & Write)** 토큰 발급 → Access Key ID / Secret을 앱 `AWS_ACCESS_KEY`/`AWS_SECRET_KEY`로 사용. (Terraform 토큰과 별개)
 
-### 3.2 `main.tf` 골자
+### 3.2 `main.tf` 골자 (cloudflare provider v5)
 ```hcl
 terraform {
   required_providers {
-    cloudflare = { source = "cloudflare/cloudflare", version = "~> 4" }
+    cloudflare = { source = "cloudflare/cloudflare", version = "~> 5" }
   }
 }
 
@@ -140,23 +140,29 @@ provider "cloudflare" {
 }
 
 resource "cloudflare_r2_bucket" "video" {
-  account_id = var.account_id
-  name       = var.bucket_name
-  location   = "APAC"
+  account_id    = var.account_id
+  name          = var.bucket_name
+  location      = var.location   # v5는 소문자: apac/eeur/enam/weur/wnam/oc
+  storage_class = "Standard"
 }
 
 # 브라우저 직접 PUT 업로드를 위한 CORS (프론트 출처와 동기화)
-resource "cloudflare_r2_bucket_cors_configuration" "video" {
+# v5 리소스명은 cloudflare_r2_bucket_cors, rules는 블록이 아닌 객체 리스트
+resource "cloudflare_r2_bucket_cors" "video" {
   account_id  = var.account_id
   bucket_name = cloudflare_r2_bucket.video.name
-  rules {
-    allowed { methods = ["GET", "PUT"], origins = var.allowed_origins, headers = ["*"] }
+
+  rules = [{
+    allowed = {
+      methods = ["GET", "PUT"]
+      origins = var.allowed_origins
+      headers = ["*"]
+    }
     expose_headers  = ["ETag"]   # completeMultipartUpload는 파트 ETag가 필요
     max_age_seconds = 3600
-  }
+  }]
 }
 ```
-> CORS 리소스명/스키마는 사용 중인 cloudflare provider 4.x 실제 버전에 맞춰 확정한다(provider 메이저에 따라 R2 CORS 지원 여부·형식이 다를 수 있어, 미지원 시 R2 대시보드 수동 설정으로 대체하고 그 사실을 문서화).
 > `allowed_origins`는 application.yaml의 `cors.allowed-origins`(현재 localhost 및 운영 프론트 도메인)와 일치시킨다. **ETag expose 필수** — 미설정 시 브라우저가 파트 ETag를 못 읽어 `completeMultipartUpload`가 실패.
 
 ### 3.3 `backend.tf` — R2를 원격 state backend로

--- a/docs/specs/r2-migration-spec.md
+++ b/docs/specs/r2-migration-spec.md
@@ -66,7 +66,10 @@ public S3Client s3Client(AwsCredentialsProvider provider) {
             .region(Region.of(awsS3Properties.getRegion()))
             .credentialsProvider(provider);
     if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
-        builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()));
+        builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build());
     }
     return builder.build();
 }
@@ -77,13 +80,16 @@ public S3Presigner s3Presigner(AwsCredentialsProvider provider) {
             .region(Region.of(awsS3Properties.getRegion()))
             .credentialsProvider(provider);
     if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
-        builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()));
+        builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build());
     }
     return builder.build();
 }
 ```
 
-> **path-style fallback**: R2는 가상호스팅(`https://<bucket>.<account>.r2.cloudflarestorage.com`)을 기본 지원하므로 별도 설정 불필요. 만약 호스트 해석 문제 발생 시 양쪽 builder에 `.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())` 추가.
+> **path-style 필수**: R2의 기본 엔드포인트(`<account>.r2.cloudflarestorage.com`)는 **path-style만 지원**한다. AWS SDK 기본값인 가상 호스트 스타일은 `<bucket>.<account>.r2.cloudflarestorage.com`(2단계 서브도메인)로 요청하는데, 와일드카드 인증서(`*.r2.cloudflarestorage.com`)가 이를 커버하지 못해 SSL 핸드셰이크가 실패한다. 따라서 endpoint가 설정될 때 `S3Client`/`S3Presigner` 양쪽에 `pathStyleAccessEnabled(true)`를 **반드시** 적용한다. (가상 호스트 스타일은 R2에 커스텀 도메인을 연결한 경우에만 가능)
 
 ### 2.3 `application.yaml`
 `src/main/resources/application.yaml` (`aws.s3` 블록)
@@ -93,7 +99,7 @@ aws:
   s3:
     access-key: ${AWS_ACCESS_KEY}      # R2 Access Key ID로 교체
     secret-key: ${AWS_SECRET_KEY}      # R2 Secret Access Key로 교체
-    region: ${AWS_REGION:auto}         # R2는 'auto' (기본값 변경)
+    region: ${AWS_REGION:ap-northeast-2}   # 기본값은 S3 롤백 안전을 위해 유지, R2는 AWS_REGION=auto 주입
     bucket: ${AWS_S3_BUCKET}
     endpoint: ${AWS_S3_ENDPOINT:}      # https://<ACCOUNT_ID>.r2.cloudflarestorage.com
 ```

--- a/scripts/migrate-s3-to-r2.sh
+++ b/scripts/migrate-s3-to-r2.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# AWS S3 -> Cloudflare R2 영상 데이터 전수 마이그레이션 (rclone)
+#
+# 사전 준비:
+#   1) rclone 설치 (https://rclone.org/install/)
+#   2) rclone 리모트 2개 구성 (~/.config/rclone/rclone.conf):
+#
+#      [s3]
+#      type = s3
+#      provider = AWS
+#      access_key_id = <AWS_ACCESS_KEY>
+#      secret_access_key = <AWS_SECRET_KEY>
+#      region = ap-northeast-2
+#
+#      [r2]
+#      type = s3
+#      provider = Cloudflare
+#      access_key_id = <R2_ACCESS_KEY>
+#      secret_access_key = <R2_SECRET_KEY>
+#      endpoint = https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+#      region = auto
+#
+# 사용:
+#   ./scripts/migrate-s3-to-r2.sh <SOURCE_S3_BUCKET> <DEST_R2_BUCKET>
+#
+# 멱등(idempotent): rclone copy 는 동일 객체를 건너뛴다.
+# 운영 전환 직전 동일 명령을 한 번 더 실행해 증분(delta) 재동기화를 권장한다.
+
+set -euo pipefail
+
+SRC_BUCKET="${1:?사용법: $0 <SOURCE_S3_BUCKET> <DEST_R2_BUCKET>}"
+DST_BUCKET="${2:?사용법: $0 <SOURCE_S3_BUCKET> <DEST_R2_BUCKET>}"
+
+echo ">> S3(${SRC_BUCKET}) -> R2(${DST_BUCKET}) 복사 시작"
+rclone copy "s3:${SRC_BUCKET}" "r2:${DST_BUCKET}" \
+  --transfers 16 --checkers 16 --progress
+
+echo ">> 검증: 개수/크기 대조 (one-way)"
+rclone check "s3:${SRC_BUCKET}" "r2:${DST_BUCKET}" --one-way
+
+echo ">> 완료. 운영 전환 직전 본 스크립트를 한 번 더 실행해 증분 재동기화하세요."

--- a/src/main/java/team/startup/gwangjutalentfestival/global/s3/config/AwsS3Config.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/s3/config/AwsS3Config.java
@@ -63,6 +63,12 @@ public class AwsS3Config {
     }
 
     private URI customEndpoint() {
-        return URI.create(awsS3Properties.getEndpoint());
+        URI uri = URI.create(awsS3Properties.getEndpoint());
+        String scheme = uri.getScheme();
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            throw new IllegalStateException(
+                    "aws.s3.endpoint는 http:// 또는 https:// 스키마로 시작해야 합니다: " + awsS3Properties.getEndpoint());
+        }
+        return uri;
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/s3/config/AwsS3Config.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/s3/config/AwsS3Config.java
@@ -20,6 +20,11 @@ import java.net.URI;
 @RequiredArgsConstructor
 public class AwsS3Config {
 
+    // R2 기본 엔드포인트는 path-style만 지원(가상 호스트 스타일은 와일드카드 인증서 미커버로 SSL 실패)
+    private static final S3Configuration PATH_STYLE = S3Configuration.builder()
+            .pathStyleAccessEnabled(true)
+            .build();
+
     private final AwsS3Properties awsS3Properties;
 
     @Bean
@@ -34,12 +39,9 @@ public class AwsS3Config {
         S3ClientBuilder builder = S3Client.builder()
                 .region(Region.of(awsS3Properties.getRegion()))
                 .credentialsProvider(awsCredentialsProvider);
-        if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
-            // R2 기본 엔드포인트는 path-style만 지원(가상 호스트 스타일은 와일드카드 인증서 미커버로 SSL 실패)
-            builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()))
-                    .serviceConfiguration(S3Configuration.builder()
-                            .pathStyleAccessEnabled(true)
-                            .build());
+        if (hasCustomEndpoint()) {
+            builder.endpointOverride(customEndpoint())
+                    .serviceConfiguration(PATH_STYLE);
         }
         return builder.build();
     }
@@ -49,13 +51,18 @@ public class AwsS3Config {
         S3Presigner.Builder builder = S3Presigner.builder()
                 .region(Region.of(awsS3Properties.getRegion()))
                 .credentialsProvider(awsCredentialsProvider);
-        if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
-            // presigned URL도 path-style로 생성되도록 강제(R2 가상 호스트 스타일 미지원)
-            builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()))
-                    .serviceConfiguration(S3Configuration.builder()
-                            .pathStyleAccessEnabled(true)
-                            .build());
+        if (hasCustomEndpoint()) {
+            builder.endpointOverride(customEndpoint())
+                    .serviceConfiguration(PATH_STYLE);
         }
         return builder.build();
+    }
+
+    private boolean hasCustomEndpoint() {
+        return StringUtils.hasText(awsS3Properties.getEndpoint());
+    }
+
+    private URI customEndpoint() {
+        return URI.create(awsS3Properties.getEndpoint());
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/s3/config/AwsS3Config.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/s3/config/AwsS3Config.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import team.startup.gwangjutalentfestival.global.s3.properties.AwsS3Properties;
 
@@ -34,7 +35,11 @@ public class AwsS3Config {
                 .region(Region.of(awsS3Properties.getRegion()))
                 .credentialsProvider(awsCredentialsProvider);
         if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
-            builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()));
+            // R2 기본 엔드포인트는 path-style만 지원(가상 호스트 스타일은 와일드카드 인증서 미커버로 SSL 실패)
+            builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()))
+                    .serviceConfiguration(S3Configuration.builder()
+                            .pathStyleAccessEnabled(true)
+                            .build());
         }
         return builder.build();
     }
@@ -45,7 +50,11 @@ public class AwsS3Config {
                 .region(Region.of(awsS3Properties.getRegion()))
                 .credentialsProvider(awsCredentialsProvider);
         if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
-            builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()));
+            // presigned URL도 path-style로 생성되도록 강제(R2 가상 호스트 스타일 미지원)
+            builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()))
+                    .serviceConfiguration(S3Configuration.builder()
+                            .pathStyleAccessEnabled(true)
+                            .build());
         }
         return builder.build();
     }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/s3/config/AwsS3Config.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/s3/config/AwsS3Config.java
@@ -3,13 +3,17 @@ package team.startup.gwangjutalentfestival.global.s3.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import team.startup.gwangjutalentfestival.global.s3.properties.AwsS3Properties;
+
+import java.net.URI;
 
 @Configuration
 @RequiredArgsConstructor
@@ -26,17 +30,23 @@ public class AwsS3Config {
 
     @Bean
     public S3Client s3Client(AwsCredentialsProvider awsCredentialsProvider) {
-        return S3Client.builder()
+        S3ClientBuilder builder = S3Client.builder()
                 .region(Region.of(awsS3Properties.getRegion()))
-                .credentialsProvider(awsCredentialsProvider)
-                .build();
+                .credentialsProvider(awsCredentialsProvider);
+        if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
+            builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()));
+        }
+        return builder.build();
     }
 
     @Bean
     public S3Presigner s3Presigner(AwsCredentialsProvider awsCredentialsProvider) {
-        return S3Presigner.builder()
+        S3Presigner.Builder builder = S3Presigner.builder()
                 .region(Region.of(awsS3Properties.getRegion()))
-                .credentialsProvider(awsCredentialsProvider)
-                .build();
+                .credentialsProvider(awsCredentialsProvider);
+        if (StringUtils.hasText(awsS3Properties.getEndpoint())) {
+            builder.endpointOverride(URI.create(awsS3Properties.getEndpoint()));
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/s3/properties/AwsS3Properties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/s3/properties/AwsS3Properties.java
@@ -12,4 +12,5 @@ public class AwsS3Properties {
     private String secretKey;
     private String region;
     private String bucket;
+    private String endpoint;
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -111,8 +111,9 @@ aws:
   s3:
     access-key: ${AWS_ACCESS_KEY}
     secret-key: ${AWS_SECRET_KEY}
-    region: ${AWS_REGION:ap-northeast-2}
+    region: ${AWS_REGION:auto}
     bucket: ${AWS_S3_BUCKET}
+    endpoint: ${AWS_S3_ENDPOINT:}
 
 monitoring:
   anomaly:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -111,7 +111,7 @@ aws:
   s3:
     access-key: ${AWS_ACCESS_KEY}
     secret-key: ${AWS_SECRET_KEY}
-    region: ${AWS_REGION:auto}
+    region: ${AWS_REGION:ap-northeast-2}
     bucket: ${AWS_S3_BUCKET}
     endpoint: ${AWS_S3_ENDPOINT:}
 

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,28 @@
+# R2(S3 호환)를 Terraform 원격 state backend로 사용.
+#
+# 사전 준비(부트스트랩, chicken-and-egg):
+#   - state 전용 R2 버킷을 Cloudflare 대시보드에서 먼저 생성해야 한다.
+#   - backend 자격증명은 환경변수로 주입한다:
+#       export AWS_ACCESS_KEY_ID=<R2 Access Key>
+#       export AWS_SECRET_ACCESS_KEY=<R2 Secret>
+#   - 아래 <...> 값을 실제 값으로 치환한 뒤 `terraform init` 실행.
+#
+# R2 호환을 위해 skip_* 옵션과 skip_s3_checksum(terraform 1.6.3+)이 필수.
+terraform {
+  backend "s3" {
+    bucket = "<STATE_BUCKET>"
+    key    = "r2-migration/terraform.tfstate"
+    region = "auto"
+
+    endpoints = {
+      s3 = "https://<ACCOUNT_ID>.r2.cloudflarestorage.com"
+    }
+
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_metadata_api_check     = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4"
+      version = "~> 5"
     }
   }
 }
@@ -15,24 +15,25 @@ provider "cloudflare" {
 
 # 영상 저장용 R2 버킷
 resource "cloudflare_r2_bucket" "video" {
-  account_id = var.account_id
-  name       = var.bucket_name
-  location   = var.location
+  account_id    = var.account_id
+  name          = var.bucket_name
+  location      = var.location
+  storage_class = "Standard"
 }
 
 # 브라우저에서 presigned URL로 직접 파트를 PUT 업로드하기 위한 CORS 설정.
 # completeMultipartUpload가 파트 ETag를 필요로 하므로 ETag expose가 필수.
-resource "cloudflare_r2_bucket_cors_configuration" "video" {
+resource "cloudflare_r2_bucket_cors" "video" {
   account_id  = var.account_id
   bucket_name = cloudflare_r2_bucket.video.name
 
-  rules {
-    allowed {
+  rules = [{
+    allowed = {
       methods = ["GET", "PUT"]
       origins = var.allowed_origins
       headers = ["*"]
     }
     expose_headers  = ["ETag"]
     max_age_seconds = 3600
-  }
+  }]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_version = ">= 1.6.3"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+# 영상 저장용 R2 버킷
+resource "cloudflare_r2_bucket" "video" {
+  account_id = var.account_id
+  name       = var.bucket_name
+  location   = var.location
+}
+
+# 브라우저에서 presigned URL로 직접 파트를 PUT 업로드하기 위한 CORS 설정.
+# completeMultipartUpload가 파트 ETag를 필요로 하므로 ETag expose가 필수.
+resource "cloudflare_r2_bucket_cors_configuration" "video" {
+  account_id  = var.account_id
+  bucket_name = cloudflare_r2_bucket.video.name
+
+  rules {
+    allowed {
+      methods = ["GET", "PUT"]
+      origins = var.allowed_origins
+      headers = ["*"]
+    }
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3600
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "생성된 R2 버킷명. 앱의 AWS_S3_BUCKET에 사용."
+  value       = cloudflare_r2_bucket.video.name
+}
+
+output "endpoint" {
+  description = "R2 S3 호환 엔드포인트. 앱의 AWS_S3_ENDPOINT에 사용."
+  value       = "https://${var.account_id}.r2.cloudflarestorage.com"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,15 @@
+# 실제 값을 채워 terraform.tfvars 로 복사해 사용 (terraform.tfvars 는 .gitignore 처리됨).
+
+cloudflare_api_token = "<CLOUDFLARE_ACCOUNT_R2_ADMIN_TOKEN>"
+account_id           = "<CLOUDFLARE_ACCOUNT_ID>"
+bucket_name          = "gwangjutalentfestival-video"
+location             = "APAC"
+
+allowed_origins = [
+  "http://localhost:3000",
+  "http://localhost:3001",
+  "http://localhost:3002",
+  "http://localhost:3003",
+  "http://localhost:3004",
+  # 운영 프론트엔드 도메인 추가
+]

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -3,7 +3,7 @@
 cloudflare_api_token = "<CLOUDFLARE_ACCOUNT_R2_ADMIN_TOKEN>"
 account_id           = "<CLOUDFLARE_ACCOUNT_ID>"
 bucket_name          = "gwangjutalentfestival-video"
-location             = "APAC"
+location             = "apac"
 
 allowed_origins = [
   "http://localhost:3000",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,26 @@
+variable "cloudflare_api_token" {
+  description = "Cloudflare API 토큰 (계정 레벨 R2 관리 권한). Terraform 전용."
+  type        = string
+  sensitive   = true
+}
+
+variable "account_id" {
+  description = "Cloudflare 계정 ID. R2 엔드포인트(https://<account_id>.r2.cloudflarestorage.com)에 사용."
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "영상 저장용 R2 버킷명."
+  type        = string
+}
+
+variable "location" {
+  description = "R2 버킷 location 힌트."
+  type        = string
+  default     = "APAC"
+}
+
+variable "allowed_origins" {
+  description = "브라우저 직접 업로드(presigned PUT)를 허용할 출처 목록. application.yaml의 cors.allowed-origins와 동기화."
+  type        = list(string)
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,9 +15,14 @@ variable "bucket_name" {
 }
 
 variable "location" {
-  description = "R2 버킷 location 힌트."
+  description = "R2 버킷 location 힌트. provider v5는 소문자만 허용."
   type        = string
-  default     = "APAC"
+  default     = "apac"
+
+  validation {
+    condition     = contains(["apac", "eeur", "enam", "weur", "wnam", "oc"], var.location)
+    error_message = "location은 apac, eeur, enam, weur, wnam, oc 중 하나여야 합니다."
+  }
 }
 
 variable "allowed_origins" {


### PR DESCRIPTION
## ✨ 작업 내용

> S3 전송 OUT(egress) 요금 절감을 위해 영상 스토리지를 **AWS S3 → Cloudflare R2**로 마이그레이션합니다.
> R2는 S3 호환 API라서 **`AwsS3Adapter` 로직은 변경 없이**, 엔드포인트·리전·자격증명 설정만 전환합니다.

| 구분 | 변경 내용 |
|------|-----------|
| **코드** | `AwsS3Properties`에 `endpoint` 필드 추가 / `AwsS3Config`에서 endpoint 설정 시 `endpointOverride` + **path-style** 적용 (빈 값이면 기존 S3로 동작) |
| **설정** | `application.yaml`에 `endpoint` 환경변수 추가 (`region` 기본값은 S3 롤백 안전을 위해 `ap-northeast-2` 유지) |
| **인프라** | Terraform 신규: R2 버킷(`apac`) + CORS + 원격 state backend (cloudflare provider v5) |
| **데이터** | `scripts/migrate-s3-to-r2.sh` (rclone 전수 복사) |
| **문서** | `docs/specs/r2-migration-spec.md` |

핵심 동작: **`AWS_S3_ENDPOINT`가 비면 S3, 채우면 R2** — 환경변수만으로 전환/롤백됩니다.

---

## 🔍 리뷰 시 참고사항

- **path-style 필수** — R2 기본 엔드포인트는 와일드카드 인증서가 가상 호스트 스타일(`<bucket>.<account>...`)을 못 덮어 SSL이 깨집니다. 그래서 `pathStyleAccessEnabled(true)`를 적용했습니다. *(리뷰 반영)*
- **AWS SDK `2.28.0` 고정** — SDK 2.30+는 기본 체크섬 강제로 R2 presigned 업로드가 깨집니다. 업그레이드 시 `requestChecksumCalculation(WHEN_REQUIRED)` 필요.
- **CORS `ETag` expose 필수** — 미설정 시 브라우저가 파트 ETag를 못 읽어 멀티파트 완료가 실패합니다.
- **검증** — 로컬 MinIO로 멀티파트 업로드 → presigned PUT/GET → 한글 파일명 다운로드 → 4xx 예외 매핑까지 E2E 통과. Terraform은 v5 provider로 `validate` 통과. *(실제 R2 최종 확인은 검증 환경에서 1회 예정)*

---

## 🛠 배포 전 해야 할 일 (DevOps)

> ⚠️ 레포 파일 변경만으로는 운영에 반영되지 않습니다. 아래 작업이 별도로 필요합니다.

1. **GitHub Secret 갱신** (`cd.yml`이 주입)
   - `APPLICATION_YML` → `aws.s3.endpoint` 반영
   - `ENV_FILE` → R2 키/시크릿, `AWS_REGION=auto`, `AWS_S3_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com`, `AWS_S3_BUCKET`
2. **Cloudflare 토큰 2종 발급** — Terraform용(계정 R2 관리) / 앱용(버킷 범위 Access Key·Secret)
3. **Terraform state 버킷 사전 생성** (chicken-and-egg) → `backend.tf`의 `<...>` 치환 후 `terraform init`
4. **데이터 마이그레이션** — `scripts/migrate-s3-to-r2.sh` 실행 + 전환 직전 증분 재동기화

<details>
<summary><b>📌 CORS — 등록할 내용 (할 일은 딱 하나)</b></summary>

Terraform `cloudflare_r2_bucket_cors`로 자동 등록됩니다. 아래 규칙은 이미 설정되어 있습니다.

| 항목 | 값 | 이유 |
|------|-----|------|
| origins | 프론트 도메인 (`var.allowed_origins`) | 브라우저 직접 업로드 허용 |
| methods | `GET`, `PUT` | PUT=파트 업로드 / GET=다운로드 |
| headers | `["*"]` | presigned 요청 헤더 허용 |
| **expose_headers** | `["ETag"]` | **멀티파트 완료에 파트 ETag 필요 (핵심)** |
| max_age_seconds | `3600` | preflight 캐시 |

**할 일**: `terraform.tfvars`의 `allowed_origins`에 운영 프론트 도메인만 채우고 `apply`.
```hcl
allowed_origins = [
  "https://<운영-프론트-도메인>",   # ← 이것만 채우면 끝
  "http://localhost:3000",
]
```
</details>

---

## 🖥 프론트엔드 참고

<details>
<summary>펼쳐보기</summary>

- **API 계약(엔드포인트·요청/응답 형식)은 변경 없습니다.** 멀티파트 시작/파트 URL/완료/다운로드 호출 방식 동일.
- presigned URL **도메인이 변경**됩니다: `*.amazonaws.com` → `<account>.r2.cloudflarestorage.com` (path-style 형태). CSP `connect-src` 등에 화이트리스트했다면 R2 도메인 추가 필요.
- 파트 PUT 후 응답의 **`ETag` 헤더를 읽어 완료 요청에 전달**하는 흐름은 기존과 동일 (R2 CORS에 ETag expose 설정됨).
- CORS 허용 origin에 프론트 도메인이 포함돼야 직접 업로드 가능 → 운영 도메인 확정 시 공유 요청.

</details>

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈
- Close #142
