### PR TITLE
chore: Dev 배포 파이프라인 단순화 - 외부 데이터베이스 사용

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -42,16 +42,11 @@ jobs:
 
       - name: Deploy with Docker Compose
         run: |
-          docker rm -f spring-app-dev mysql-dev redis-dev prometheus-dev grafana-dev || true
-          docker compose -f docker-compose.dev.yml --env-file .env up -d
           docker rm -f spring-app-dev || true
           docker run -d \
             --name spring-app-dev \
             --restart always \
-            --network gwangjutalentfestival_default \
             --env-file .env \
-            -e DB_URL="jdbc:mysql://mysql:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8" \
-            -e REDIS_HOST=redis \
             -e SPRING_DOCKER_COMPOSE_ENABLED=false \
             -p 8080:8080 \
             gwangju-festival:dev


### PR DESCRIPTION
## 📝 설명

Dev 환경 배포 파이프라인을 단순화하고 안정성을 개선합니다.

## 🔧 변경사항

- docker-compose를 통한 mysql 컨테이너 오케스트레이션 제거
- 외부 데이터베이스 (10.0.0.79:3306)를 사용하도록 변경
- spring-app-dev를 직접 docker run으로 배포

## 💡 이유

- 기존 docker-compose mysql 설정이 컨테이너 실패로 인해 작동하지 않음
- 외부 데이터베이스 사용으로 더 간단하고 안정적인 배포 구성
- Dev 환경에서 불필요한 리소스 오버헤드 제거

## ✅ 테스트 계획

1. GitHub Actions에서 cd-develop 워크플로우 수동 실행
2. spring-app-dev 컨테이너가 정상 시작되는지 확인
3. 외부 데이터베이스에 정상 연결되는지 확인
4. 애플리케이션이 포트 8080에서 접근 가능한지 확인