### PR TITLE
 심사위원 필기 코멘트 저장/조회 API 추가

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgeCommentEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgeCommentEntity.java
@@ -1,0 +1,46 @@
+package team.startup.gwangjutalentfestival.domain.judge.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+
+/**
+ * 심사위원의 필기 코멘트(stroke 데이터)를 저장하는 엔티티.
+ * strokes는 프론트엔드가 정의한 JSON 구조를 그대로 문자열로 저장하며,
+ * (team_id, user_id) 조합에 유니크 제약이 적용된다.
+ */
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(
+        name = "judge_comment",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"team_id", "user_id"})
+        }
+)
+public class JudgeCommentEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "strokes", columnDefinition = "JSON", nullable = false)
+    private String strokes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "team_id", nullable = false)
+    private TeamEntity team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/controller/JudgeController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/controller/JudgeController.java
@@ -11,11 +11,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeCommentRequest;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgementScoreRequest;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeCommentResponse;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgementResponse;
 import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeEventService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetAllJudgementService;
+import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeCommentService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgementService;
+import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgeCommentService;
 import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgementScoreService;
 
 import java.util.List;
@@ -34,6 +38,8 @@ public class JudgeController {
     private final GetAllJudgementService getAllJudgementService;
     private final GetJudgementService getJudgementService;
     private final ConnectSseJudgeEventService connectSseJudgeEventService;
+    private final GetJudgeCommentService getJudgeCommentService;
+    private final SaveJudgeCommentService saveJudgeCommentService;
 
     @Operation(summary = "SSE 연결", description = "심사 이벤트 수신을 위한 SSE 연결을 맺습니다.")
     @ApiResponses({
@@ -103,5 +109,45 @@ public class JudgeController {
     public ResponseEntity<GetJudgementResponse> getJudgement(
             @Parameter(description = "팀 ID", required = true) @PathVariable Long teamId) {
         return ResponseEntity.ok(getJudgementService.execute(teamId));
+    }
+
+    @Operation(summary = "필기 코멘트 조회", description = "특정 팀에 대한 현재 심사위원의 필기 코멘트를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "팀을 찾을 수 없음")
+    })
+    /**
+     * 현재 로그인한 심사위원의 특정 팀 필기 코멘트를 조회한다.
+     *
+     * @param teamId 조회할 팀 ID
+     * @return 필기 코멘트 응답
+     */
+    @SecurityRequirement(name = "Authorization")
+    @GetMapping("/{teamId}/comment")
+    public ResponseEntity<GetJudgeCommentResponse> getJudgeComment(
+            @Parameter(description = "팀 ID", required = true) @PathVariable Long teamId) {
+        return ResponseEntity.ok(getJudgeCommentService.execute(teamId));
+    }
+
+    @Operation(summary = "필기 코멘트 저장", description = "특정 팀에 대한 필기 코멘트를 저장하거나 덮어씁니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "저장 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "팀을 찾을 수 없음")
+    })
+    /**
+     * 특정 팀에 대한 필기 코멘트를 저장하거나 덮어쓴다.
+     *
+     * @param teamId  대상 팀 ID
+     * @param request 필기 코멘트 요청 데이터
+     * @return 204 No Content
+     */
+    @SecurityRequirement(name = "Authorization")
+    @PutMapping("/{teamId}/comment")
+    public ResponseEntity<Void> saveJudgeComment(
+            @PathVariable Long teamId,
+            @RequestBody @Valid SaveJudgeCommentRequest request) {
+        saveJudgeCommentService.execute(request, teamId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgeCommentRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgeCommentRequest.java
@@ -1,0 +1,9 @@
+package team.startup.gwangjutalentfestival.domain.judge.presentation.data.request;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import jakarta.validation.constraints.NotNull;
+
+public record SaveJudgeCommentRequest(
+        @NotNull ArrayNode strokes
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/GetJudgeCommentResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/GetJudgeCommentResponse.java
@@ -1,0 +1,9 @@
+package team.startup.gwangjutalentfestival.domain.judge.presentation.data.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record GetJudgeCommentResponse(
+        Long teamId,
+        JsonNode strokes
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgeCommentRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgeCommentRepository.java
@@ -21,7 +21,7 @@ public interface JudgeCommentRepository extends JpaRepository<JudgeCommentEntity
     @Query(value = """
             INSERT INTO judge_comment (team_id, user_id, strokes)
             VALUES (:teamId, :userId, :strokes)
-            ON DUPLICATE KEY UPDATE strokes = VALUES(strokes)
+            ON DUPLICATE KEY UPDATE strokes = :strokes
             """, nativeQuery = true)
     void upsert(@Param("teamId") Long teamId, @Param("userId") Long userId, @Param("strokes") String strokes);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgeCommentRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgeCommentRepository.java
@@ -1,0 +1,27 @@
+package team.startup.gwangjutalentfestival.domain.judge.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeCommentEntity;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+
+import java.util.Optional;
+
+public interface JudgeCommentRepository extends JpaRepository<JudgeCommentEntity, Long> {
+    Optional<JudgeCommentEntity> findByTeamAndUser(TeamEntity team, UserEntity user);
+
+    /**
+     * (team_id, user_id) 유니크 제약을 이용한 원자적 upsert.
+     * 동시에 같은 팀/심사위원 조합으로 첫 저장이 들어와도 유니크 제약 위반 없이 하나만 반영된다.
+     */
+    @Modifying
+    @Query(value = """
+            INSERT INTO judge_comment (team_id, user_id, strokes)
+            VALUES (:teamId, :userId, :strokes)
+            ON DUPLICATE KEY UPDATE strokes = VALUES(strokes)
+            """, nativeQuery = true)
+    void upsert(@Param("teamId") Long teamId, @Param("userId") Long userId, @Param("strokes") String strokes);
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentService.java
@@ -1,0 +1,7 @@
+package team.startup.gwangjutalentfestival.domain.judge.service;
+
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeCommentResponse;
+
+public interface GetJudgeCommentService {
+    GetJudgeCommentResponse execute(Long teamId);
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentService.java
@@ -1,0 +1,7 @@
+package team.startup.gwangjutalentfestival.domain.judge.service;
+
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeCommentRequest;
+
+public interface SaveJudgeCommentService {
+    void execute(SaveJudgeCommentRequest request, Long teamId);
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeCommentServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeCommentServiceImpl.java
@@ -1,0 +1,52 @@
+package team.startup.gwangjutalentfestival.domain.judge.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeCommentResponse;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeCommentService;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundException;
+import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+/**
+ * {@link GetJudgeCommentService} 구현체.
+ * 특정 팀에 대한 현재 심사위원의 필기 코멘트를 조회하여 반환한다.
+ * strokes 구조는 해석하지 않고 저장된 JSON을 그대로 반환한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class GetJudgeCommentServiceImpl implements GetJudgeCommentService {
+    private final UserUtil userUtil;
+    private final TeamRepository teamRepository;
+    private final JudgeCommentRepository judgeCommentRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public GetJudgeCommentResponse execute(Long teamId) {
+        UserEntity user = userUtil.getCurrentUser();
+        TeamEntity team = teamRepository.findById(teamId)
+                .orElseThrow(TeamNotFoundException::new);
+
+        JsonNode strokes = judgeCommentRepository.findByTeamAndUser(team, user)
+                .map(comment -> readTree(comment.getStrokes()))
+                .orElseGet(objectMapper::createArrayNode);
+
+        return new GetJudgeCommentResponse(teamId, strokes);
+    }
+
+    private JsonNode readTree(String strokes) {
+        try {
+            return objectMapper.readTree(strokes);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("저장된 strokes 데이터가 올바른 JSON 형식이 아닙니다.", e);
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeCommentServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeCommentServiceImpl.java
@@ -31,7 +31,7 @@ public class GetJudgeCommentServiceImpl implements GetJudgeCommentService {
     @Override
     @Transactional(readOnly = true)
     public GetJudgeCommentResponse execute(Long teamId) {
-        UserEntity user = userUtil.getCurrentUser();
+        UserEntity user = userUtil.getCurrentUserRef();
         TeamEntity team = teamRepository.findById(teamId)
                 .orElseThrow(TeamNotFoundException::new);
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgeCommentServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgeCommentServiceImpl.java
@@ -32,7 +32,7 @@ public class SaveJudgeCommentServiceImpl implements SaveJudgeCommentService {
     @Override
     @Transactional
     public void execute(SaveJudgeCommentRequest request, Long teamId) {
-        UserEntity user = userUtil.getCurrentUser();
+        UserEntity user = userUtil.getCurrentUserRef();
         TeamEntity team = teamRepository.findById(teamId)
                 .orElseThrow(TeamNotFoundException::new);
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgeCommentServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgeCommentServiceImpl.java
@@ -1,0 +1,51 @@
+package team.startup.gwangjutalentfestival.domain.judge.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeCommentRequest;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgeCommentService;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundException;
+import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+/**
+ * {@link SaveJudgeCommentService} 구현체.
+ * 특정 팀에 대한 현재 심사위원의 필기 코멘트를 저장하거나 덮어쓴다(upsert).
+ * strokes 구조는 해석하지 않고 전달받은 JSON을 그대로 직렬화하여 저장한다.
+ * <p>필기 autosave 특성상 같은 팀/심사위원 조합으로 저장 요청이 동시에 들어올 수 있어,
+ * 조회 후 분기하는 대신 DB의 유니크 제약을 이용한 원자적 upsert 쿼리를 사용한다.</p>
+ */
+@Service
+@RequiredArgsConstructor
+public class SaveJudgeCommentServiceImpl implements SaveJudgeCommentService {
+    private final UserUtil userUtil;
+    private final TeamRepository teamRepository;
+    private final JudgeCommentRepository judgeCommentRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional
+    public void execute(SaveJudgeCommentRequest request, Long teamId) {
+        UserEntity user = userUtil.getCurrentUser();
+        TeamEntity team = teamRepository.findById(teamId)
+                .orElseThrow(TeamNotFoundException::new);
+
+        String strokes = writeValueAsString(request.strokes());
+
+        judgeCommentRepository.upsert(team.getId(), user.getId(), strokes);
+    }
+
+    private String writeValueAsString(Object strokes) {
+        try {
+            return objectMapper.writeValueAsString(strokes);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("strokes 데이터를 직렬화할 수 없습니다.", e);
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentServiceTest.java
@@ -78,7 +78,7 @@ class GetJudgeCommentServiceTest {
                 .user(user)
                 .build();
 
-        given(userUtil.getCurrentUser()).willReturn(user);
+        given(userUtil.getCurrentUserRef()).willReturn(user);
         given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
         given(judgeCommentRepository.findByTeamAndUser(team, user)).willReturn(Optional.of(comment));
 
@@ -90,7 +90,7 @@ class GetJudgeCommentServiceTest {
 
     @Test
     void 코멘트가_없으면_빈_배열이_반환된다() {
-        given(userUtil.getCurrentUser()).willReturn(user);
+        given(userUtil.getCurrentUserRef()).willReturn(user);
         given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
         given(judgeCommentRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
 
@@ -103,7 +103,7 @@ class GetJudgeCommentServiceTest {
 
     @Test
     void 존재하지_않는_팀이면_TeamNotFoundException이_발생한다() {
-        given(userUtil.getCurrentUser()).willReturn(user);
+        given(userUtil.getCurrentUserRef()).willReturn(user);
         given(teamRepository.findById(NOT_FOUND_TEAM_ID)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> getJudgeCommentService.execute(NOT_FOUND_TEAM_ID))

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentServiceTest.java
@@ -1,0 +1,112 @@
+package team.startup.gwangjutalentfestival.domain.judge.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeCommentEntity;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeCommentResponse;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.service.impl.GetJudgeCommentServiceImpl;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.team.enums.TeamGenre;
+import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
+import team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundException;
+import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GetJudgeCommentServiceTest {
+
+    private static final Long TEAM_ID = 1L;
+    private static final Long NOT_FOUND_TEAM_ID = 99L;
+
+    @Mock
+    private UserUtil userUtil;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private JudgeCommentRepository judgeCommentRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private GetJudgeCommentServiceImpl getJudgeCommentService;
+
+    private UserEntity user;
+    private TeamEntity team;
+
+    @BeforeEach
+    void setUp() {
+        getJudgeCommentService = new GetJudgeCommentServiceImpl(
+                userUtil, teamRepository, judgeCommentRepository, objectMapper);
+
+        user = UserEntity.builder()
+                .id(1L)
+                .role(Role.ADMIN)
+                .build();
+
+        team = TeamEntity.builder()
+                .id(TEAM_ID)
+                .teamName("팀A")
+                .school("광주고")
+                .teamStatus(TeamStatus.PENDING)
+                .teamGenre(TeamGenre.SING)
+                .performOrder(1)
+                .totalScore(50)
+                .build();
+    }
+
+    @Test
+    void 코멘트가_있으면_저장된_strokes가_반환된다() {
+        JudgeCommentEntity comment = JudgeCommentEntity.builder()
+                .id(10L)
+                .strokes("[{\"x\":1,\"y\":2}]")
+                .team(team)
+                .user(user)
+                .build();
+
+        given(userUtil.getCurrentUser()).willReturn(user);
+        given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
+        given(judgeCommentRepository.findByTeamAndUser(team, user)).willReturn(Optional.of(comment));
+
+        GetJudgeCommentResponse response = getJudgeCommentService.execute(TEAM_ID);
+
+        assertThat(response.teamId()).isEqualTo(TEAM_ID);
+        assertThat(response.strokes().get(0).get("x").asInt()).isEqualTo(1);
+    }
+
+    @Test
+    void 코멘트가_없으면_빈_배열이_반환된다() {
+        given(userUtil.getCurrentUser()).willReturn(user);
+        given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
+        given(judgeCommentRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
+
+        GetJudgeCommentResponse response = getJudgeCommentService.execute(TEAM_ID);
+
+        JsonNode strokes = response.strokes();
+        assertThat(strokes.isArray()).isTrue();
+        assertThat(strokes).isEmpty();
+    }
+
+    @Test
+    void 존재하지_않는_팀이면_TeamNotFoundException이_발생한다() {
+        given(userUtil.getCurrentUser()).willReturn(user);
+        given(teamRepository.findById(NOT_FOUND_TEAM_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> getJudgeCommentService.execute(NOT_FOUND_TEAM_ID))
+                .isInstanceOf(TeamNotFoundException.class);
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentServiceTest.java
@@ -1,0 +1,100 @@
+package team.startup.gwangjutalentfestival.domain.judge.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeCommentRequest;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.service.impl.SaveJudgeCommentServiceImpl;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.team.enums.TeamGenre;
+import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
+import team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundException;
+import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SaveJudgeCommentServiceTest {
+
+    private static final Long TEAM_ID = 1L;
+    private static final Long USER_ID = 1L;
+    private static final Long NOT_FOUND_TEAM_ID = 99L;
+
+    @Mock
+    private UserUtil userUtil;
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private JudgeCommentRepository judgeCommentRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private SaveJudgeCommentServiceImpl saveJudgeCommentService;
+
+    private UserEntity user;
+    private TeamEntity team;
+    private SaveJudgeCommentRequest request;
+
+    @BeforeEach
+    void setUp() {
+        saveJudgeCommentService = new SaveJudgeCommentServiceImpl(
+                userUtil, teamRepository, judgeCommentRepository, objectMapper);
+
+        user = UserEntity.builder()
+                .id(USER_ID)
+                .role(Role.ADMIN)
+                .build();
+
+        team = TeamEntity.builder()
+                .id(TEAM_ID)
+                .teamName("팀A")
+                .school("광주고")
+                .teamStatus(TeamStatus.PENDING)
+                .teamGenre(TeamGenre.SING)
+                .performOrder(1)
+                .totalScore(0)
+                .build();
+
+        ArrayNode strokes = objectMapper.createArrayNode();
+        strokes.addObject().put("x", 1).put("y", 2);
+        request = new SaveJudgeCommentRequest(strokes);
+    }
+
+    @Test
+    void 팀과_심사위원_ID로_원자적_upsert가_호출된다() {
+        given(userUtil.getCurrentUser()).willReturn(user);
+        given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
+
+        saveJudgeCommentService.execute(request, TEAM_ID);
+
+        ArgumentCaptor<String> strokesCaptor = ArgumentCaptor.forClass(String.class);
+        verify(judgeCommentRepository).upsert(eq(TEAM_ID), eq(USER_ID), strokesCaptor.capture());
+        assertThat(strokesCaptor.getValue()).contains("\"x\":1");
+    }
+
+    @Test
+    void 존재하지_않는_팀이면_TeamNotFoundException이_발생한다() {
+        given(userUtil.getCurrentUser()).willReturn(user);
+        given(teamRepository.findById(NOT_FOUND_TEAM_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> saveJudgeCommentService.execute(request, NOT_FOUND_TEAM_ID))
+                .isInstanceOf(TeamNotFoundException.class);
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentServiceTest.java
@@ -79,7 +79,7 @@ class SaveJudgeCommentServiceTest {
 
     @Test
     void 팀과_심사위원_ID로_원자적_upsert가_호출된다() {
-        given(userUtil.getCurrentUser()).willReturn(user);
+        given(userUtil.getCurrentUserRef()).willReturn(user);
         given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
 
         saveJudgeCommentService.execute(request, TEAM_ID);
@@ -91,7 +91,7 @@ class SaveJudgeCommentServiceTest {
 
     @Test
     void 존재하지_않는_팀이면_TeamNotFoundException이_발생한다() {
-        given(userUtil.getCurrentUser()).willReturn(user);
+        given(userUtil.getCurrentUserRef()).willReturn(user);
         given(teamRepository.findById(NOT_FOUND_TEAM_ID)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> saveJudgeCommentService.execute(request, NOT_FOUND_TEAM_ID))


### PR DESCRIPTION
## ✨ 작업 내용
심사위원이 제출작 위에 남긴 필기 코멘트(stroke JSON 데이터)를 팀(team) × 심사위원(user) 단위로 저장/조회하는 API를 추가했습니다.

- `GET /judge/{teamId}/comment`: 현재 로그인한 심사위원의 필기 코멘트 조회 (없으면 빈 배열 반환)
- `PUT /judge/{teamId}/comment`: 필기 코멘트 저장/덮어쓰기 (upsert)

---

## 🔍 리뷰 시 참고사항
- 기존 `judge` 도메인의 `JudgementEntity`/`SaveJudgementScoreServiceImpl` upsert 패턴을 참고해 구현했습니다.
- strokes는 프론트엔드가 정의한 stroke 벡터 구조를 백엔드가 해석하지 않고 그대로 저장/반환하는 패스스루 방식입니다. 요청 시 `ArrayNode` 타입으로 배열 형식만 강제합니다.
- 필기 autosave 특성상 같은 팀/심사위원 조합으로 저장 요청이 동시에 들어올 수 있어, 조회 후 분기하는 방식 대신 `(team_id, user_id)` UNIQUE 제약을 이용한 `INSERT ... ON DUPLICATE KEY UPDATE` 원자적 upsert 쿼리로 구현했습니다.
- 신규 ErrorCode 없이 기존 `TeamNotFoundException`을 재사용했습니다.
- `hibernate.ddl-auto: update` 설정으로 별도 마이그레이션 스크립트 없이 `judge_comment` 테이블이 자동 생성됩니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #153