### PR TITLE
심사 항목을 완성도·표현력/창의력·구성/무대매너·퍼포먼스로 재구성

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
@@ -55,11 +55,9 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
     private Map<Long, Map<Long, Integer>> buildScoreMap(List<JudgementEntity> judgements) {
         Map<Long, Map<Long, Integer>> scoreMap = new HashMap<>();
         for (JudgementEntity j : judgements) {
-            int score = nz(j.getExpressionCommunicationScore())
-                    + nz(j.getTechnicalCompletenessScore())
+            int score = nz(j.getCompletenessExpressionScore())
                     + nz(j.getCreativityCompositionScore())
-                    + nz(j.getStagePresencePerformanceScore())
-                    + nz(j.getTeamworkStageHarmonyScore());
+                    + nz(j.getStagePerformanceTeamworkScore());
             scoreMap.computeIfAbsent(j.getTeam().getId(), k -> new HashMap<>())
                     .put(j.getUser().getId(), score);
         }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgementEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgementEntity.java
@@ -12,7 +12,7 @@ import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
 /**
  * 심사 점수를 저장하는 엔티티.
- * 한 심사위원이 한 팀에 대해 입력한 5개 항목의 점수를 관리하며,
+ * 한 심사위원이 한 팀에 대해 입력한 3개 항목(완성도및표현력 40 / 창의력과구성 30 / 무대매너및퍼포먼스 30)의 점수를 관리하며,
  * (team_id, user_id) 조합에 유니크 제약이 적용된다.
  */
 @Entity
@@ -34,20 +34,14 @@ public class JudgementEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "expression_communication_score", nullable = false)
-    private Integer expressionCommunicationScore;
-
-    @Column(name = "technical_completeness_score", nullable = false)
-    private Integer technicalCompletenessScore;
+    @Column(name = "completeness_expression_score", nullable = false)
+    private Integer completenessExpressionScore;
 
     @Column(name = "creativity_composition_score", nullable = false)
     private Integer creativityCompositionScore;
 
