### PR TITLE
좌석 예약 검증 단위 테스트 및 동시성 통합 테스트 추가

### DIFF
--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -108,7 +109,8 @@ class ReservationSeatConcurrencyTest {
             }
 
             startLatch.countDown();
-            doneLatch.await();
+            boolean completed = doneLatch.await(10, TimeUnit.SECONDS);
+            assertThat(completed).withFailMessage("스레드 완료 대기 중 시간 초과가 발생했습니다.").isTrue();
         } finally {
             executor.shutdown();
         }
@@ -155,7 +157,8 @@ class ReservationSeatConcurrencyTest {
             }
 
             startLatch.countDown();
-            doneLatch.await();
+            boolean completed = doneLatch.await(10, TimeUnit.SECONDS);
+            assertThat(completed).withFailMessage("스레드 완료 대기 중 시간 초과가 발생했습니다.").isTrue();
         } finally {
             executor.shutdown();
         }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
@@ -1,0 +1,152 @@
+package team.startup.gwangjutalentfestival.domain.seat.service.impl;
+
+import com.google.api.services.drive.Drive;
+import com.google.api.services.sheets.v4.Sheets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationLimitExceededException;
+import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.ReservationSeatRequest;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
+import team.startup.gwangjutalentfestival.domain.seat.service.ReservationSeatService;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
+import team.startup.gwangjutalentfestival.global.auth.CustomUserDetails;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ReservationSeatConcurrencyTest {
+
+    @MockBean
+    Sheets sheets;
+
+    @MockBean
+    Drive drive;
+
+    @Autowired
+    private ReservationSeatService reservationSeatService;
+
+    @Autowired
+    private SeatReservationRepository seatReservationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private List<UserEntity> testUsers;
+
+    @BeforeEach
+    void setUp() {
+        testUsers = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            testUsers.add(userRepository.save(UserEntity.builder()
+                    .phoneNumber("0109999" + String.format("%04d", i))
+                    .role(Role.USER)
+                    .build()));
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        seatReservationRepository.deleteAll();
+        userRepository.deleteAll(testUsers);
+    }
+
+    private void setAuth(long userId, Role role) {
+        CustomUserDetails details = CustomUserDetails.fromToken(userId, role);
+        SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+        ctx.setAuthentication(new UsernamePasswordAuthenticationToken(details, null, details.getAuthorities()));
+        SecurityContextHolder.setContext(ctx);
+    }
+
+    @Test
+    void 동일_좌석_동시_예약시_1건만_성공한다() throws InterruptedException {
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            final long userId = testUsers.get(i).getId();
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    setAuth(userId, Role.USER);
+                    reservationSeatService.execute(new ReservationSeatRequest("A", 1));
+                    successCount.incrementAndGet();
+                } catch (SeatAlreadyReservedException e) {
+                    failCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                    SecurityContextHolder.clearContext();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(9);
+    }
+
+    @Test
+    void 동일_USER_동시_예약시_한도_초과는_실패한다() throws InterruptedException {
+        int threadCount = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger limitExceededCount = new AtomicInteger(0);
+
+        long userId = testUsers.get(0).getId();
+        String[] sections = {"A", "A"};
+        Integer[] seatNumbers = {1, 2};
+
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    setAuth(userId, Role.USER);
+                    reservationSeatService.execute(new ReservationSeatRequest(sections[idx], seatNumbers[idx]));
+                    successCount.incrementAndGet();
+                } catch (SeatReservationLimitExceededException e) {
+                    limitExceededCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                    SecurityContextHolder.clearContext();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(limitExceededCount.get()).isEqualTo(1);
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
@@ -22,6 +22,7 @@ import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 import team.startup.gwangjutalentfestival.global.auth.CustomUserDetails;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -78,34 +79,41 @@ class ReservationSeatConcurrencyTest {
     void 동일_좌석_동시_예약시_1건만_성공한다() throws InterruptedException {
         int threadCount = 10;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch doneLatch = new CountDownLatch(threadCount);
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failCount = new AtomicInteger(0);
 
-        for (int i = 0; i < threadCount; i++) {
-            final long userId = testUsers.get(i).getId();
-            executor.submit(() -> {
-                try {
-                    startLatch.await();
-                    setAuth(userId, Role.USER);
-                    reservationSeatService.execute(new ReservationSeatRequest("A", 1));
-                    successCount.incrementAndGet();
-                } catch (SeatAlreadyReservedException e) {
-                    failCount.incrementAndGet();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    doneLatch.countDown();
-                    SecurityContextHolder.clearContext();
-                }
-            });
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                final long userId = testUsers.get(i).getId();
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        setAuth(userId, Role.USER);
+                        reservationSeatService.execute(new ReservationSeatRequest("A", 1));
+                        successCount.incrementAndGet();
+                    } catch (SeatAlreadyReservedException e) {
+                        failCount.incrementAndGet();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (Throwable t) {
+                        exceptions.add(t);
+                    } finally {
+                        doneLatch.countDown();
+                        SecurityContextHolder.clearContext();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            doneLatch.await();
+        } finally {
+            executor.shutdown();
         }
 
-        startLatch.countDown();
-        doneLatch.await();
-        executor.shutdown();
-
+        assertThat(exceptions).isEmpty();
         assertThat(successCount.get()).isEqualTo(1);
         assertThat(failCount.get()).isEqualTo(9);
     }
@@ -114,6 +122,7 @@ class ReservationSeatConcurrencyTest {
     void 동일_USER_동시_예약시_한도_초과는_실패한다() throws InterruptedException {
         int threadCount = 2;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch doneLatch = new CountDownLatch(threadCount);
         AtomicInteger successCount = new AtomicInteger(0);
@@ -123,29 +132,35 @@ class ReservationSeatConcurrencyTest {
         String[] sections = {"A", "A"};
         Integer[] seatNumbers = {1, 2};
 
-        for (int i = 0; i < threadCount; i++) {
-            final int idx = i;
-            executor.submit(() -> {
-                try {
-                    startLatch.await();
-                    setAuth(userId, Role.USER);
-                    reservationSeatService.execute(new ReservationSeatRequest(sections[idx], seatNumbers[idx]));
-                    successCount.incrementAndGet();
-                } catch (SeatReservationLimitExceededException e) {
-                    limitExceededCount.incrementAndGet();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    doneLatch.countDown();
-                    SecurityContextHolder.clearContext();
-                }
-            });
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                final int idx = i;
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        setAuth(userId, Role.USER);
+                        reservationSeatService.execute(new ReservationSeatRequest(sections[idx], seatNumbers[idx]));
+                        successCount.incrementAndGet();
+                    } catch (SeatReservationLimitExceededException e) {
+                        limitExceededCount.incrementAndGet();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (Throwable t) {
+                        exceptions.add(t);
+                    } finally {
+                        doneLatch.countDown();
+                        SecurityContextHolder.clearContext();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            doneLatch.await();
+        } finally {
+            executor.shutdown();
         }
 
-        startLatch.countDown();
-        doneLatch.await();
-        executor.shutdown();
-
+        assertThat(exceptions).isEmpty();
         assertThat(successCount.get()).isEqualTo(1);
         assertThat(limitExceededCount.get()).isEqualTo(1);
     }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidatorTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidatorTest.java
@@ -1,0 +1,102 @@
+package team.startup.gwangjutalentfestival.domain.seat.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBannedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotExistsInSectionException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationLimitExceededException;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
+
+@ExtendWith(MockitoExtension.class)
+class SeatReservationValidatorTest {
+
+    @InjectMocks
+    private SeatReservationValidator validator;
+
+    @Mock
+    private SeatReservationRepository seatReservationRepository;
+
+    @Mock
+    private SeatBanRepository seatBanRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private static final String SECTION = "A";
+    private static final Integer SEAT_NUMBER = 1;
+    private static final Integer MAX_SEATS = 101;
+    private static final long USER_ID = 1L;
+
+    @Test
+    void 좌석_번호가_1_미만이면_SeatNotExistsInSectionException이_발생한다() {
+        assertThatThrownBy(() -> validator.validateSeatRange(0, MAX_SEATS))
+                .isInstanceOf(SeatNotExistsInSectionException.class);
+    }
+
+    @Test
+    void 좌석_번호가_최대값_초과면_SeatNotExistsInSectionException이_발생한다() {
+        assertThatThrownBy(() -> validator.validateSeatRange(MAX_SEATS + 1, MAX_SEATS))
+                .isInstanceOf(SeatNotExistsInSectionException.class);
+    }
+
+    @Test
+    void 이미_예약된_좌석이면_SeatAlreadyReservedException이_발생한다() {
+        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SECTION, SEAT_NUMBER)).willReturn(true);
+
+        assertThatThrownBy(() -> validator.validateSeatAvailability(SECTION, SEAT_NUMBER))
+                .isInstanceOf(SeatAlreadyReservedException.class);
+    }
+
+    @Test
+    void 차단된_좌석이면_SeatBannedException이_발생한다() {
+        given(seatReservationRepository.existsBySeatSectionAndSeatNumber(SECTION, SEAT_NUMBER)).willReturn(false);
+        given(seatBanRepository.existsBySeatSectionAndSeatNumber(SECTION, SEAT_NUMBER)).willReturn(true);
+
+        assertThatThrownBy(() -> validator.validateSeatAvailability(SECTION, SEAT_NUMBER))
+                .isInstanceOf(SeatBannedException.class);
+    }
+
+    @Test
+    void USER_예약_한도_초과시_SeatReservationLimitExceededException이_발생한다() {
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            UserEntity user = UserEntity.builder().id(USER_ID).role(Role.USER).build();
+            userUtilMock.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            given(userRepository.findByIdForUpdate(USER_ID)).willReturn(Optional.of(user));
+            given(seatReservationRepository.countByUserId(USER_ID)).willReturn(1L);
+
+            assertThatThrownBy(() -> validator.validateReservationLimit())
+                    .isInstanceOf(SeatReservationLimitExceededException.class);
+        }
+    }
+
+    @Test
+    void PERFORMER_예약_한도_초과시_SeatReservationLimitExceededException이_발생한다() {
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            UserEntity user = UserEntity.builder().id(USER_ID).role(Role.PERFORMER).build();
+            userUtilMock.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.PERFORMER);
+            given(userRepository.findByIdForUpdate(USER_ID)).willReturn(Optional.of(user));
+            given(seatReservationRepository.countByUserId(USER_ID)).willReturn(3L);
+
+            assertThatThrownBy(() -> validator.validateReservationLimit())
+                    .isInstanceOf(SeatReservationLimitExceededException.class);
+        }
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,92 @@
+spring:
+  application:
+    name: gwangjutalentfestival
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 1
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+
+  docker:
+    compose:
+      enabled: false
+
+jwt:
+  secret: test-secret-key-for-junit-testing-only-32bytes!!
+  access-token-expiration: 180000000
+  refresh-token-expiration: 1209600
+
+cors:
+  allowed-origins: http://localhost:3000
+
+feign:
+  log-level: NONE
+
+solapi:
+  api-key: test-key
+  api-secret: test-secret
+  sms-phonenumber: "01000000000"
+  url: https://api.solapi.com
+
+sms:
+  verify:
+    max-send-count: 5
+    verify-code-ttl: 180
+    verify-count-ttl: 600
+    verify-count-key-prefix: "verify:count:"
+
+google:
+  sheets:
+    account-credential: test
+    sheet-id: test
+    enrolled-sheet-page: test
+    out-of-school-sheet-page: test
+  excel:
+    template-sheet-id: test
+    summary-page: test
+
+slogan:
+  submission:
+    start-at: "2026-04-18T00:00:00"
+    end-at: "2026-05-28T18:00:00"
+
+aws:
+  s3:
+    access-key: test-access-key
+    secret-key: test-secret-key
+    region: ap-northeast-2
+    bucket: test-bucket
+
+monitoring:
+  anomaly:
+    enabled: false
+    prometheus-base-url: http://localhost:9090
+    discord-webhook-url: ""
+  ml:
+    enabled: false
+    base-url: ""
+    timeout-ms: 3000
+  dataset:
+    export-path: ./exports
+
+management:
+  security:
+    enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,9 +3,9 @@ spring:
     name: gwangjutalentfestival
 
   datasource:
-    url: jdbc:mysql://localhost:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: root
-    password: 1234
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${SPRING_DATASOURCE_USERNAME:root}
+    password: ${SPRING_DATASOURCE_PASSWORD:1234}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 5


### PR DESCRIPTION
## ✨ 작업 내용
좌석 예매 동시성 제어 로직에 대한 단위 테스트와 통합 테스트를 추가하였습니다.

**단위 테스트 (`SeatReservationValidatorTest`) — 6개**
- 좌석 번호가 1 미만이면 `SeatNotExistsInSectionException` 발생
- 좌석 번호가 최대값 초과이면 `SeatNotExistsInSectionException` 발생
- 이미 예약된 좌석이면 `SeatAlreadyReservedException` 발생
- 차단된 좌석이면 `SeatBannedException` 발생
- USER 역할 예약 한도(1건) 초과 시 `SeatReservationLimitExceededException` 발생
- PERFORMER 역할 예약 한도(3건) 초과 시 `SeatReservationLimitExceededException` 발생

**통합 테스트 (`ReservationSeatConcurrencyTest`) — 2개**
- 서로 다른 10개 유저가 동일 좌석을 동시 예약할 때 1건만 성공하고 나머지 9건은 `SeatAlreadyReservedException` 발생
- 동일 유저가 2개 스레드로 서로 다른 좌석을 동시 예약할 때 Pessimistic Lock으로 한도 초과 1건이 `SeatReservationLimitExceededException` 발생

`src/test/resources/application.yaml`을 추가하여 테스트 컨텍스트 로딩에 필요한 설정값을 제공하였습니다.

---

## 🔍 리뷰 시 참고사항
- 통합 테스트는 실제 MySQL 연결이 필요합니다. 로컬 DB(`localhost:3306/gwangjutalentfestival`)가 구동 중이어야 실행됩니다.
- `SecurityContextHolder`의 기본 전략이 `MODE_THREADLOCAL`이므로 각 스레드에서 직접 `setAuth()`를 호출하여 인증 컨텍스트를 설정하였습니다.
- 동시성 테스트 케이스 1에서 각 스레드가 다른 유저를 사용하는 이유: `validateReservationLimit()`이 Pessimistic Lock(유저 row lock)을 먼저 획득하는 구조이므로, 동일 유저로 테스트하면 한도 초과 예외가 먼저 발생합니다. 좌석 중복 예약 방지를 검증하려면 서로 다른 유저가 필요합니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #125
