### PR TITLE
심사 점수 상한 100점에서 180점으로 변경

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
@@ -78,7 +78,7 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
     private void updateTotalScore(TeamEntity team) {
         Integer total = judgementRepository.sumTotalScoreByTeam(team);
         int newTotal = total != null ? total : 0;
-        if (newTotal > 100) {
+        if (newTotal > 180) {
             throw new JudgementTotalScoreExceededException();
         }
         team.updateTotalScore(newTotal);


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

심사 점수 총합의 상한값을 100점에서 180점으로 조정하였습니다.

---

## 🔍 리뷰 시 참고사항
- 리뷰어가 알면 좋은 변경 이유, 배경, 고려했던 점 등을 적어주세요.

기존 심사 총점 상한(100점)이 실제 심사 기준과 맞지 않아 정상적인 점수 입력임에도 `JudgementTotalScoreExceededException`이 발생하는 문제가 있어, 상한값을 180점으로 상향 조정하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #