### PR TITLE
심사 집계표 엑셀 산출점수/컬럼 구조 및 팀 권한 오류 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
@@ -18,7 +18,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSummaryExcelService {
 
-    private static final int MAX_JUDGE_COUNT = 6;
+    // ponytail: 안전 상한. 알파벳 라벨(A~Z) 26개 범위 내에서 여유 있게 잡음. 초과 시 멀티레터 라벨링 필요.
+    private static final int MAX_JUDGE_COLUMNS = 20;
 
     private final TeamRepository teamRepository;
     private final JudgementRepository judgementRepository;
@@ -30,24 +31,25 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
         List<JudgementEntity> judgements = judgementRepository.findAllWithUserAndTeam();
 
         long totalJudgeCount = judgements.stream().map(j -> j.getUser().getId()).distinct().count();
-        if (totalJudgeCount > MAX_JUDGE_COUNT) {
-            log.warn("심사위원 수가 최대 허용 인원을 초과하였습니다. - total: {}, max: {}", totalJudgeCount, MAX_JUDGE_COUNT);
+        if (totalJudgeCount > MAX_JUDGE_COLUMNS) {
+            log.warn("심사위원 수가 최대 허용 인원을 초과하였습니다. - total: {}, max: {}", totalJudgeCount, MAX_JUDGE_COLUMNS);
         }
 
         List<Long> judgeIds = judgements.stream()
                 .map(j -> j.getUser().getId())
                 .distinct()
                 .sorted()
-                .limit(MAX_JUDGE_COUNT)
+                .limit(MAX_JUDGE_COLUMNS)
                 .toList();
 
         Map<Long, Map<Long, Integer>> scoreMap = buildScoreMap(judgements);
-        Map<Long, Integer> teamTotalMap = buildTeamTotalMap(teams, judgeIds, scoreMap);
+        Map<Long, Integer> teamTotalMap = teams.stream()
+                .collect(Collectors.toMap(TeamEntity::getId, TeamEntity::getTotalScore));
         Map<Long, Integer> rankMap = denseRank(teamTotalMap);
 
-        List<List<Object>> rows = teams.stream()
-                .map(t -> buildRow(t, judgeIds, scoreMap, teamTotalMap, rankMap))
-                .toList();
+        List<List<Object>> rows = new ArrayList<>();
+        rows.add(buildHeaderRow(judgeIds.size()));
+        teams.forEach(t -> rows.add(buildRow(t, judgeIds, scoreMap, teamTotalMap, rankMap)));
 
         return googleExcelAdapter.exportSummary(rows);
     }
@@ -64,20 +66,15 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
         return scoreMap;
     }
 