-    @Column(name = "stage_presence_performance_score", nullable = false)
-    private Integer stagePresencePerformanceScore;
-
-    @Column(name = "teamwork_stage_harmony_score", nullable = false)
-    private Integer teamworkStageHarmonyScore;
+    @Column(name = "stage_performance_teamwork_score", nullable = false)
+    private Integer stagePerformanceTeamworkScore;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.CASCADE)
@@ -62,23 +56,17 @@ public class JudgementEntity {
     /**
      * 심사 점수를 새로운 값으로 갱신한다.
      *
-     * @param expressionCommunicationScore  표현·소통 점수
-     * @param technicalCompletenessScore    기술·완성도 점수
-     * @param creativityCompositionScore    창의·구성 점수
-     * @param stagePresencePerformanceScore 무대 장악력·퍼포먼스 점수
-     * @param teamworkStageHarmonyScore     팀워크·무대 조화 점수
+     * @param completenessExpressionScore   완성도 및 표현력 점수
+     * @param creativityCompositionScore    창의력과 구성 점수
+     * @param stagePerformanceTeamworkScore 무대매너 및 퍼포먼스/팀워크·무대 조화 점수
      */
     public void updateScore(
-            Integer expressionCommunicationScore,
-            Integer technicalCompletenessScore,
+            Integer completenessExpressionScore,
             Integer creativityCompositionScore,
-            Integer stagePresencePerformanceScore,
-            Integer teamworkStageHarmonyScore
+            Integer stagePerformanceTeamworkScore
     ){
-        this.expressionCommunicationScore = expressionCommunicationScore;
-        this.technicalCompletenessScore = technicalCompletenessScore;
+        this.completenessExpressionScore = completenessExpressionScore;
         this.creativityCompositionScore = creativityCompositionScore;
-        this.stagePresencePerformanceScore = stagePresencePerformanceScore;
-        this.teamworkStageHarmonyScore = teamworkStageHarmonyScore;
+        this.stagePerformanceTeamworkScore = stagePerformanceTeamworkScore;
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/mapper/JudgementMapper.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/mapper/JudgementMapper.java
@@ -11,11 +11,9 @@ import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
  */
 public final class JudgementMapper {
 
-    private static final int DEFAULT_EXPRESSION_COMMUNICATION_SCORE = 40;
-    private static final int DEFAULT_TECHNICAL_COMPLETENESS_SCORE = 30;
+    private static final int DEFAULT_COMPLETENESS_EXPRESSION_SCORE = 40;
     private static final int DEFAULT_CREATIVITY_COMPOSITION_SCORE = 30;
-    private static final int DEFAULT_STAGE_PRESENCE_PERFORMANCE_SCORE = 30;
-    private static final int DEFAULT_TEAMWORK_STAGE_HARMONY_SCORE = 30;
+    private static final int DEFAULT_STAGE_PERFORMANCE_TEAMWORK_SCORE = 30;
 
     /**
      * 팀 엔티티와 심사 엔티티를 {@link GetJudgementResponse}로 변환한다.
@@ -30,11 +28,9 @@ public final class JudgementMapper {
                 jm != null ? jm.getId() : null,
                 team.getId(),
                 team.getTeamName(),
-                jm != null ? jm.getExpressionCommunicationScore() : DEFAULT_EXPRESSION_COMMUNICATION_SCORE,
-                jm != null ? jm.getTechnicalCompletenessScore() : DEFAULT_TECHNICAL_COMPLETENESS_SCORE,
+                jm != null ? jm.getCompletenessExpressionScore() : DEFAULT_COMPLETENESS_EXPRESSION_SCORE,
                 jm != null ? jm.getCreativityCompositionScore() : DEFAULT_CREATIVITY_COMPOSITION_SCORE,
-                jm != null ? jm.getStagePresencePerformanceScore() : DEFAULT_STAGE_PRESENCE_PERFORMANCE_SCORE,
-                jm != null ? jm.getTeamworkStageHarmonyScore() : DEFAULT_TEAMWORK_STAGE_HARMONY_SCORE,
+                jm != null ? jm.getStagePerformanceTeamworkScore() : DEFAULT_STAGE_PERFORMANCE_TEAMWORK_SCORE,
                 team.getTotalScore() != null ? team.getTotalScore() : 0,
                 team.getTeamStatus() != TeamStatus.PENDING,
                 jm != null

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgementScoreRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgementScoreRequest.java
@@ -7,17 +7,13 @@ import jakarta.validation.constraints.NotNull;
 /**
  * 심사 점수 저장 요청 DTO.
  *
- * @param expressionCommunicationScore  표현·소통 점수 (0~40)
- * @param technicalCompletenessScore    기술·완성도 점수 (0~40)
- * @param creativityCompositionScore    창의·구성 점수 (0~30)
- * @param stagePresencePerformanceScore 무대 장악력·퍼포먼스 점수 (0~30)
- * @param teamworkStageHarmonyScore     팀워크·무대 조화 점수 (0~40)
+ * @param completenessExpressionScore   완성도 및 표현력 점수 (0~40)
+ * @param creativityCompositionScore    창의력과 구성 점수 (0~30)
+ * @param stagePerformanceTeamworkScore 무대매너 및 퍼포먼스/팀워크·무대 조화 점수 (0~30)
  */
 public record SaveJudgementScoreRequest(
-        @NotNull @Min(0) @Max(40) Integer expressionCommunicationScore,
-        @NotNull @Min(0) @Max(40) Integer technicalCompletenessScore,
+        @NotNull @Min(0) @Max(40) Integer completenessExpressionScore,
         @NotNull @Min(0) @Max(30) Integer creativityCompositionScore,
-        @NotNull @Min(0) @Max(30) Integer stagePresencePerformanceScore,
-        @NotNull @Min(0) @Max(40) Integer teamworkStageHarmonyScore
+        @NotNull @Min(0) @Max(30) Integer stagePerformanceTeamworkScore
 ) {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/GetJudgementResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/GetJudgementResponse.java
@@ -6,11 +6,9 @@ package team.startup.gwangjutalentfestival.domain.judge.presentation.data.respon
  * @param judgementId                   심사 엔티티 ID (미심사 시 {@code null})
  * @param teamId                        팀 ID
  * @param teamName                      팀명
- * @param expressionCommunicationScore  표현·소통 점수
- * @param technicalCompletenessScore    기술·완성도 점수
- * @param creativityCompositionScore    창의·구성 점수
- * @param stagePresencePerformanceScore 무대 장악력·퍼포먼스 점수
- * @param teamworkStageHarmonyScore     팀워크·무대 조화 점수
+ * @param completenessExpressionScore   완성도 및 표현력 점수
+ * @param creativityCompositionScore    창의력과 구성 점수
+ * @param stagePerformanceTeamworkScore 무대매너 및 퍼포먼스/팀워크·무대 조화 점수
  * @param totalScore                    팀의 전체 심사위원 합산 총점
  * @param isPerformed                   공연 완료 여부
  * @param isJudged                      현재 심사위원의 심사 완료 여부
@@ -19,11 +17,9 @@ public record GetJudgementResponse(
         Long judgementId,
         Long teamId,
         String teamName,
-        Integer expressionCommunicationScore,
-        Integer technicalCompletenessScore,
+        Integer completenessExpressionScore,
         Integer creativityCompositionScore,
-        Integer stagePresencePerformanceScore,
-        Integer teamworkStageHarmonyScore,
+        Integer stagePerformanceTeamworkScore,
         int totalScore,
         Boolean isPerformed,
         Boolean isJudged

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgementRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgementRepository.java
@@ -26,13 +26,13 @@ public interface JudgementRepository extends JpaRepository<JudgementEntity, Long
     Optional<JudgementEntity> findByTeamAndUser(TeamEntity team, UserEntity user);
 
     /**
-     * 특정 팀에 대한 심사위원별 총점(5개 항목 합계) 목록을 조회한다.
+     * 특정 팀에 대한 심사위원별 총점(3개 항목 합계) 목록을 조회한다.
      *
      * @param team 집계 대상 팀 엔티티
      * @return 심사위원별 총점 목록 (심사 데이터가 없으면 빈 목록)
      */
     @Query("""
-            SELECT (j.expressionCommunicationScore + j.technicalCompletenessScore + j.creativityCompositionScore + j.stagePresencePerformanceScore + j.teamworkStageHarmonyScore)
+            SELECT (j.completenessExpressionScore + j.creativityCompositionScore + j.stagePerformanceTeamworkScore)
             FROM JudgementEntity j
             WHERE j.team = :team""")
     List<Integer> findAllJudgeTotalScoresByTeam(@Param("team") TeamEntity team);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
@@ -59,18 +59,14 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
                     judgementRepository.findByTeamAndUser(team, user)
                             .ifPresentOrElse(
                                     judgement -> judgement.updateScore(
-                                            request.expressionCommunicationScore(),
-                                            request.technicalCompletenessScore(),
+                                            request.completenessExpressionScore(),
                                             request.creativityCompositionScore(),
-                                            request.stagePresencePerformanceScore(),
-                                            request.teamworkStageHarmonyScore()
+                                            request.stagePerformanceTeamworkScore()
                                     ),
                                     () -> judgementRepository.save(JudgementEntity.builder()
-                                            .expressionCommunicationScore(request.expressionCommunicationScore())
-                                            .technicalCompletenessScore(request.technicalCompletenessScore())
+                                            .completenessExpressionScore(request.completenessExpressionScore())
                                             .creativityCompositionScore(request.creativityCompositionScore())
-                                            .stagePresencePerformanceScore(request.stagePresencePerformanceScore())
-                                            .teamworkStageHarmonyScore(request.teamworkStageHarmonyScore())
+                                            .stagePerformanceTeamworkScore(request.stagePerformanceTeamworkScore())
                                             .team(team)
                                             .user(user)
                                             .build()));

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepositoryCustomImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepositoryCustomImpl.java
@@ -25,7 +25,7 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
 
     /**
      * 총점 내림차순, 세부 심사 점수 평균 순으로 팀 랭킹을 조회한다.
-     * 동점일 경우 표현/소통 점수, 창의성/구성 점수, 무대 매너/퍼포먼스 점수, ID 오름차순으로 순위를 결정한다.
+     * 동점일 경우 완성도/표현력 점수, 창의력/구성 점수, 무대매너/퍼포먼스 점수, ID 오름차순으로 순위를 결정한다.
      *
      * @return 순위가 부여된 팀 랭킹 목록
      */
@@ -38,9 +38,9 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
                 .groupBy(team.id, team.teamName)
                 .orderBy(
                         team.totalScore.desc(),
-                        judgement.expressionCommunicationScore.avg().desc(),
+                        judgement.completenessExpressionScore.avg().desc(),
                         judgement.creativityCompositionScore.avg().desc(),
-                        judgement.stagePresencePerformanceScore.avg().desc(),
+                        judgement.stagePerformanceTeamworkScore.avg().desc(),
                         team.id.asc()
                 )
                 .fetch();

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
@@ -55,13 +55,11 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         return UserEntity.builder().id(id).role(Role.ADMIN).build();
     }
 
-    private JudgementEntity judgement(TeamEntity team, UserEntity user, int s1, int s2, int s3, int s4, int s5) {
+    private JudgementEntity judgement(TeamEntity team, UserEntity user, int s1, int s2, int s3) {
         return JudgementEntity.builder()
-                .expressionCommunicationScore(s1)
-                .technicalCompletenessScore(s2)
-                .creativityCompositionScore(s3)
-                .stagePresencePerformanceScore(s4)
-                .teamworkStageHarmonyScore(s5)
+                .completenessExpressionScore(s1)
+                .creativityCompositionScore(s2)
+                .stagePerformanceTeamworkScore(s3)
                 .team(team)
                 .user(user)
                 .build();
@@ -107,11 +105,11 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         TeamEntity teamA = team(1L, 1, "팀A");
         UserEntity judge1 = user(1L);
         UserEntity judge2 = user(2L);
-        // judge1: 10*5=50, judge2: 5*5=25 → total=75 (trimming 없음)
+        // judge1: 10*3=30, judge2: 5*3=15 → total=45 (trimming 없음)
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
-                judgement(teamA, judge1, 10, 10, 10, 10, 10),
-                judgement(teamA, judge2, 5, 5, 5, 5, 5)
+                judgement(teamA, judge1, 10, 10, 10),
+                judgement(teamA, judge2, 5, 5, 5)
         ));
 
         service.execute();
@@ -120,7 +118,7 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         verify(googleExcelAdapter).exportSummary(captor.capture());
         List<Object> row = ((List<List<Object>>) captor.getValue()).get(0);
 
-        assertThat(row.get(8)).isEqualTo(75);
+        assertThat(row.get(8)).isEqualTo(45);
     }
 
     @Test
@@ -130,12 +128,12 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         UserEntity judge1 = user(1L);
         UserEntity judge2 = user(2L);
         UserEntity judge3 = user(3L);
-        // judge1=50, judge2=25, judge3=10 → 정렬: [10, 25, 50] → skip min/max → sum=25
+        // judge1=30, judge2=15, judge3=6 → 정렬: [6, 15, 30] → skip min/max → sum=15
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
-                judgement(teamA, judge1, 10, 10, 10, 10, 10),
-                judgement(teamA, judge2, 5, 5, 5, 5, 5),
-                judgement(teamA, judge3, 2, 2, 2, 2, 2)
+                judgement(teamA, judge1, 10, 10, 10),
+                judgement(teamA, judge2, 5, 5, 5),
+                judgement(teamA, judge3, 2, 2, 2)
         ));
 
         service.execute();
@@ -144,7 +142,7 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         verify(googleExcelAdapter).exportSummary(captor.capture());
         List<Object> row = ((List<List<Object>>) captor.getValue()).get(0);
 
-        assertThat(row.get(8)).isEqualTo(25);
+        assertThat(row.get(8)).isEqualTo(15);
     }
 
     @Test
