### PR TITLE
개발 환경 compose 네트워크 설정 및 CD 배포 방식 수정

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -42,8 +42,19 @@ jobs:
 
       - name: Deploy with Docker Compose
         run: |
-          docker compose -f docker-compose.dev.yml --env-file .env down --remove-orphans
+          docker rm -f spring-app-dev mysql-dev redis-dev prometheus-dev grafana-dev || true
           docker compose -f docker-compose.dev.yml --env-file .env up -d
+          docker rm -f spring-app-dev || true
+          docker run -d \
+            --name spring-app-dev \
+            --restart always \
+            --network gwangjutalentfestival_default \
+            --env-file .env \
+            -e DB_URL="jdbc:mysql://mysql:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8" \
+            -e REDIS_HOST=redis \
+            -e SPRING_DOCKER_COMPOSE_ENABLED=false \
+            -p 8080:8080 \
+            gwangju-festival:dev
 
       - name: Notify Discord on success
         if: success()

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:8.0
     container_name: mysql
     environment:
-      MYSQL_DATABASE: ${DB_NAME:-}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-}
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-}
     ports:
       - "3306:3306"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:8.0
     container_name: mysql
     environment:
-      MYSQL_DATABASE: gwangjutalentfestival
+      MYSQL_DATABASE: ${DB_NAME:-}
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-}
     ports:
       - "3306:3306"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
     container_name: mysql
     environment:
       MYSQL_DATABASE: gwangjutalentfestival
-      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-}
     ports:
       - "3306:3306"
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,28 +1,12 @@
-services:
-  app:
-    image: gwangju-festival:dev
-    container_name: spring-app-dev
-    ports:
-      - "8080:8080"
-    env_file:
-      - ./.env
-    environment:
-      REDIS_HOST: redis
-      DB_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-      SPRING_DOCKER_COMPOSE_ENABLED: "false"
-    depends_on:
-      mysql:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    restart: always
+name: gwangjutalentfestival
 
+services:
   mysql:
     image: mysql:8.0
-    container_name: mysql-dev
+    container_name: mysql
     environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: gwangjutalentfestival
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
     ports:
       - "3306:3306"
     volumes:
@@ -37,7 +21,7 @@ services:
 
   redis:
     image: redis:7.4
-    container_name: redis-dev
+    container_name: redis
     ports:
       - "6379:6379"
     healthcheck:
@@ -49,7 +33,7 @@ services:
 
   prometheus:
     image: prom/prometheus:v3.1.0
-    container_name: prometheus-dev
+    container_name: prometheus
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
@@ -59,7 +43,7 @@ services:
 
   grafana:
     image: grafana/grafana:11.5.1
-    container_name: grafana-dev
+    container_name: grafana
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

개발 환경 배포 시 Spring App 컨테이너가 인프라 컨테이너(MySQL, Redis 등)와 올바르게 연결되지 않는 문제를 수정하였습니다.

`docker-compose.dev.yml`에서 Spring App 서비스를 분리하고, CD 워크플로우에서 `docker run`으로 직접 실행하도록 변경하였습니다. 또한 compose 프로젝트 이름을 명시하여 네트워크 이름을 고정하였습니다.

**변경 사항**
- `docker-compose.dev.yml`: 프로젝트 이름 `gwangjutalentfestival` 명시, Spring App 서비스 제거, 컨테이너 이름 단순화 (`mysql-dev` → `mysql` 등)
- `.github/workflows/cd-develop.yml`: `docker compose down` 대신 컨테이너 이름 기반 강제 삭제로 변경, Spring App을 `docker run`으로 직접 실행

---

## 🔍 리뷰 시 참고사항
- 리뷰어가 알면 좋은 변경 이유, 배경, 고려했던 점 등을 적어주세요.

기존에는 `docker compose down --remove-orphans` 사용 시 MySQL, Redis 등 인프라 컨테이너까지 함께 내려가는 문제가 있었습니다. Spring App을 compose에서 분리하여 인프라와 독립적으로 재배포할 수 있도록 하였습니다.

Spring App 실행 시 `--network gwangjutalentfestival_default`를 명시하여 compose로 구성된 인프라 컨테이너와 동일한 네트워크에 연결되도록 하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #148