-    private Map<Long, Integer> buildTeamTotalMap(
-            List<TeamEntity> teams,
-            List<Long> judgeIds,
-            Map<Long, Map<Long, Integer>> scoreMap) {
-        return teams.stream()
-                .collect(Collectors.toMap(
-                        TeamEntity::getId,
-                        t -> {
-                            List<Integer> scores = judgeIds.stream()
-                                    .map(judgeId -> scoreMap.getOrDefault(t.getId(), Collections.emptyMap()).get(judgeId))
-                                    .toList();
-                            return trimmedSum(scores);
-                        }
-                ));
+    private List<Object> buildHeaderRow(int judgeCount) {
+        List<Object> header = new ArrayList<>();
+        header.add("심사번호");
+        for (int i = 0; i < judgeCount; i++) {
+            header.add("심사위원 (" + (char) ('A' + i) + ")");
+        }
+        header.add("산출점수");
+        header.add("순위");
+        return header;
     }
 
     private List<Object> buildRow(
@@ -88,10 +85,8 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
             Map<Long, Integer> rankMap) {
         List<Object> row = new ArrayList<>();
         row.add(team.getPerformOrder());
-        row.add(team.getTeamName());
         judgeIds.forEach(judgeId ->
                 row.add(scoreMap.getOrDefault(team.getId(), Collections.emptyMap()).get(judgeId)));
-        row.addAll(Collections.nCopies(MAX_JUDGE_COUNT - judgeIds.size(), null));
         row.add(teamTotalMap.get(team.getId()));
         row.add(rankMap.get(team.getId()));
         return row;
@@ -99,18 +94,6 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
 
     private int nz(Integer v) {
         return Optional.ofNullable(v).orElse(0);
-    }
-
-    private int trimmedSum(List<Integer> scores) {
-        List<Integer> valid = scores.stream().filter(Objects::nonNull).toList();
-        if (valid.isEmpty()) return 0;
-        if (valid.size() < 3) return valid.stream().mapToInt(Integer::intValue).sum();
-        return valid.stream()
-                .sorted()
-                .skip(1)
-                .limit(valid.size() - 2)
-                .mapToInt(Integer::intValue)
-                .sum();
     }
 
     private Map<Long, Integer> denseRank(Map<Long, Integer> teamTotalMap) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
@@ -28,8 +28,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService {
 
-    private static final int TOTAL_JUDGE_COUNT = 5;
-
     private final JudgementRepository judgementRepository;
     private final TeamRepository teamRepository;
     private final UserUtil userUtil;
@@ -77,8 +75,8 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
 
     /**
      * 팀 총점을 재계산한다.
-     * 심사위원 5명이 모두 채점을 완료하면 최고점과 최저점을 제외한 나머지 점수의 평균(반올림)으로 계산하고,
-     * 그 전에는 제출된 심사위원 점수를 단순 합산한다.
+     * 심사위원 수와 무관하게 최고점과 최저점을 제외한 나머지 점수의 평균(반올림)으로 계산한다.
+     * 예선/본선 등 라운드마다 채점 인원이 달라도 동일한 기준이 적용된다.
      *
      * @param team 총점을 갱신할 팀 엔티티
      */
@@ -92,8 +90,9 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
             return 0;
         }
         int sum = scores.stream().mapToInt(Integer::intValue).sum();
-        if (scores.size() < TOTAL_JUDGE_COUNT) {
-            return sum;
+        // ponytail: 최고/최저를 제외하면 최소 1명은 남아야 트리밍이 의미 있으므로 3명 미만은 단순 평균
+        if (scores.size() < 3) {
+            return Math.round(sum / (float) scores.size());
         }
         int max = Collections.max(scores);
         int min = Collections.min(scores);

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
                         .requestMatchers(PublicEndpointMatcher.matchers()).permitAll()
 
                         // team
-                        .requestMatchers("/team/**").hasRole("ADMIN")
+                        .requestMatchers("/team/**").hasAnyAuthority(Role.ADMIN.name())
 
                         // seat
                         .requestMatchers(HttpMethod.POST, "/seat").authenticated()

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapter.java
@@ -174,8 +174,14 @@ public class GoogleExcelAdapter {
                 .orElseThrow(GoogleSheetsException::new);
     }
 
-    // ponytail: 26컬럼(Z) 이내로 가정, 그 이상 컬럼이 필요하면 멀티레터 로직 필요
     static String columnLetter(int columnCount) {
-        return String.valueOf((char) ('A' + Math.max(columnCount, 1) - 1));
+        StringBuilder columnName = new StringBuilder();
+        int remaining = Math.max(columnCount, 1);
+        while (remaining > 0) {
+            int rem = (remaining - 1) % 26;
+            columnName.insert(0, (char) ('A' + rem));
+            remaining = (remaining - 1) / 26;
+        }
+        return columnName.toString();
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapter.java
@@ -3,7 +3,23 @@ package team.startup.gwangjutalentfestival.global.thirdparty.google.adapter;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.BatchUpdateSpreadsheetRequest;
+import com.google.api.services.sheets.v4.model.Border;
+import com.google.api.services.sheets.v4.model.Borders;
+import com.google.api.services.sheets.v4.model.CellData;
+import com.google.api.services.sheets.v4.model.CellFormat;
 import com.google.api.services.sheets.v4.model.ClearValuesRequest;
+import com.google.api.services.sheets.v4.model.Color;
+import com.google.api.services.sheets.v4.model.DimensionProperties;
+import com.google.api.services.sheets.v4.model.DimensionRange;
+import com.google.api.services.sheets.v4.model.GridRange;
+import com.google.api.services.sheets.v4.model.MergeCellsRequest;
+import com.google.api.services.sheets.v4.model.RepeatCellRequest;
+import com.google.api.services.sheets.v4.model.Request;
+import com.google.api.services.sheets.v4.model.Spreadsheet;
+import com.google.api.services.sheets.v4.model.TextFormat;
+import com.google.api.services.sheets.v4.model.UnmergeCellsRequest;
+import com.google.api.services.sheets.v4.model.UpdateDimensionPropertiesRequest;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +31,7 @@ import team.startup.gwangjutalentfestival.global.thirdparty.google.properties.Go
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -23,6 +40,15 @@ import java.util.List;
 public class GoogleExcelAdapter {
 
     private static final String XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    private static final int HEADER_ROW = 3;
+    private static final int TITLE_ROWS = 2;
+    // ponytail: 클리어 범위는 이전 실행의 잔여 데이터까지 지우도록 넉넉한 하한을 유지
+    private static final int CLEAR_ROW_FLOOR = 1000;
+    // ponytail: 제목/확인자 병합 해제 시 안전하게 잡는 넉넉한 컬럼 상한 (26컬럼 가정과 동일)
+    private static final int MERGE_COLUMN_CEILING = 26;
+    // 1~2행(제목/확인자)은 고정, 헤더 행부터 데이터 행까지만 이 크기로 맞춘다.
+    private static final int COLUMN_WIDTH_PX = 100;
+    private static final int ROW_HEIGHT_PX = 50;
 
     private final Sheets sheets;
     private final Drive drive;
@@ -31,12 +57,18 @@ public class GoogleExcelAdapter {
     public synchronized byte[] exportSummary(List<List<Object>> rows) {
         String sheetId = properties.templateSheetId();
         String page = properties.summaryPage().replace("'", "''");
-        String writeRange = "'" + page + "'!A3";
-        String clearRange = "'" + page + "'!A3:J1000";
+        int columnCount = rows.isEmpty() ? 0 : rows.get(0).size();
+        String endColumn = columnLetter(columnCount);
+        String writeRange = "'" + page + "'!A" + HEADER_ROW;
+        String clearRange = "'" + page + "'!A" + HEADER_ROW + ":" + endColumn + CLEAR_ROW_FLOOR;
+        int lastDataRow = HEADER_ROW + rows.size() - 1;
+
         try {
             sheets.spreadsheets().values()
                     .clear(sheetId, clearRange, new ClearValuesRequest())
                     .execute();
+
+            formatTable(sheetId, page, columnCount, lastDataRow);
 
             ValueRange valueRange = new ValueRange().setValues(rows);
             sheets.spreadsheets().values()
@@ -69,5 +101,81 @@ public class GoogleExcelAdapter {
                 log.error("Google Sheets 사후 데이터 초기화 실패 - message: {}", e.getMessage());
             }
         }
+    }
+
+    private void formatTable(String spreadsheetId, String page, int columnCount, int lastDataRow) throws IOException {
+        if (columnCount == 0) {
+            return;
+        }
+
+        Integer gridSheetId = resolveGridSheetId(spreadsheetId, page);
+        List<Request> requests = new ArrayList<>();
+
+        requests.add(new Request().setUnmergeCells(new UnmergeCellsRequest()
+                .setRange(gridRange(gridSheetId, 0, TITLE_ROWS, 0, MERGE_COLUMN_CEILING))));
+        for (int titleRow = 0; titleRow < TITLE_ROWS; titleRow++) {
+            requests.add(new Request().setMergeCells(new MergeCellsRequest()
+                    .setRange(gridRange(gridSheetId, titleRow, titleRow + 1, 0, columnCount))
+                    .setMergeType("MERGE_ALL")));
+        }
+
+        Border thinBorder = new Border().setStyle("SOLID").setColor(new Color().setRed(0f).setGreen(0f).setBlue(0f));
+        Borders tableBorders = new Borders().setTop(thinBorder).setBottom(thinBorder).setLeft(thinBorder).setRight(thinBorder);
+        CellFormat bodyFormat = new CellFormat()
+                .setBorders(tableBorders)
+                .setHorizontalAlignment("CENTER")
+                .setVerticalAlignment("MIDDLE");
+        requests.add(new Request().setRepeatCell(new RepeatCellRequest()
+                .setRange(gridRange(gridSheetId, HEADER_ROW - 1, lastDataRow, 0, columnCount))
+                .setCell(new CellData().setUserEnteredFormat(bodyFormat))
+                .setFields("userEnteredFormat(borders,horizontalAlignment,verticalAlignment)")));
+
+        CellFormat headerFormat = new CellFormat()
+                .setBackgroundColor(new Color().setRed(0.9f).setGreen(0.9f).setBlue(0.93f))
+                .setTextFormat(new TextFormat().setBold(true));
+        requests.add(new Request().setRepeatCell(new RepeatCellRequest()
+                .setRange(gridRange(gridSheetId, HEADER_ROW - 1, HEADER_ROW, 0, columnCount))
+                .setCell(new CellData().setUserEnteredFormat(headerFormat))
+                .setFields("userEnteredFormat(backgroundColor,textFormat.bold)")));
+
+        requests.add(new Request().setUpdateDimensionProperties(new UpdateDimensionPropertiesRequest()
+                .setRange(new DimensionRange().setSheetId(gridSheetId).setDimension("COLUMNS")
+                        .setStartIndex(0).setEndIndex(columnCount))
+                .setProperties(new DimensionProperties().setPixelSize(COLUMN_WIDTH_PX))
+                .setFields("pixelSize")));
+        requests.add(new Request().setUpdateDimensionProperties(new UpdateDimensionPropertiesRequest()
+                .setRange(new DimensionRange().setSheetId(gridSheetId).setDimension("ROWS")
+                        .setStartIndex(HEADER_ROW - 1).setEndIndex(lastDataRow))
+                .setProperties(new DimensionProperties().setPixelSize(ROW_HEIGHT_PX))
+                .setFields("pixelSize")));
+
+        sheets.spreadsheets()
+                .batchUpdate(spreadsheetId, new BatchUpdateSpreadsheetRequest().setRequests(requests))
+                .execute();
+    }
+
+    private GridRange gridRange(Integer gridSheetId, int startRow, int endRow, int startColumn, int endColumn) {
+        return new GridRange()
+                .setSheetId(gridSheetId)
+                .setStartRowIndex(startRow)
+                .setEndRowIndex(endRow)
+                .setStartColumnIndex(startColumn)
+                .setEndColumnIndex(endColumn);
+    }
+
+    private Integer resolveGridSheetId(String spreadsheetId, String page) throws IOException {
+        String unescapedPage = page.replace("''", "'");
+        Spreadsheet spreadsheet = sheets.spreadsheets().get(spreadsheetId).setFields("sheets.properties").execute();
+        return spreadsheet.getSheets().stream()
+                .map(sheet -> sheet.getProperties())
+                .filter(sheetProperties -> unescapedPage.equals(sheetProperties.getTitle()))
+                .map(sheetProperties -> sheetProperties.getSheetId())
+                .findFirst()
+                .orElseThrow(GoogleSheetsException::new);
+    }
+
+    // ponytail: 26컬럼(Z) 이내로 가정, 그 이상 컬럼이 필요하면 멀티레터 로직 필요
+    static String columnLetter(int columnCount) {
+        return String.valueOf((char) ('A' + Math.max(columnCount, 1) - 1));
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
@@ -18,6 +18,7 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
 
 import java.util.List;
+import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,7 +40,7 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         given(googleExcelAdapter.exportSummary(any())).willReturn(new byte[0]);
     }
 
-    private TeamEntity team(long id, int order, String name) {
+    private TeamEntity team(long id, int order, String name, int totalScore) {
         return TeamEntity.builder()
                 .id(id)
                 .teamName(name)
@@ -47,7 +48,7 @@ class DownloadJudgingSummaryExcelServiceImplTest {
                 .teamStatus(TeamStatus.PENDING)
                 .teamGenre(TeamGenre.SING)
                 .performOrder(order)
-                .totalScore(0)
+                .totalScore(totalScore)
                 .build();
     }
 
@@ -67,7 +68,7 @@ class DownloadJudgingSummaryExcelServiceImplTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void 팀_목록이_없으면_빈_rows로_export가_호출된다() {
+    void 팀_목록이_없으면_헤더행만_export된다() {
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of());
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
 
@@ -75,37 +76,18 @@ class DownloadJudgingSummaryExcelServiceImplTest {
 
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(googleExcelAdapter).exportSummary(captor.capture());
-        assertThat(captor.getValue()).isEmpty();
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void 심사위원이_없으면_총점이_0이고_1위가_된다() {
-        TeamEntity teamA = team(1L, 1, "팀A");
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
-
-        service.execute();
-
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<List<Object>> rows = captor.getValue();
+        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
 
         assertThat(rows).hasSize(1);
-        List<Object> row = rows.get(0);
-        assertThat(row.get(0)).isEqualTo(1);       // performOrder
-        assertThat(row.get(1)).isEqualTo("팀A");   // teamName
-        assertThat(row.get(8)).isEqualTo(0);        // total
-        assertThat(row.get(9)).isEqualTo(1);        // rank
+        assertThat(rows.get(0)).containsExactly("심사번호", "산출점수", "순위");
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    void 심사위원_2명_이하이면_전체_합산된다() {
-        TeamEntity teamA = team(1L, 1, "팀A");
+    void 헤더행에_팀명_컬럼_없이_심사위원_수만큼_헤더가_생성된다() {
+        TeamEntity teamA = team(1L, 1, "팀A", 0);
         UserEntity judge1 = user(1L);
         UserEntity judge2 = user(2L);
-        // judge1: 10*3=30, judge2: 5*3=15 → total=45 (trimming 없음)
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
                 judgement(teamA, judge1, 10, 10, 10),
@@ -116,48 +98,21 @@ class DownloadJudgingSummaryExcelServiceImplTest {
 
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<Object> row = ((List<List<Object>>) captor.getValue()).get(0);
+        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
 
-        assertThat(row.get(8)).isEqualTo(45);
+        assertThat(rows.get(0)).containsExactly("심사번호", "심사위원 (A)", "심사위원 (B)", "산출점수", "순위");
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    void 심사위원_3명_이상이면_최고_최저_제거_후_합산된다() {
-        TeamEntity teamA = team(1L, 1, "팀A");
+    void 팀_데이터_행은_팀명_없이_심사번호_심사위원점수_산출점수_순위_순으로_구성된다() {
+        TeamEntity teamA = team(1L, 1, "팀A", 45);
         UserEntity judge1 = user(1L);
         UserEntity judge2 = user(2L);
-        UserEntity judge3 = user(3L);
-        // judge1=30, judge2=15, judge3=6 → 정렬: [6, 15, 30] → skip min/max → sum=15
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
                 judgement(teamA, judge1, 10, 10, 10),
-                judgement(teamA, judge2, 5, 5, 5),
-                judgement(teamA, judge3, 2, 2, 2)
-        ));
-
-        service.execute();
-
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<Object> row = ((List<List<Object>>) captor.getValue()).get(0);
-
-        assertThat(row.get(8)).isEqualTo(15);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void 동점_팀은_동일_순위가_부여된다() {
-        TeamEntity teamA = team(1L, 1, "팀A");
-        TeamEntity teamB = team(2L, 2, "팀B");
-        TeamEntity teamC = team(3L, 3, "팀C");
-        UserEntity judge1 = user(1L);
-        // teamA=60, teamB=60, teamC=30 → A:1위, B:1위, C:2위
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB, teamC));
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
-                judgement(teamA, judge1, 20, 20, 20),
-                judgement(teamB, judge1, 20, 20, 20),
-                judgement(teamC, judge1, 10, 10, 10)
+                judgement(teamA, judge2, 5, 5, 5)
         ));
 
         service.execute();
@@ -165,18 +120,53 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(googleExcelAdapter).exportSummary(captor.capture());
         List<List<Object>> rows = (List<List<Object>>) captor.getValue();
+        List<Object> dataRow = rows.get(1);
 
-        assertThat(rows.get(0).get(9)).isEqualTo(1);
-        assertThat(rows.get(1).get(9)).isEqualTo(1);
-        assertThat(rows.get(2).get(9)).isEqualTo(2);
+        assertThat(dataRow).containsExactly(1, 30, 15, 45, 1);
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    void 심사위원_수가_6명_초과이면_6명까지만_집계한다() {
-        TeamEntity teamA = team(1L, 1, "팀A");
-        // judge ID 1~7 → limit(6) 적용 시 ID 1~6만 집계
-        List<JudgementEntity> judgements = java.util.stream.LongStream.rangeClosed(1, 7)
+    void 산출점수는_team_totalScore를_그대로_재사용한다() {
+        TeamEntity teamA = team(1L, 1, "팀A", 80);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
+
+        service.execute();
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(googleExcelAdapter).exportSummary(captor.capture());
+        List<Object> dataRow = ((List<List<Object>>) captor.getValue()).get(1);
+
+        assertThat(dataRow).containsExactly(1, 80, 1);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void 동점_팀은_동일_순위가_부여된다() {
+        TeamEntity teamA = team(1L, 1, "팀A", 60);
+        TeamEntity teamB = team(2L, 2, "팀B", 60);
+        TeamEntity teamC = team(3L, 3, "팀C", 30);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB, teamC));
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
+
+        service.execute();
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(googleExcelAdapter).exportSummary(captor.capture());
+        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
+
+        assertThat(rows.get(1).get(2)).isEqualTo(1); // teamA 순위
+        assertThat(rows.get(2).get(2)).isEqualTo(1); // teamB 순위
+        assertThat(rows.get(3).get(2)).isEqualTo(2); // teamC 순위
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void 심사위원_수가_안전_상한을_초과하면_상한까지만_집계한다() {
+        TeamEntity teamA = team(1L, 1, "팀A", 0);
+        // judge ID 1~21 → 안전 상한(20) 적용 시 ID 1~20만 헤더/컬럼에 반영
+        List<JudgementEntity> judgements = LongStream.rangeClosed(1, 21)
                 .mapToObj(id -> judgement(teamA, user(id), 10, 10, 10))
                 .toList();
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
@@ -187,7 +177,8 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(googleExcelAdapter).exportSummary(captor.capture());
         List<List<Object>> rows = (List<List<Object>>) captor.getValue();
-        // 심사위원 6명 모두 30점 → trimming 후: [30,30,30,30] → 합=120
-        assertThat(rows.get(0).get(8)).isEqualTo(120);
+
+        // 헤더: 심사번호 + 심사위원 20명 + 산출점수 + 순위 = 23컬럼
+        assertThat(rows.get(0)).hasSize(23);
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
@@ -117,7 +117,7 @@ class SaveJudgementScoreServiceTest {
     }
 
     @Test
-    void 심사위원이_5명_미만이면_단순_합산으로_계산된다() {
+    void 심사위원이_3명_미만이면_단순_평균으로_계산된다() {
         given(userUtil.getCurrentUser()).willReturn(user);
         given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
         given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
@@ -125,7 +125,19 @@ class SaveJudgementScoreServiceTest {
 
         saveJudgementScoreService.execute(request, TEAM_ID);
 
-        assertThat(team.getTotalScore()).isEqualTo(150);
+        assertThat(team.getTotalScore()).isEqualTo(75);
+    }
+
+    @Test
+    void 심사위원이_3명이면_최고점과_최저점을_제외한_평균으로_계산된다() {
+        given(userUtil.getCurrentUser()).willReturn(user);
+        given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
+        given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
+        given(judgementRepository.findAllJudgeTotalScoresByTeam(team)).willReturn(List.of(90, 60, 30));
+
+        saveJudgementScoreService.execute(request, TEAM_ID);
+
+        assertThat(team.getTotalScore()).isEqualTo(60);
     }
 
     @Test
@@ -141,7 +153,7 @@ class SaveJudgementScoreServiceTest {
     }
 
     @Test
-    void 심사위원이_5명이면_최고점과_최저점을_제외한_평균으로_계산된다() {
+    void 심사위원이_5명이어도_최고점과_최저점을_제외한_평균으로_계산된다() {
         given(userUtil.getCurrentUser()).willReturn(user);
         given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
         given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());

--- a/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapterTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapterTest.java
@@ -1,0 +1,23 @@
+package team.startup.gwangjutalentfestival.global.thirdparty.google.adapter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GoogleExcelAdapterTest {
+
+    @Test
+    void 컬럼_1개는_A로_변환된다() {
+        assertThat(GoogleExcelAdapter.columnLetter(1)).isEqualTo("A");
+    }
+
+    @Test
+    void 컬럼_9개는_I로_변환된다() {
+        assertThat(GoogleExcelAdapter.columnLetter(9)).isEqualTo("I");
+    }
+
+    @Test
+    void 컬럼_0개는_A로_변환된다() {
+        assertThat(GoogleExcelAdapter.columnLetter(0)).isEqualTo("A");
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapterTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapterTest.java
@@ -1,10 +1,104 @@
 package team.startup.gwangjutalentfestival.global.thirdparty.google.adapter;
 
+import com.google.api.services.drive.Drive;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.BatchUpdateSpreadsheetRequest;
+import com.google.api.services.sheets.v4.model.Sheet;
+import com.google.api.services.sheets.v4.model.SheetProperties;
+import com.google.api.services.sheets.v4.model.Spreadsheet;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.global.thirdparty.google.exception.GoogleSheetsException;
+import team.startup.gwangjutalentfestival.global.thirdparty.google.properties.GoogleExcelProperties;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class GoogleExcelAdapterTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private Sheets sheets;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private Drive drive;
+
+    @Mock
+    private GoogleExcelProperties properties;
+
+    private GoogleExcelAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new GoogleExcelAdapter(sheets, drive, properties);
+    }
+
+    private void stubProperties() {
+        given(properties.templateSheetId()).willReturn("SHEET_ID");
+        given(properties.summaryPage()).willReturn("심사집계표");
+    }
+
+    private void stubGridSheetId(int gridSheetId) throws Exception {
+        SheetProperties sheetProperties = new SheetProperties().setTitle("심사집계표").setSheetId(gridSheetId);
+        Spreadsheet spreadsheet = new Spreadsheet().setSheets(List.of(new Sheet().setProperties(sheetProperties)));
+        given(sheets.spreadsheets().get("SHEET_ID").setFields(anyString()).execute()).willReturn(spreadsheet);
+    }
+
+    @Test
+    void 정상_흐름에서_clear_서식적용_write_export가_수행된다() throws Exception {
+        stubProperties();
+        stubGridSheetId(42);
+        List<List<Object>> rows = List.of(
+                List.of("심사번호", "심사위원 (A)", "산출점수", "순위"),
+                List.of(1, 80, 80, 1)
+        );
+
+        byte[] result = adapter.exportSummary(rows);
+
+        assertThat(result).isNotNull();
+        verify(sheets.spreadsheets().values(), times(2))
+                .clear(eq("SHEET_ID"), eq("'심사집계표'!A3:D1000"), any());
+        verify(sheets.spreadsheets().values())
+                .update(eq("SHEET_ID"), eq("'심사집계표'!A3"), any());
+        verify(sheets.spreadsheets())
+                .batchUpdate(eq("SHEET_ID"), any(BatchUpdateSpreadsheetRequest.class));
+        verify(drive.files().export(eq("SHEET_ID"), anyString()))
+                .executeMediaAndDownloadTo(any());
+    }
+
+    @Test
+    void 데이터가_없으면_서식_배치업데이트_없이_진행된다() throws Exception {
+        stubProperties();
+        byte[] result = adapter.exportSummary(List.of());
+
+        assertThat(result).isNotNull();
+        verify(sheets.spreadsheets(), never()).batchUpdate(anyString(), any());
+    }
+
+    @Test
+    void 템플릿에_해당_페이지_시트가_없으면_GoogleSheetsException이_발생한다() throws Exception {
+        stubProperties();
+        Spreadsheet spreadsheet = new Spreadsheet().setSheets(List.of());
+        given(sheets.spreadsheets().get("SHEET_ID").setFields(anyString()).execute()).willReturn(spreadsheet);
+
+        List<List<Object>> rows = List.of(List.of("심사번호", "산출점수", "순위"));
+
+        assertThatThrownBy(() -> adapter.exportSummary(rows))
+                .isInstanceOf(GoogleSheetsException.class);
+    }
 
     @Test
     void 컬럼_1개는_A로_변환된다() {

--- a/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapterTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapterTest.java
@@ -114,4 +114,19 @@ class GoogleExcelAdapterTest {
     void 컬럼_0개는_A로_변환된다() {
         assertThat(GoogleExcelAdapter.columnLetter(0)).isEqualTo("A");
     }
+
+    @Test
+    void 컬럼_26개는_Z로_변환된다() {
+        assertThat(GoogleExcelAdapter.columnLetter(26)).isEqualTo("Z");
+    }
+
+    @Test
+    void 컬럼_27개는_AA로_변환된다() {
+        assertThat(GoogleExcelAdapter.columnLetter(27)).isEqualTo("AA");
+    }
+
+    @Test
+    void 컬럼_52개는_AZ로_변환된다() {
+        assertThat(GoogleExcelAdapter.columnLetter(52)).isEqualTo("AZ");
+    }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 팀 총점 계산을 심사위원 인원수와 무관하게 항상 "최고점/최저점 제외 후 평균" 방식으로 통일 (기존 5명 임계값 하드코딩 제거)
- 엑셀 심사 집계표가 `team.totalScore`(위 로직으로 계산된 값)를 그대로 재사용하도록 수정 (기존엔 엑셀에서 별도로 "제외 후 합계"를 재계산해서 앱 랭킹과 값이 어긋났음)
- 엑셀 컬럼 구성에서 팀명 컬럼 제거, 심사위원 헤더/컬럼 수를 실제 채점 인원수만큼 동적으로 생성
- 팀 데이터 행 수를 실제 팀 개수만큼 동적으로 처리하고, 템플릿 서식(테두리/병합/행높이/열너비)을 매 실행마다 명시적으로 다시 그려서 팀이 12개를 넘어도 표가 깨지지 않도록 수정
- `SecurityConfig`에서 `/team/**`이 `hasRole("ADMIN")`으로 설정돼 있었는데, 실제 권한은 `ROLE_` 접두어 없이 부여되어 항상 403이 나던 버그 수정 (`hasAnyAuthority(Role.ADMIN.name())`로 통일)

## 🔍 리뷰 시 참고사항
- 로컬에 MySQL/Redis 띄우고 관리자/심사위원 계정 + 24팀 + 144건 채점 데이터를 시딩해서 실제 라이브 Google Sheets 템플릿으로 다운로드 검증까지 완료했습니다 (검증 후 시트는 다시 clear됨, 잔여 데이터 없음).
- 예선/본선처럼 라운드에 따라 심사위원 수가 달라지는 부분은 이미 동적으로 처리되어 추가 코드가 필요 없다고 판단했습니다. 다만 라운드 전환 시 데이터 초기화/팀 관리 기능은 별도 논의가 필요해 노션에 제안서만 정리해두었습니다.

## ✅ 체크리스트
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요? (실제 Google Sheets 라이브 템플릿으로 검증)
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?

## 📎 관련 이슈
- Close #169 #168 