### PR TITLE
좌석 예약 API 사용자별 요청 쿨다운 적용

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,6 @@ END_AT=LocalDateTime
 # Multipart Upload Limit (Optional, default 500MB)
 MAX_FILE_SIZE=String
 MAX_REQUEST_SIZE=String
+
+# Rate Limit (Optional, default 1초)
+RATE_LIMIT_COOLDOWN_SECONDS=Long

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatController.java
@@ -18,6 +18,7 @@ import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetSeatResponse;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetSeatsBySectionResponse;
 import team.startup.gwangjutalentfestival.domain.seat.service.*;
+import team.startup.gwangjutalentfestival.global.ratelimit.RateLimited;
 
 import java.util.List;
 
@@ -51,8 +52,10 @@ public class SeatController {
             @ApiResponse(responseCode = "201", description = "좌석 예약 성공"),
             @ApiResponse(responseCode = "400", description = "유효하지 않은 좌석 구역"),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
-            @ApiResponse(responseCode = "409", description = "이미 예약된 좌석")
+            @ApiResponse(responseCode = "409", description = "이미 예약된 좌석"),
+            @ApiResponse(responseCode = "429", description = "쿨다운 내 재요청")
     })
+    @RateLimited(key = "seat:reservation")
     @PostMapping
     public ResponseEntity<Void> reservationSeat(
             @Valid @RequestBody ReservationSeatRequest reservationSeatRequest) {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/config/WebConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/config/WebConfig.java
@@ -1,0 +1,23 @@
+package team.startup.gwangjutalentfestival.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import team.startup.gwangjutalentfestival.global.ratelimit.RateLimitInterceptor;
+
+/**
+ * Spring MVC 설정.
+ * <p>요청 제한 인터셉터를 등록한다.</p>
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor);
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
@@ -78,6 +78,9 @@ public enum ErrorCode {
     GOOGLE_SHEETS_IO_ERROR(503, "Google Sheets 서버와 연결할 수 없습니다."),
     GOOGLE_SHEETS_INIT_ERROR(500, "Google Sheets 초기화 중 오류가 발생했습니다."),
 
+    // RateLimit
+    TOO_MANY_REQUESTS(429, "요청이 너무 잦습니다. 잠시 후 다시 시도해주세요."),
+
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다.");
 
     private final int status;

--- a/src/main/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimitInterceptor.java
@@ -7,17 +7,20 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
-import team.startup.gwangjutalentfestival.global.util.UserUtil;
+import team.startup.gwangjutalentfestival.global.auth.CustomUserDetails;
 
 import java.time.Duration;
 
 /**
  * {@link RateLimited}가 붙은 엔드포인트에 사용자별 Redis 쿨다운을 적용하는 인터셉터.
  * <p>쿨다운 키를 {@code SETNX}로 선점하지 못하면 {@link TooManyRequestsException}을 던져
- * DB 접근 이전에 요청을 차단한다. Redis 장애 시에는 요청을 허용한다(fail-open).</p>
+ * DB 접근 이전에 요청을 차단한다. Redis 장애 시에는 요청을 허용한다(fail-open).
+ * 인증 정보가 없는 요청은 사용자 ID 대신 클라이언트 IP를 식별자로 사용한다.</p>
  */
 @Slf4j
 @Component
@@ -38,12 +41,12 @@ public class RateLimitInterceptor implements HandlerInterceptor {
         RateLimited rateLimited = handlerMethod.getMethodAnnotation(RateLimited.class);
         if (rateLimited == null) return true;
 
-        String key = COOLDOWN_PREFIX + rateLimited.key() + ":" + UserUtil.getCurrentUserId();
+        String key = COOLDOWN_PREFIX + rateLimited.key() + ":" + resolveIdentifier(request);
 
         Boolean acquired;
         try {
             acquired = redisTemplate.opsForValue()
-                    .setIfAbsent(key, "1", Duration.ofSeconds(cooldownSeconds));
+                    .setIfAbsent(key, "1", Duration.ofSeconds(Math.max(cooldownSeconds, 1)));
         } catch (DataAccessException e) {
             log.error("Redis 쿨다운 확인 실패 - 요청을 허용합니다. key: {}", key, e);
             return true;
@@ -53,5 +56,21 @@ public class RateLimitInterceptor implements HandlerInterceptor {
             throw new TooManyRequestsException();
         }
         return true;
+    }
+
+    private String resolveIdentifier(HttpServletRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            return String.valueOf(userDetails.getUserId());
+        }
+        return resolveClientIp(request);
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded == null || forwarded.isBlank() || "unknown".equalsIgnoreCase(forwarded)) {
+            return request.getRemoteAddr();
+        }
+        return forwarded.split(",")[0].trim();
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,57 @@
+package team.startup.gwangjutalentfestival.global.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import java.time.Duration;
+
+/**
+ * {@link RateLimited}가 붙은 엔드포인트에 사용자별 Redis 쿨다운을 적용하는 인터셉터.
+ * <p>쿨다운 키를 {@code SETNX}로 선점하지 못하면 {@link TooManyRequestsException}을 던져
+ * DB 접근 이전에 요청을 차단한다. Redis 장애 시에는 요청을 허용한다(fail-open).</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${rate-limit.cooldown-seconds:1}")
+    private long cooldownSeconds;
+
+    private static final String COOLDOWN_PREFIX = "rate-limit:";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (!(handler instanceof HandlerMethod handlerMethod)) return true;
+
+        RateLimited rateLimited = handlerMethod.getMethodAnnotation(RateLimited.class);
+        if (rateLimited == null) return true;
+
+        String key = COOLDOWN_PREFIX + rateLimited.key() + ":" + UserUtil.getCurrentUserId();
+
+        Boolean acquired;
+        try {
+            acquired = redisTemplate.opsForValue()
+                    .setIfAbsent(key, "1", Duration.ofSeconds(cooldownSeconds));
+        } catch (DataAccessException e) {
+            log.error("Redis 쿨다운 확인 실패 - 요청을 허용합니다. key: {}", key, e);
+            return true;
+        }
+
+        if (Boolean.FALSE.equals(acquired)) {
+            throw new TooManyRequestsException();
+        }
+        return true;
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimited.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimited.java
@@ -1,0 +1,22 @@
+package team.startup.gwangjutalentfestival.global.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 사용자별 Redis 쿨다운 기반 요청 제한을 적용하는 어노테이션.
+ * <p>쿨다운 시간 내 동일 사용자의 재요청은 429 Too Many Requests로 거절된다.</p>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimited {
+
+    /**
+     * 쿨다운 Redis 키를 구분하는 식별자 (예: "seat:reservation").
+     *
+     * @return 요청 제한 대상 식별자
+     */
+    String key();
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/global/ratelimit/TooManyRequestsException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/ratelimit/TooManyRequestsException.java
@@ -1,0 +1,13 @@
+package team.startup.gwangjutalentfestival.global.ratelimit;
+
+import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
+import team.startup.gwangjutalentfestival.global.exception.GlobalException;
+
+/**
+ * 쿨다운 시간 내에 동일 사용자가 재요청했을 때 발생하는 예외.
+ */
+public class TooManyRequestsException extends GlobalException {
+    public TooManyRequestsException() {
+        super(ErrorCode.TOO_MANY_REQUESTS);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,6 +46,9 @@ jwt:
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:3004}
 
+rate-limit:
+  cooldown-seconds: ${RATE_LIMIT_COOLDOWN_SECONDS:1}
+
 feign:
   log-level: ${FEIGN_LOG_LEVEL:BASIC}
 

--- a/src/test/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimitInterceptorTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimitInterceptorTest.java
@@ -1,0 +1,113 @@
+package team.startup.gwangjutalentfestival.global.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.method.HandlerMethod;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class RateLimitInterceptorTest {
+
+    @InjectMocks
+    private RateLimitInterceptor interceptor;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+    private final HttpServletResponse response = mock(HttpServletResponse.class);
+
+    private static final long USER_ID = 1L;
+
+    private HandlerMethod rateLimitedHandler;
+    private HandlerMethod plainHandler;
+
+    @BeforeEach
+    void setUp() throws NoSuchMethodException {
+        ReflectionTestUtils.setField(interceptor, "cooldownSeconds", 1L);
+        rateLimitedHandler = new HandlerMethod(new TestController(), TestController.class.getMethod("rateLimited"));
+        plainHandler = new HandlerMethod(new TestController(), TestController.class.getMethod("plain"));
+    }
+
+    static class TestController {
+        @RateLimited(key = "seat:reservation")
+        public void rateLimited() {}
+
+        public void plain() {}
+    }
+
+    @Test
+    void 쿨다운_키_선점에_성공하면_요청이_허용된다() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+
+        try (MockedStatic<UserUtil> userUtil = mockStatic(UserUtil.class)) {
+            userUtil.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
+
+            assertThat(interceptor.preHandle(request, response, rateLimitedHandler)).isTrue();
+        }
+    }
+
+    @Test
+    void 쿨다운_내_재요청이면_TooManyRequestsException이_발생한다() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(false);
+
+        try (MockedStatic<UserUtil> userUtil = mockStatic(UserUtil.class)) {
+            userUtil.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
+
+            assertThatThrownBy(() -> interceptor.preHandle(request, response, rateLimitedHandler))
+                    .isInstanceOf(TooManyRequestsException.class);
+        }
+    }
+
+    @Test
+    void Redis_장애_시_요청이_허용된다() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willThrow(new QueryTimeoutException("Redis timeout"));
+
+        try (MockedStatic<UserUtil> userUtil = mockStatic(UserUtil.class)) {
+            userUtil.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
+
+            assertThat(interceptor.preHandle(request, response, rateLimitedHandler)).isTrue();
+        }
+    }
+
+    @Test
+    void RateLimited가_없는_핸들러는_Redis를_조회하지_않고_허용된다() {
+        assertThat(interceptor.preHandle(request, response, plainHandler)).isTrue();
+        verifyNoInteractions(redisTemplate);
+    }
+
+    @Test
+    void HandlerMethod가_아닌_핸들러는_허용된다() {
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+        verifyNoInteractions(redisTemplate);
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimitInterceptorTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/ratelimit/RateLimitInterceptorTest.java
@@ -2,19 +2,23 @@ package team.startup.gwangjutalentfestival.global.ratelimit;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.method.HandlerMethod;
-import team.startup.gwangjutalentfestival.global.util.UserUtil;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.auth.CustomUserDetails;
 
 import java.time.Duration;
 
@@ -24,7 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,6 +58,17 @@ class RateLimitInterceptorTest {
         plainHandler = new HandlerMethod(new TestController(), TestController.class.getMethod("plain"));
     }
 
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void authenticate() {
+        CustomUserDetails userDetails = CustomUserDetails.fromToken(USER_ID, Role.USER);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
+    }
+
     static class TestController {
         @RateLimited(key = "seat:reservation")
         public void rateLimited() {}
@@ -63,40 +78,70 @@ class RateLimitInterceptorTest {
 
     @Test
     void 쿨다운_키_선점에_성공하면_요청이_허용된다() {
+        authenticate();
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
 
-        try (MockedStatic<UserUtil> userUtil = mockStatic(UserUtil.class)) {
-            userUtil.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
+        assertThat(interceptor.preHandle(request, response, rateLimitedHandler)).isTrue();
 
-            assertThat(interceptor.preHandle(request, response, rateLimitedHandler)).isTrue();
-        }
+        verify(valueOperations).setIfAbsent("rate-limit:seat:reservation:" + USER_ID, "1", Duration.ofSeconds(1));
     }
 
     @Test
     void 쿨다운_내_재요청이면_TooManyRequestsException이_발생한다() {
+        authenticate();
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(false);
 
-        try (MockedStatic<UserUtil> userUtil = mockStatic(UserUtil.class)) {
-            userUtil.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
-
-            assertThatThrownBy(() -> interceptor.preHandle(request, response, rateLimitedHandler))
-                    .isInstanceOf(TooManyRequestsException.class);
-        }
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, rateLimitedHandler))
+                .isInstanceOf(TooManyRequestsException.class);
     }
 
     @Test
     void Redis_장애_시_요청이_허용된다() {
+        authenticate();
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class)))
                 .willThrow(new QueryTimeoutException("Redis timeout"));
 
-        try (MockedStatic<UserUtil> userUtil = mockStatic(UserUtil.class)) {
-            userUtil.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
+        assertThat(interceptor.preHandle(request, response, rateLimitedHandler)).isTrue();
+    }
 
-            assertThat(interceptor.preHandle(request, response, rateLimitedHandler)).isTrue();
-        }
+    @Test
+    void 인증_정보가_없으면_클라이언트_IP를_식별자로_사용한다() {
+        given(request.getHeader("X-Forwarded-For")).willReturn(null);
+        given(request.getRemoteAddr()).willReturn("10.0.0.7");
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+
+        assertThat(interceptor.preHandle(request, response, rateLimitedHandler)).isTrue();
+
+        verify(valueOperations).setIfAbsent("rate-limit:seat:reservation:10.0.0.7", "1", Duration.ofSeconds(1));
+    }
+
+    @Test
+    void XForwardedFor_헤더가_있으면_첫_번째_IP를_식별자로_사용한다() {
+        given(request.getHeader("X-Forwarded-For")).willReturn("203.0.113.5, 70.41.3.18");
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+
+        assertThat(interceptor.preHandle(request, response, rateLimitedHandler)).isTrue();
+
+        verify(valueOperations).setIfAbsent("rate-limit:seat:reservation:203.0.113.5", "1", Duration.ofSeconds(1));
+    }
+
+    @Test
+    void 쿨다운_설정이_0_이하면_1초로_보정된다() {
+        authenticate();
+        ReflectionTestUtils.setField(interceptor, "cooldownSeconds", 0L);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+
+        assertThat(interceptor.preHandle(request, response, rateLimitedHandler)).isTrue();
+
+        ArgumentCaptor<Duration> durationCaptor = ArgumentCaptor.forClass(Duration.class);
+        verify(valueOperations).setIfAbsent(anyString(), anyString(), durationCaptor.capture());
+        assertThat(durationCaptor.getValue()).isEqualTo(Duration.ofSeconds(1));
     }
 
     @Test


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

