### PR TITLE
JaCoCo 코드 커버리지 및 Codecov 연동 설정 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,13 @@ jobs:
           GOOGLE_EXCEL_TEMPLATE_SHEET_ID: "test"
           GOOGLE_EXCEL_SUMMARY_PAGE: "0"
         run: ./gradlew clean build
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: build/reports/jacoco/test/jacocoTestReport.xml
+          flags: backend
+          name: gwangju-talent-festival-server
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true

--- a/build.gradle
+++ b/build.gradle
@@ -120,4 +120,11 @@ tasks.named('jacocoTestReport') {
         html.required = true
         csv.required = false
     }
+
+    classDirectories.setFrom(files(classDirectories.files.collect {
+        fileTree(dir: it, exclude: [
+            "**/Q*",
+            "**/*Application*"
+        ])
+    }))
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.5.11'
     id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -16,6 +17,10 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+}
+
+jacoco {
+    toolVersion = '0.8.13'
 }
 
 configurations {
@@ -104,4 +109,15 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy tasks.named('jacocoTestReport')
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn tasks.named('test')
+
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
 }


### PR DESCRIPTION
## ✨ 작업 내용
JaCoCo 플러그인을 `build.gradle`에 추가하여 테스트 실행 후 XML/HTML 형식의 커버리지 리포트가 자동 생성되도록 설정하였습니다.
또한 CI 워크플로우에 `codecov/codecov-action@v5` 스텝을 추가하여 JaCoCo 리포트가 Codecov로 자동 업로드되도록 연동하였습니다.

---

## 🔍 리뷰 시 참고사항
- `build.gradle`에 `jacoco` 플러그인(버전 0.8.13)을 추가하고, `test` 태스크가 완료되면 `jacocoTestReport`가 자동 실행되도록 설정하였습니다.
- XML 리포트를 필수로 활성화하여 Codecov가 파싱할 수 있도록 하였으며, HTML 리포트도 함께 생성되도록 하였습니다.
- CI에서 `CODECOV_TOKEN` 시크릿을 통해 인증하며, `fail_ci_if_error: false`로 설정하여 Codecov 업로드 실패 시에도 CI가 중단되지 않도록 하였습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #147
