### PR TITLE
apply 멀티파트 업로드 검증 로그 추가 및 ftyp box 탐색 방식 개선

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/apply/service/impl/ApplyServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/apply/service/impl/ApplyServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.List;
 public class ApplyServiceImpl implements ApplyService {
 
     private static final int MP4_HEADER_LENGTH = 12;
+    private static final int MP4_VALIDATION_HEADER_LENGTH = 1024;
     private static final String MP4_EXTENSION = ".mp4";
     private static final String DEFAULT_FILENAME = "video.mp4";
     private static final int MAX_FILENAME_LENGTH = 255;
@@ -114,7 +115,7 @@ public class ApplyServiceImpl implements ApplyService {
     }
 
     private void validateUploadedMp4(String key) {
-        byte[] header = awsS3Adapter.readObjectHead(key, MP4_HEADER_LENGTH);
+        byte[] header = awsS3Adapter.readObjectHead(key, MP4_VALIDATION_HEADER_LENGTH);
         log.info("[apply] MP4 헤더 읽기 완료: key={}, headerLength={}", key, header.length);
         if (header.length < MP4_HEADER_LENGTH) {
             log.warn("[apply] validateUploadedMp4 실패: 헤더 길이 부족 (읽은 길이={}, 필요={}) key={}", header.length, MP4_HEADER_LENGTH, key);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/apply/service/impl/ApplyServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/apply/service/impl/ApplyServiceImpl.java
@@ -133,7 +133,12 @@ public class ApplyServiceImpl implements ApplyService {
     }
 
     private boolean isMp4Header(byte[] header) {
-        // ftyp box: offset 4~7 == 0x66 0x74 0x79 0x70
-        return header[4] == 0x66 && header[5] == 0x74 && header[6] == 0x79 && header[7] == 0x70;
+        // ftyp box가 항상 offset 4에 있지 않을 수 있으므로 범위 내에서 탐색한다.
+        for (int i = 4; i <= header.length - 4; i++) {
+            if (header[i] == 0x66 && header[i + 1] == 0x74 && header[i + 2] == 0x79 && header[i + 3] == 0x70) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/apply/service/impl/ApplyServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/apply/service/impl/ApplyServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.gwangjutalentfestival.domain.apply.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
@@ -17,6 +18,7 @@ import team.startup.gwangjutalentfestival.global.s3.exception.InvalidVideoFileEx
 import java.util.Comparator;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ApplyServiceImpl implements ApplyService {
@@ -55,10 +57,24 @@ public class ApplyServiceImpl implements ApplyService {
     }
 
     private void validateRequest(ApplyCompleteRequest request) {
-        if (request == null || ApplyVideoKey.isInvalid(request.key())
-                || request.uploadId() == null || request.uploadId().isBlank()
-                || request.parts() == null || request.parts().isEmpty()
-                || hasInvalidPart(request.parts())) {
+        if (request == null) {
+            log.warn("[apply] validateRequest 실패: request가 null");
+            throw new InvalidVideoFileException();
+        }
+        if (ApplyVideoKey.isInvalid(request.key())) {
+            log.warn("[apply] validateRequest 실패: 잘못된 key={}", request.key());
+            throw new InvalidVideoFileException();
+        }
+        if (request.uploadId() == null || request.uploadId().isBlank()) {
+            log.warn("[apply] validateRequest 실패: uploadId가 null 또는 빈 값, key={}", request.key());
+            throw new InvalidVideoFileException();
+        }
+        if (request.parts() == null || request.parts().isEmpty()) {
+            log.warn("[apply] validateRequest 실패: parts가 null 또는 비어있음, key={}", request.key());
+            throw new InvalidVideoFileException();
+        }
+        if (hasInvalidPart(request.parts())) {
+            log.warn("[apply] validateRequest 실패: 유효하지 않은 part 존재, key={}, parts={}", request.key(), request.parts());
             throw new InvalidVideoFileException();
         }
     }
@@ -99,9 +115,21 @@ public class ApplyServiceImpl implements ApplyService {
 
     private void validateUploadedMp4(String key) {
         byte[] header = awsS3Adapter.readObjectHead(key, MP4_HEADER_LENGTH);
-        if (header.length < MP4_HEADER_LENGTH || !isMp4Header(header)) {
+        log.info("[apply] MP4 헤더 읽기 완료: key={}, headerLength={}", key, header.length);
+        if (header.length < MP4_HEADER_LENGTH) {
+            log.warn("[apply] validateUploadedMp4 실패: 헤더 길이 부족 (읽은 길이={}, 필요={}) key={}", header.length, MP4_HEADER_LENGTH, key);
             throw new InvalidVideoFileException();
         }
+        if (!isMp4Header(header)) {
+            log.warn("[apply] validateUploadedMp4 실패: ftyp box 불일치, key={}, offset4-7=[{}, {}, {}, {}]",
+                    key,
+                    String.format("0x%02X", header[4]),
+                    String.format("0x%02X", header[5]),
+                    String.format("0x%02X", header[6]),
+                    String.format("0x%02X", header[7]));
+            throw new InvalidVideoFileException();
+        }
+        log.info("[apply] MP4 헤더 검증 성공: key={}", key);
     }
 
     private boolean isMp4Header(byte[] header) {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/s3/adapter/AwsS3Adapter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/s3/adapter/AwsS3Adapter.java
@@ -102,6 +102,7 @@ public class AwsS3Adapter {
         } catch (S3Exception e) {
             // 잘못된 uploadId·ETag 등 클라이언트 요청 오류(4xx)는 400으로 처리한다.
             if (e.statusCode() >= 400 && e.statusCode() < 500) {
+                log.warn("[s3] completeMultipartUpload 4xx 오류: key={}, status={}, message={}", key, e.statusCode(), e.getMessage());
                 throw new InvalidVideoFileException();
             }
             throw new S3MultipartException();


### PR DESCRIPTION
## ✨ 작업 내용
> apply 멀티파트 업로드 완료 API에서 발생하는 검증 실패 원인을 추적할 수 있도록 로그를 추가하였습니다. 또한 일부 MP4 파일에서 ftyp box가 offset 4 이외의 위치에 존재하는 경우 검증에 실패하는 버그를 수정하였습니다.

- `validateRequest`: 각 실패 조건(key, uploadId, parts)별로 분리하여 원인을 특정할 수 있도록 warn 로그를 추가하였습니다.
- `validateUploadedMp4`: R2에서 읽은 헤더 바이트 및 ftyp box 불일치 시 실제 hex 값을 로그로 출력하도록 하였습니다.
- `AwsS3Adapter.completeMultipartUpload`: R2가 4xx를 반환할 경우 status code와 message를 warn 로그로 출력하도록 추가하였습니다.
- `isMp4Header`: ftyp box를 offset 4 고정이 아닌 범위 탐색 방식으로 변경하여, 다양한 인코딩 방식의 MP4 파일을 수용하도록 수정하였습니다.

---

## 🔍 리뷰 시 참고사항
- 표준 MP4는 첫 번째 box가 `ftyp`이지만, iOS MOV → mp4 변환, 영상 편집 후 export, 일부 안드로이드 녹화 파일은 `free`, `wide`, `mdat` 등의 box가 먼저 등장하여 ftyp가 offset 4 이외의 위치에 있을 수 있습니다.
- 기존에는 ETag 형식 오류 등으로 R2가 4xx를 반환해도 로그 없이 400만 응답되어 원인 파악이 불가능하였습니다. 이번 변경으로 서버 로그만으로 원인을 특정할 수 있게 되었습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #
