### PR TITLE
DEV 배포 docker network 이름 불일치 수정

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -47,7 +47,7 @@ jobs:
           docker run -d \
             --name spring-app-dev \
             --restart always \
-            --network gwangju-talent-festival-server-v2_default \
+            --network gwangjutalentfestival_default \
             --env-file .env \
             -e SPRING_DOCKER_COMPOSE_ENABLED=false \
             -p 8081:8080 \


### PR DESCRIPTION
## 문제
PR #174 배포 후 DEV 컨테이너가 계속 크래시 루프:
```
Unable to determine Dialect without JDBC metadata
Caused by: ... Network is unreachable
```

## 원인
`docker-compose.dev.yml`의 `name: gwangjutalentfestival` 필드가 이제 정상 반영되어 실제 생성되는 네트워크가 `gwangjutalentfestival_default`인데, `cd-develop.yml`의 앱 컨테이너는 옛 이름(`gwangju-talent-festival-server-v2_default`)에 붙으려고 해서 DB(외부 10.0.0.79)/Redis 연결이 끊김.

## 수정
`--network` 값을 실제 생성되는 이름으로 맞춤.

## 테스트
서버에서 수동으로 올바른 네트워크로 재기동 후 정상 응답 확인 (401)