### PR TITLE
chore: simplify dev deployment - use external database

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -42,16 +42,11 @@ jobs:
 
       - name: Deploy with Docker Compose
         run: |
-          docker rm -f spring-app-dev mysql-dev redis-dev prometheus-dev grafana-dev || true
-          docker compose -f docker-compose.dev.yml --env-file .env up -d
           docker rm -f spring-app-dev || true
           docker run -d \
             --name spring-app-dev \
             --restart always \
-            --network gwangjutalentfestival_default \
             --env-file .env \
-            -e DB_URL="jdbc:mysql://mysql:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8" \
-            -e REDIS_HOST=redis \
             -e SPRING_DOCKER_COMPOSE_ENABLED=false \
             -p 8080:8080 \
             gwangju-festival:dev


### PR DESCRIPTION
## Summary
- Remove docker-compose mysql setup from dev deployment
- Use external database (10.0.0.79) instead for dev environment
- Simplifies dev deployment pipeline and avoids mysql container failures

## Changes
- Modified cd-develop.yml to remove docker-compose orchestration
- Deploy spring-app-dev directly with external database configuration

## Test plan
- Run cd-develop workflow manually
- Verify spring-app-dev container starts and connects to external database
- Check application is accessible on port 8080