- 좌석 예약 API(`POST /seat`)에 사용자별 Redis 쿨다운(기본 1초) 기반 요청 제한을 추가하였습니다.
- `@RateLimited` 어노테이션 + `RateLimitInterceptor`(HandlerInterceptor) 구조로 구현하여, 트랜잭션 시작·비관적 락 획득 이전에 연타/재시도 요청을 차단합니다.
- 쿨다운 내 재요청은 `429 Too Many Requests`(`ErrorCode.TOO_MANY_REQUESTS`)로 응답하며, Redis 장애 시에는 요청을 허용(fail-open)하고 ERROR 로그를 남깁니다.
- 쿨다운 시간은 `RATE_LIMIT_COOLDOWN_SECONDS` 환경변수로 조정 가능하도록 분리하였습니다.

---

## 🔍 리뷰 시 참고사항
- 좌석 중복 예약의 정합성은 기존 DB 유니크 제약이 이미 보장하고 있으며, 본 PR은 예매 오픈 시 실패가 확정된 연타 요청이 커넥션 점유 → 트랜잭션 시작 → 비관적 락 → 롤백 자원을 낭비하는 문제를 DB 앞단에서 차단하기 위한 것입니다.
- 실제 서버 기동 후 연타 429 차단, 1초 후 재요청 통과, 사용자별 쿨다운 분리, 동시 5연발 중 1건만 통과(SETNX 원자성), Redis 중단 시 fail-open 동작을 직접 확인하였습니다.
- fail-open 정책은 기존 `TokenBlacklistRepository`의 Redis 장애 처리 방침과 동일하게 맞추었습니다.