@@ -154,12 +152,12 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         TeamEntity teamB = team(2L, 2, "팀B");
         TeamEntity teamC = team(3L, 3, "팀C");
         UserEntity judge1 = user(1L);
-        // teamA=100, teamB=100, teamC=50 → A:1위, B:1위, C:2위
+        // teamA=60, teamB=60, teamC=30 → A:1위, B:1위, C:2위
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB, teamC));
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
-                judgement(teamA, judge1, 20, 20, 20, 20, 20),
-                judgement(teamB, judge1, 20, 20, 20, 20, 20),
-                judgement(teamC, judge1, 10, 10, 10, 10, 10)
+                judgement(teamA, judge1, 20, 20, 20),
+                judgement(teamB, judge1, 20, 20, 20),
+                judgement(teamC, judge1, 10, 10, 10)
         ));
 
         service.execute();
@@ -179,7 +177,7 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         TeamEntity teamA = team(1L, 1, "팀A");
         // judge ID 1~7 → limit(6) 적용 시 ID 1~6만 집계
         List<JudgementEntity> judgements = java.util.stream.LongStream.rangeClosed(1, 7)
-                .mapToObj(id -> judgement(teamA, user(id), 10, 10, 10, 10, 10))
+                .mapToObj(id -> judgement(teamA, user(id), 10, 10, 10))
                 .toList();
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(judgements);
@@ -189,7 +187,7 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(googleExcelAdapter).exportSummary(captor.capture());
         List<List<Object>> rows = (List<List<Object>>) captor.getValue();
