### PR TITLE
필기 코멘트 strokes 검증 및 예외 처리 강화

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/converter/JsonNodeAttributeConverter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/converter/JsonNodeAttributeConverter.java
@@ -1,0 +1,34 @@
+package team.startup.gwangjutalentfestival.domain.judge.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Converter
+@Component
+@RequiredArgsConstructor
+public class JsonNodeAttributeConverter implements AttributeConverter<JsonNode, String> {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String convertToDatabaseColumn(JsonNode attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("strokes 데이터를 직렬화할 수 없습니다.", e);
+        }
+    }
+
+    @Override
+    public JsonNode convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readTree(dbData);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("저장된 strokes 데이터가 올바른 JSON 형식이 아닙니다.", e);
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/converter/JsonNodeAttributeConverter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/converter/JsonNodeAttributeConverter.java
@@ -16,6 +16,9 @@ public class JsonNodeAttributeConverter implements AttributeConverter<JsonNode, 
 
     @Override
     public String convertToDatabaseColumn(JsonNode attribute) {
+        if (attribute == null) {
+            return null;
+        }
         try {
             return objectMapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
@@ -25,6 +28,9 @@ public class JsonNodeAttributeConverter implements AttributeConverter<JsonNode, 
 
     @Override
     public JsonNode convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
         try {
             return objectMapper.readTree(dbData);
         } catch (JsonProcessingException e) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgeCommentEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgeCommentEntity.java
@@ -1,5 +1,6 @@
 package team.startup.gwangjutalentfestival.domain.judge.entity;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,12 +8,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import team.startup.gwangjutalentfestival.domain.judge.converter.JsonNodeAttributeConverter;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
 /**
  * 심사위원의 필기 코멘트(stroke 데이터)를 저장하는 엔티티.
- * strokes는 프론트엔드가 정의한 JSON 구조를 그대로 문자열로 저장하며,
+ * strokes는 프론트엔드가 정의한 JSON 구조를 해석하지 않고 {@link JsonNodeAttributeConverter}로 그대로 저장/복원하며,
  * (team_id, user_id) 조합에 유니크 제약이 적용된다.
  */
 @Entity
@@ -31,8 +33,9 @@ public class JudgeCommentEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Convert(converter = JsonNodeAttributeConverter.class)
     @Column(name = "strokes", columnDefinition = "JSON", nullable = false)
-    private String strokes;
+    private JsonNode strokes;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.CASCADE)

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/exception/JudgeCommentTooLargeException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/exception/JudgeCommentTooLargeException.java
@@ -1,0 +1,13 @@
+package team.startup.gwangjutalentfestival.domain.judge.exception;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+/**
+ * 필기 코멘트 strokes 페이로드가 허용 크기를 초과할 때 발생하는 예외.
+ */
+public class JudgeCommentTooLargeException extends GlobalException {
+    public JudgeCommentTooLargeException() {
+        super(ErrorCode.JUDGE_COMMENT_TOO_LARGE);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeCommentServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeCommentServiceImpl.java
@@ -37,6 +37,7 @@ public class GetJudgeCommentServiceImpl implements GetJudgeCommentService {
 
         JsonNode strokes = judgeCommentRepository.findByTeamAndUser(team, user)
                 .map(JudgeCommentEntity::getStrokes)
+                .filter(node -> node != null && !node.isNull())
                 .orElseGet(objectMapper::createArrayNode);
 
         return new GetJudgeCommentResponse(teamId, strokes);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeCommentServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeCommentServiceImpl.java
@@ -1,11 +1,11 @@
 package team.startup.gwangjutalentfestival.domain.judge.service.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeCommentEntity;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeCommentResponse;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeCommentService;
@@ -36,17 +36,9 @@ public class GetJudgeCommentServiceImpl implements GetJudgeCommentService {
                 .orElseThrow(TeamNotFoundException::new);
 
         JsonNode strokes = judgeCommentRepository.findByTeamAndUser(team, user)
-                .map(comment -> readTree(comment.getStrokes()))
+                .map(JudgeCommentEntity::getStrokes)
                 .orElseGet(objectMapper::createArrayNode);
 
         return new GetJudgeCommentResponse(teamId, strokes);
-    }
-
-    private JsonNode readTree(String strokes) {
-        try {
-            return objectMapper.readTree(strokes);
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("저장된 strokes 데이터가 올바른 JSON 형식이 아닙니다.", e);
-        }
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgeCommentServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgeCommentServiceImpl.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.judge.exception.JudgeCommentTooLargeException;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeCommentRequest;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
 import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgeCommentService;
@@ -13,6 +14,8 @@ import team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundExce
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * {@link SaveJudgeCommentService} 구현체.
@@ -24,6 +27,8 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 @Service
 @RequiredArgsConstructor
 public class SaveJudgeCommentServiceImpl implements SaveJudgeCommentService {
+    private static final int MAX_STROKES_BYTES = 500_000;
+
     private final UserUtil userUtil;
     private final TeamRepository teamRepository;
     private final JudgeCommentRepository judgeCommentRepository;
@@ -37,6 +42,7 @@ public class SaveJudgeCommentServiceImpl implements SaveJudgeCommentService {
                 .orElseThrow(TeamNotFoundException::new);
 
         String strokes = writeValueAsString(request.strokes());
+        validateSize(strokes);
 
         judgeCommentRepository.upsert(team.getId(), user.getId(), strokes);
     }
@@ -46,6 +52,12 @@ public class SaveJudgeCommentServiceImpl implements SaveJudgeCommentService {
             return objectMapper.writeValueAsString(strokes);
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("strokes 데이터를 직렬화할 수 없습니다.", e);
+        }
+    }
+
+    private void validateSize(String strokes) {
+        if (strokes.getBytes(StandardCharsets.UTF_8).length > MAX_STROKES_BYTES) {
+            throw new JudgeCommentTooLargeException();
         }
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
 
     // Judge
     JUDGEMENT_TOTAL_SCORE_EXCEEDED(400, "총점은 100점을 초과할 수 없습니다."),
+    JUDGE_COMMENT_TOO_LARGE(400, "필기 데이터가 너무 큽니다."),
 
     // Monitoring
     ANOMALY_EVENT_NOT_FOUND(404, "이상 탐지 이벤트를 찾을 수 없습니다."),

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/converter/JsonNodeAttributeConverterTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/converter/JsonNodeAttributeConverterTest.java
@@ -1,0 +1,37 @@
+package team.startup.gwangjutalentfestival.domain.judge.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonNodeAttributeConverterTest {
+
+    private final JsonNodeAttributeConverter converter = new JsonNodeAttributeConverter(new ObjectMapper());
+
+    @Test
+    void attribute가_null이면_null을_반환한다() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @Test
+    void dbData가_null이면_null을_반환한다() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void dbData가_빈_문자열이면_null을_반환한다() {
+        assertThat(converter.convertToEntityAttribute("  ")).isNull();
+    }
+
+    @Test
+    void 정상적인_JSON은_왕복_변환된다() {
+        JsonNode node = new ObjectMapper().createArrayNode().add(1);
+
+        String column = converter.convertToDatabaseColumn(node);
+        JsonNode restored = converter.convertToEntityAttribute(column);
+
+        assertThat(restored).isEqualTo(node);
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgeCommentRequestTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgeCommentRequestTest.java
@@ -1,0 +1,36 @@
+package team.startup.gwangjutalentfestival.domain.judge.presentation.data.request;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SaveJudgeCommentRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void strokes가_배열이_아닌_객체이면_역직렬화에_실패한다() {
+        assertThatThrownBy(() -> objectMapper.readValue(
+                "{\"strokes\":{\"x\":1}}", SaveJudgeCommentRequest.class))
+                .isInstanceOf(MismatchedInputException.class);
+    }
+
+    @Test
+    void strokes가_배열이_아닌_문자열이면_역직렬화에_실패한다() {
+        assertThatThrownBy(() -> objectMapper.readValue(
+                "{\"strokes\":\"invalid\"}", SaveJudgeCommentRequest.class))
+                .isInstanceOf(MismatchedInputException.class);
+    }
+
+    @Test
+    void strokes가_배열이면_정상적으로_역직렬화된다() throws Exception {
+        SaveJudgeCommentRequest request = objectMapper.readValue(
+                "{\"strokes\":[{\"x\":1}]}", SaveJudgeCommentRequest.class);
+
+        assertThat(request.strokes().isArray()).isTrue();
+        assertThat(request.strokes().get(0).get("x").asInt()).isEqualTo(1);
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentServiceTest.java
@@ -109,4 +109,23 @@ class GetJudgeCommentServiceTest {
         assertThatThrownBy(() -> getJudgeCommentService.execute(NOT_FOUND_TEAM_ID))
                 .isInstanceOf(TeamNotFoundException.class);
     }
+
+    @Test
+    void 저장된_strokes가_NullNode이면_빈_배열이_반환된다() {
+        JudgeCommentEntity comment = JudgeCommentEntity.builder()
+                .id(11L)
+                .strokes(objectMapper.nullNode())
+                .team(team)
+                .user(user)
+                .build();
+
+        given(userUtil.getCurrentUserRef()).willReturn(user);
+        given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
+        given(judgeCommentRepository.findByTeamAndUser(team, user)).willReturn(Optional.of(comment));
+
+        GetJudgeCommentResponse response = getJudgeCommentService.execute(TEAM_ID);
+
+        assertThat(response.strokes().isArray()).isTrue();
+        assertThat(response.strokes()).isEmpty();
+    }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeCommentServiceTest.java
@@ -70,10 +70,10 @@ class GetJudgeCommentServiceTest {
     }
 
     @Test
-    void 코멘트가_있으면_저장된_strokes가_반환된다() {
+    void 코멘트가_있으면_저장된_strokes가_반환된다() throws Exception {
         JudgeCommentEntity comment = JudgeCommentEntity.builder()
                 .id(10L)
-                .strokes("[{\"x\":1,\"y\":2}]")
+                .strokes(objectMapper.readTree("[{\"x\":1,\"y\":2}]"))
                 .team(team)
                 .user(user)
                 .build();

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.judge.exception.JudgeCommentTooLargeException;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeCommentRequest;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
 import team.startup.gwangjutalentfestival.domain.judge.service.impl.SaveJudgeCommentServiceImpl;
@@ -96,5 +97,21 @@ class SaveJudgeCommentServiceTest {
 
         assertThatThrownBy(() -> saveJudgeCommentService.execute(request, NOT_FOUND_TEAM_ID))
                 .isInstanceOf(TeamNotFoundException.class);
+    }
+
+    @Test
+    void strokes가_크기_제한을_초과하면_JudgeCommentTooLargeException이_발생한다() {
+        ArrayNode largeStrokes = objectMapper.createArrayNode();
+        String padding = "a".repeat(1000);
+        for (int i = 0; i < 600; i++) {
+            largeStrokes.addObject().put("data", padding);
+        }
+        SaveJudgeCommentRequest largeRequest = new SaveJudgeCommentRequest(largeStrokes);
+
+        given(userUtil.getCurrentUserRef()).willReturn(user);
+        given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
+
+        assertThatThrownBy(() -> saveJudgeCommentService.execute(largeRequest, TEAM_ID))
+                .isInstanceOf(JudgeCommentTooLargeException.class);
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
PR #154(judge comment API) 병합 이후 팀 내부 리뷰(이슈 #155)에서 요청된 하드닝 작업입니다.

- `JsonNodeAttributeConverter` 도입 — Entity의 `strokes`를 `String` → `JsonNode`로 전환. GET 경로(`findByTeamAndUser`)에서 자동 적용되어 수동 JSON 파싱/예외처리 코드 제거
- strokes 페이로드 크기 제한(500KB) 추가 — 초과 시 `JudgeCommentTooLargeException` → `ErrorCode.JUDGE_COMMENT_TOO_LARGE`(400)로 명확히 처리
- 순수 Jackson 역직렬화 경계 테스트(`SaveJudgeCommentRequestTest`) 추가

## 🔍 리뷰 시 참고사항
- `JudgeCommentRepository.upsert()`는 native query라 JPA `AttributeConverter`가 적용되지 않습니다. 따라서 GET 경로는 컨버터로 자동 변환되지만, PUT 경로(`SaveJudgeCommentServiceImpl`)는 여전히 `ObjectMapper`로 수동 직렬화해서 문자열 파라미터로 넘깁니다.
- `IllegalStateException`(컨버터 내부 직렬화/역직렬화 실패)은 실질적으로 도달 불가능한 방어 코드로 판단해 500 폴백을 유지했습니다. 실제 발생 가능한 "너무 큰 payload" 케이스만 전용 400으로 분리했습니다.
- 로컬에서 curl로 8개 시나리오(코멘트 없는 조회, insert/update upsert, 존재하지 않는 teamId, 배열 아닌 strokes, JSON 문법 오류, strokes 누락, 500KB 초과, 인증 없는 요청) 전부 기대한 상태 코드로 확인했습니다.
- `judge_comment.strokes` 컬럼은 `SHOW CREATE TABLE`로 확인한 결과 `json` 타입입니다 — TEXT 64KB 제한 해당 없음.

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

## 📎 관련 이슈(선택)
- Close #155
- 관련 PR: #154