### 🛠 DevOps 확인 사항
- 배포 환경에 `RATE_LIMIT_COOLDOWN_SECONDS` 환경변수를 추가해주세요. (선택값, 미설정 시 기본 1초)
- 예매 당일 트래픽 상황에 따라 이 값으로 쿨다운을 즉시 조정할 수 있습니다. (예: 연타가 심하면 2~3초로 상향)
- Redis는 기존 auth 도메인에서 사용 중인 인스턴스를 그대로 사용하므로 추가 인프라 작업은 없습니다.
- Redis 장애 시 요청당 `Redis 쿨다운 확인 실패` ERROR 로그가 발생하므로, 해당 로그 기반 알림을 설정해두면 장애를 빠르게 감지할 수 있습니다.

### 🖥 프론트엔드 확인 사항
- `POST /seat`에 새 응답 코드 **429**가 추가되었습니다. 응답 형식은 기존 에러와 동일합니다: `{"status": 429, "message": "요청이 너무 잦습니다. 잠시 후 다시 시도해주세요."}`
- 429 수신 시 사용자에게 message를 그대로 노출하거나, 잠시 후 재시도 안내를 표시해주세요.
- 예약 버튼 클릭 후 1초간 버튼 비활성화(디바운스)를 적용하면 사용자가 429를 마주칠 일 자체를 줄일 수 있습니다.
- 좌석 조회(`GET /seat`, `GET /seat/all`) 등 다른 API에는 요청 제한이 적용되지 않았습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #157