-        // 심사위원 6명 모두 50점 → trimming 후: [50,50,50,50] → 합=200
-        assertThat(rows.get(0).get(8)).isEqualTo(200);
+        // 심사위원 6명 모두 30점 → trimming 후: [30,30,30,30] → 합=120
+        assertThat(rows.get(0).get(8)).isEqualTo(120);
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetAllJudgementServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetAllJudgementServiceTest.java
@@ -74,11 +74,9 @@ class GetAllJudgementServiceTest {
     void 심사_기록이_있는_팀은_실제_점수가_반환된다() {
         JudgementEntity judgement = JudgementEntity.builder()
                 .id(10L)
-                .expressionCommunicationScore(30)
-                .technicalCompletenessScore(20)
+                .completenessExpressionScore(30)
                 .creativityCompositionScore(15)
-                .stagePresencePerformanceScore(10)
-                .teamworkStageHarmonyScore(5)
+                .stagePerformanceTeamworkScore(10)
                 .team(team1)
                 .user(user)
                 .build();
@@ -94,8 +92,8 @@ class GetAllJudgementServiceTest {
                 .findFirst().orElseThrow();
 
         assertThat(team1Response.judgementId()).isEqualTo(10L);
-        assertThat(team1Response.expressionCommunicationScore()).isEqualTo(30);
-        assertThat(team1Response.technicalCompletenessScore()).isEqualTo(20);
+        assertThat(team1Response.completenessExpressionScore()).isEqualTo(30);
+        assertThat(team1Response.creativityCompositionScore()).isEqualTo(15);
         assertThat(team1Response.isJudged()).isTrue();
     }
 
@@ -109,11 +107,9 @@ class GetAllJudgementServiceTest {
 
         GetJudgementResponse team2Response = result.get(0);
         assertThat(team2Response.judgementId()).isNull();
-        assertThat(team2Response.expressionCommunicationScore()).isEqualTo(40);
-        assertThat(team2Response.technicalCompletenessScore()).isEqualTo(30);
+        assertThat(team2Response.completenessExpressionScore()).isEqualTo(40);
         assertThat(team2Response.creativityCompositionScore()).isEqualTo(30);
-        assertThat(team2Response.stagePresencePerformanceScore()).isEqualTo(30);
-        assertThat(team2Response.teamworkStageHarmonyScore()).isEqualTo(30);
+        assertThat(team2Response.stagePerformanceTeamworkScore()).isEqualTo(30);
         assertThat(team2Response.isJudged()).isFalse();
     }
 

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgementServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgementServiceTest.java
@@ -79,11 +79,9 @@ class GetJudgementServiceTest {
     void 심사_기록이_있으면_실제_점수가_반환된다() {
         JudgementEntity judgement = JudgementEntity.builder()
                 .id(10L)
-                .expressionCommunicationScore(20)
-                .technicalCompletenessScore(15)
+                .completenessExpressionScore(20)
                 .creativityCompositionScore(10)
-                .stagePresencePerformanceScore(5)
-                .teamworkStageHarmonyScore(8)
+                .stagePerformanceTeamworkScore(5)
                 .team(pendingTeam)
                 .user(user)
                 .build();
@@ -97,11 +95,9 @@ class GetJudgementServiceTest {
         assertThat(response.judgementId()).isEqualTo(10L);
         assertThat(response.teamId()).isEqualTo(TEAM_ID);
         assertThat(response.teamName()).isEqualTo("팀A");
-        assertThat(response.expressionCommunicationScore()).isEqualTo(20);
-        assertThat(response.technicalCompletenessScore()).isEqualTo(15);
+        assertThat(response.completenessExpressionScore()).isEqualTo(20);
         assertThat(response.creativityCompositionScore()).isEqualTo(10);
-        assertThat(response.stagePresencePerformanceScore()).isEqualTo(5);
-        assertThat(response.teamworkStageHarmonyScore()).isEqualTo(8);
+        assertThat(response.stagePerformanceTeamworkScore()).isEqualTo(5);
         assertThat(response.isJudged()).isTrue();
     }
 
@@ -114,11 +110,9 @@ class GetJudgementServiceTest {
         GetJudgementResponse response = getJudgementService.execute(TEAM_ID);
 
         assertThat(response.judgementId()).isNull();
-        assertThat(response.expressionCommunicationScore()).isEqualTo(40);
-        assertThat(response.technicalCompletenessScore()).isEqualTo(30);
+        assertThat(response.completenessExpressionScore()).isEqualTo(40);
         assertThat(response.creativityCompositionScore()).isEqualTo(30);
-        assertThat(response.stagePresencePerformanceScore()).isEqualTo(30);
-        assertThat(response.teamworkStageHarmonyScore()).isEqualTo(30);
+        assertThat(response.stagePerformanceTeamworkScore()).isEqualTo(30);
         assertThat(response.isJudged()).isFalse();
     }
 

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
@@ -77,7 +77,7 @@ class SaveJudgementScoreServiceTest {
                 .totalScore(0)
                 .build();
 
-        request = new SaveJudgementScoreRequest(10, 10, 10, 10, 10);
+        request = new SaveJudgementScoreRequest(10, 10, 10);
     }
 
     @Test
@@ -96,11 +96,9 @@ class SaveJudgementScoreServiceTest {
     void 심사_기록이_있으면_점수가_수정된다() {
         JudgementEntity existing = JudgementEntity.builder()
                 .id(1L)
-                .expressionCommunicationScore(5)
-                .technicalCompletenessScore(5)
+                .completenessExpressionScore(5)
                 .creativityCompositionScore(5)
-                .stagePresencePerformanceScore(5)
-                .teamworkStageHarmonyScore(5)
+                .stagePerformanceTeamworkScore(5)
                 .team(team)
                 .user(user)
                 .build();
@@ -112,11 +110,9 @@ class SaveJudgementScoreServiceTest {
 
         saveJudgementScoreService.execute(request, TEAM_ID);
 
-        assertThat(existing.getExpressionCommunicationScore()).isEqualTo(10);
-        assertThat(existing.getTechnicalCompletenessScore()).isEqualTo(10);
+        assertThat(existing.getCompletenessExpressionScore()).isEqualTo(10);
         assertThat(existing.getCreativityCompositionScore()).isEqualTo(10);
-        assertThat(existing.getStagePresencePerformanceScore()).isEqualTo(10);
-        assertThat(existing.getTeamworkStageHarmonyScore()).isEqualTo(10);
+        assertThat(existing.getStagePerformanceTeamworkScore()).isEqualTo(10);
         verify(judgementRepository, never()).save(any());
     }
 


### PR DESCRIPTION
## ✨ 작업 내용
- 심사 점수 항목을 실제 심사표 기준에 맞춰 5개에서 3개로 재구성하였습니다.
  - `completenessExpressionScore` (완성도 및 표현력, 0~40)
  - `creativityCompositionScore` (창의력과 구성, 0~30)
  - `stagePerformanceTeamworkScore` (무대매너 및 퍼포먼스/팀워크·무대 조화, 0~30)
- 위 필드 변경에 따라 요청/응답 DTO, 매퍼 기본값, 팀 총점 합산 쿼리, 랭킹 타이브레이크 쿼리, 심사 요약 엑셀 다운로드 로직을 모두 갱신하였습니다.

---

## 🔍 리뷰 시 참고사항
- 기존 5개 필드(표현·소통 40 / 기술·완성도 40 / 창의·구성 30 / 무대장악력·퍼포먼스 30 / 팀워크·조화 40, 합계 180점)는 실제 심사표(완성도및표현력 40 / 창의력과구성 30 / 무대매너및퍼포먼스 30, 합계 100점)와 맞지 않아 3개 항목으로 재구성하였습니다.
- 심사위원 5명 최고·최저 제외 평균 계산 로직(`SaveJudgementScoreServiceImpl.calculateTotalScore`)은 필드 개수와 무관하게 총점 리스트 기반으로 동작하므로 변경하지 않았습니다.
- DB 마이그레이션 도구(Flyway 등)가 없고 `ddl-auto: update`로 스키마를 관리하는 구조이며, 아직 실제 심사가 시작되지 않아 별도 데이터 이관 없이 진행하였습니다.
- 관련 테스트(요청/응답 필드, 기본값, 랭킹, 엑셀 합산 수치) 전부 갱신하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #