### PR TITLE
fix :: application.yaml bad substitution 오류 수정

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -23,9 +23,11 @@ jobs:
         run: chmod +x gradlew
 
       - name: Create application.yaml
+        env:
+          APPLICATION_YML: ${{ secrets.APPLICATION_YML_DEV }}
         run: |
           mkdir -p src/main/resources
-          echo "${{ secrets.APPLICATION_YML_DEV }}" > src/main/resources/application.yaml
+          printf '%s' "$APPLICATION_YML" > src/main/resources/application.yaml
 
       - name: Build with Gradle
         run: ./gradlew build -x test --no-daemon


### PR DESCRIPTION
## Summary

- `echo` 인라인 방식으로 secret을 주입할 때 YAML 내 `${VAR:default}` 패턴을 bash가 변수 치환으로 해석해 `bad substitution` 오류 발생
- `env:` 블록으로 분리 후 `printf '%s'`로 쓰도록 수정

## Test plan

- [ ] develop 머지 후 `CD (develop)` 워크플로우 `Create application.yaml` 단계 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)