### PR TITLE
fix :: mysql 헬스체크 CMD-SHELL로 변경 및 start_period 추가

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -30,7 +30,7 @@ jobs:
           printf '%s' "$APPLICATION_YML" > src/main/resources/application.yaml
 
       - name: Build with Gradle
-        run: ./gradlew build -x test --no-daemon
+        run: ./gradlew clean build -x test --no-daemon
 
       - name: Build Docker image
         run: docker build -t gwangju-festival:dev .

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,10 +23,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Create application.yml
+      - name: Create application.yaml
+        env:
+          APPLICATION_YML: ${{ secrets.APPLICATION_YML }}
         run: |
           mkdir -p src/main/resources
-          echo "${{ secrets.APPLICATION_YML }}" > src/main/resources/application.yml
+          printf '%s' "$APPLICATION_YML" > src/main/resources/application.yaml
 
       - name: Build with Gradle
         run: ./gradlew build -x test --no-daemon

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,10 +27,11 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$$MYSQL_ROOT_PASSWORD"]
       interval: 10s
       timeout: 5s
       retries: 10
+      start_period: 40s
     restart: always
 
   redis:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,7 @@ services:
     environment:
       REDIS_HOST: redis
       DB_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      SPRING_DOCKER_COMPOSE_ENABLED: "false"
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- MySQL 헬스체크 `CMD` → `CMD-SHELL` 변경 (`$MYSQL_ROOT_PASSWORD` 환경변수 정상 확장)
- `start_period: 40s` 추가 (첫 부팅 시 MySQL 초기화 완료 후 헬스체크 시작)

## Test plan

- [ ] develop 머지 후 `CD (develop)` 워크플로우에서 mysql-dev 컨테이너 healthy 상태 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)