### PR TITLE
엑셀 다운로드 시 null 값으로 인한 컬럼 밀림 문제 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
@@ -44,7 +44,7 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
 
         Map<Long, Map<Long, Integer>> scoreMap = buildScoreMap(judgements);
         Map<Long, Integer> teamTotalMap = teams.stream()
-                .collect(Collectors.toMap(TeamEntity::getId, TeamEntity::getTotalScore));
+                .collect(Collectors.toMap(TeamEntity::getId, t -> nz(t.getTotalScore())));
         Map<Long, Integer> rankMap = denseRank(teamTotalMap);
 
         List<List<Object>> rows = new ArrayList<>();
@@ -84,11 +84,11 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
             Map<Long, Integer> teamTotalMap,
             Map<Long, Integer> rankMap) {
         List<Object> row = new ArrayList<>();
-        row.add(team.getPerformOrder());
+        row.add(nz(team.getPerformOrder()));
         judgeIds.forEach(judgeId ->
-                row.add(scoreMap.getOrDefault(team.getId(), Collections.emptyMap()).get(judgeId)));
-        row.add(teamTotalMap.get(team.getId()));
-        row.add(rankMap.get(team.getId()));
+                row.add(scoreMap.getOrDefault(team.getId(), Collections.emptyMap()).getOrDefault(judgeId, 0)));
+        row.add(nz(teamTotalMap.get(team.getId())));
+        row.add(nz(rankMap.get(team.getId())));
         return row;
     }
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
@@ -85,8 +85,8 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
             Map<Long, Integer> rankMap) {
         List<Object> row = new ArrayList<>();
         row.add(nz(team.getPerformOrder()));
-        judgeIds.forEach(judgeId ->
-                row.add(scoreMap.getOrDefault(team.getId(), Collections.emptyMap()).getOrDefault(judgeId, 0)));
+        Map<Long, Integer> teamScores = scoreMap.getOrDefault(team.getId(), Collections.emptyMap());
+        judgeIds.forEach(judgeId -> row.add(teamScores.getOrDefault(judgeId, 0)));
         row.add(nz(teamTotalMap.get(team.getId())));
         row.add(nz(rankMap.get(team.getId())));
         return row;

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
@@ -181,4 +181,53 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         // 헤더: 심사번호 + 심사위원 20명 + 산출점수 + 순위 = 23컬럼
         assertThat(rows.get(0)).hasSize(23);
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void 팀을_채점하지_않은_심사위원의_점수는_0으로_채워지고_뒤_컬럼이_밀리지_않는다() {
+        TeamEntity teamA = team(1L, 1, "팀A", 99);
+        TeamEntity teamB = team(2L, 2, "팀B", 10);
+        UserEntity judge1 = user(1L);
+        UserEntity judge2 = user(2L);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB));
+        // judge2는 teamB만 채점하고 teamA는 채점하지 않음
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
+                judgement(teamA, judge1, 10, 5, 5),
+                judgement(teamB, judge1, 5, 5, 0),
+                judgement(teamB, judge2, 5, 5, 0)
+        ));
+
+        service.execute();
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(googleExcelAdapter).exportSummary(captor.capture());
+        List<Object> teamARow = ((List<List<Object>>) captor.getValue()).get(1);
+
+        // 심사번호, 심사위원(A)=20, 심사위원(B)=0(null 아님, 밀리지 않음), 산출점수=99, 순위=1
+        assertThat(teamARow).containsExactly(1, 20, 0, 99, 1);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void performOrder가_null인_팀은_심사번호가_0으로_채워지고_뒤_컬럼이_밀리지_않는다() {
+        TeamEntity teamA = TeamEntity.builder()
+                .id(1L)
+                .teamName("팀A")
+                .school("광주고")
+                .teamStatus(TeamStatus.PENDING)
+                .teamGenre(TeamGenre.SING)
+                .performOrder(null)
+                .totalScore(50)
+                .build();
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
+
+        service.execute();
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(googleExcelAdapter).exportSummary(captor.capture());
+        List<Object> dataRow = ((List<List<Object>>) captor.getValue()).get(1);
+
+        assertThat(dataRow).containsExactly(0, 50, 1);
+    }
 }


### PR DESCRIPTION
## ✨ 작업 내용
심사 집계표 엑셀 다운로드 시, 채점하지 않은 심사위원의 점수나 순서 미배정 팀의 심사번호가 null로 들어가면서 뒤 컬럼들이 밀려 엉뚱한 값이 표시되던 문제 수정.

---

## 🔍 리뷰 시 참고사항
- 원인: `DownloadJudgingSummaryExcelServiceImpl.buildRow()`가 만드는 행(row)에 Java `null`이 들어갈 수 있었는데, `google-api-client`가 리스트 안의 `null`을 직렬화 시 스킵해버려서 그 뒤 값들이 한 칸씩 당겨져 써짐.
- 수정: 심사번호 / 심사위원별 점수 / 산출점수 / 순위 4곳 모두 기존 `nz()` 헬퍼(또는 `getOrDefault(..., 0)`)로 감싸 null이 절대 row에 들어가지 않도록 고정.
- 참고: `performOrder`가 null인 팀은 심사번호가 `0`으로 표시되는데, 이는 관리자가 아직 팀 순서를 배정하지 않은 데이터 문제이지 이번 수정 범위(엑셀 코드)의 문제는 아님.

---

## ✅ 체크리스트
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요? (관련 단위 테스트 8건 전체 통과)
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요? (회귀 테스트 2건 추가)
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요? (해당 없음)
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #175