### PR TITLE
엑셀 null 밀림 방지 회귀 테스트 및 GsonFactory 직렬화 검증 테스트 추가

### DIFF
--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
@@ -230,4 +230,37 @@ class DownloadJudgingSummaryExcelServiceImplTest {
 
         assertThat(dataRow).containsExactly(0, 50, 1);
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void 심사위원이_전체_팀_중_한_팀만_평가해도_나머지_팀은_0으로_채워지고_밀리지_않는다() {
+        TeamEntity teamA = team(1L, 1, "팀A", 0);
+        TeamEntity teamB = team(2L, 2, "팀B", 0);
+        TeamEntity teamC = team(3L, 3, "팀C", 0);
+        TeamEntity teamD = team(4L, 4, "팀D", 0);
+        UserEntity judge1 = user(1L);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB, teamC, teamD));
+        // judge1이 teamB 한 팀만 평가하고 나머지는 아무 동작도 하지 않음(저장 자체가 없음)
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
+                judgement(teamB, judge1, 10, 10, 10)
+        ));
+
+        service.execute();
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(googleExcelAdapter).exportSummary(captor.capture());
+        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
+
+        assertThat(rows.get(0)).containsExactly("심사번호", "심사위원 (A)", "산출점수", "순위");
+        int expectedColumnCount = rows.get(0).size();
+        rows.forEach(row -> {
+            assertThat(row).hasSize(expectedColumnCount);
+            assertThat(row).doesNotContainNull();
+        });
+
+        assertThat(rows.get(1)).containsExactly(1, 0, 0, 1); // teamA: 평가 안 받음 → 0
+        assertThat(rows.get(2)).containsExactly(2, 30, 0, 1); // teamB: judge1이 평가한 팀 → 실제 점수
+        assertThat(rows.get(3)).containsExactly(3, 0, 0, 1); // teamC: 평가 안 받음 → 0
+        assertThat(rows.get(4)).containsExactly(4, 0, 0, 1); // teamD: 평가 안 받음 → 0
+    }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapterTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapterTest.java
@@ -1,11 +1,13 @@
 package team.startup.gwangjutalentfestival.global.thirdparty.google.adapter;
 
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.BatchUpdateSpreadsheetRequest;
 import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.SheetProperties;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
+import com.google.api.services.sheets.v4.model.ValueRange;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.exception.GoogleSheetsException;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.properties.GoogleExcelProperties;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -98,6 +101,18 @@ class GoogleExcelAdapterTest {
 
         assertThatThrownBy(() -> adapter.exportSummary(rows))
                 .isInstanceOf(GoogleSheetsException.class);
+    }
+
+    @Test
+    void row에_null이_있으면_GsonFactory_직렬화_시_해당_칸이_통째로_사라진다() throws Exception {
+        // exportSummary 호출자가 row에 절대 null을 넣으면 안 되는 이유를 실제 직렬화 결과로 증명한다.
+        // null은 "빈 문자열"처럼 그 칸만 비는 게 아니라, 배열 자체에서 빠져 뒤 값들이 앞으로 당겨진다.
+        List<List<Object>> rows = List.of(List.of(1, 2, 3), Arrays.asList(1, null, 3, null, 5));
+        ValueRange valueRange = new ValueRange().setValues(rows);
+
+        String json = GsonFactory.getDefaultInstance().toString(valueRange);
+
+        assertThat(json).isEqualTo("{\"values\":[[1,2,3],[1,3,5]]}");
     }
 
     @Test


### PR DESCRIPTION
## ✨ 작업 내용
PR #176(null 값으로 인한 엑셀 컬럼 밀림 수정)에 대한 추가 검증 테스트 2건 작성. production 코드 변경 없음, 테스트만 추가.

---

## 🔍 리뷰 시 참고사항
- `DownloadJudgingSummaryExcelServiceImplTest`: 심사위원 1명이 전체 팀 중 1팀만 평가하고 나머지 팀은 아무 저장도 안 한 실사용 시나리오를 재현 → 나머지 팀의 해당 심사위원 컬럼이 전부 0(null 아님)으로 채워지고 행 길이가 밀리지 않음을 검증.
- `GoogleExcelAdapterTest`: 애초 버그 원인 가설("google-api-client의 GsonFactory가 List 안의 null을 직렬화 시 스킵한다")을 실제 라이브러리로 직접 검증 → `[1,null,3,null,5]`가 `{"values":[[1,3,5]]}`로 직렬화됨을 확인.

---

## ✅ 체크리스트
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요? (전체 19개 테스트 통과)
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요? (해당 없음)
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #178