### PR TITLE
JWT 서명 검증 실패 시 예외 포착 오류 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/global/jwt/JwtProvider.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/jwt/JwtProvider.java
@@ -2,6 +2,7 @@ package team.startup.gwangjutalentfestival.global.jwt;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/team/startup/gwangjutalentfestival/global/jwt/JwtProviderTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/jwt/JwtProviderTest.java
@@ -40,9 +40,6 @@ class JwtProviderTest {
 
     private String tamperSignature(String token) {
         String[] parts = token.split("\\.");
-        char lastChar = parts[2].charAt(parts[2].length() - 1);
-        char replacement = lastChar == 'A' ? 'B' : 'A';
-        String tamperedSignature = parts[2].substring(0, parts[2].length() - 1) + replacement;
-        return parts[0] + "." + parts[1] + "." + tamperedSignature;
+        return parts[0] + "." + parts[1] + "." + "invalidSignature";
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/global/jwt/JwtProviderTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/jwt/JwtProviderTest.java
@@ -1,0 +1,48 @@
+package team.startup.gwangjutalentfestival.global.jwt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class JwtProviderTest {
+
+    private JwtProvider jwtProvider;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = new JwtProperties(
+                "test-secret-key-for-jwt-provider-unit-test-1234567890",
+                3600L,
+                3600L
+        );
+        jwtProvider = new JwtProvider(jwtProperties);
+        jwtProvider.init();
+    }
+
+    @Test
+    void 서명이_변조된_토큰은_예외_없이_유효하지_않은_토큰으로_판별한다() {
+        String token = jwtProvider.generateAccessToken(1L, Role.USER);
+        String tamperedToken = tamperSignature(token);
+
+        assertThatCode(() -> jwtProvider.validateToken(tamperedToken)).doesNotThrowAnyException();
+        assertThat(jwtProvider.validateToken(tamperedToken)).isFalse();
+    }
+
+    @Test
+    void 정상_토큰은_유효한_토큰으로_판별한다() {
+        String token = jwtProvider.generateAccessToken(1L, Role.USER);
+
+        assertThat(jwtProvider.validateToken(token)).isTrue();
+    }
+
+    private String tamperSignature(String token) {
+        String[] parts = token.split("\\.");
+        char lastChar = parts[2].charAt(parts[2].length() - 1);
+        char replacement = lastChar == 'A' ? 'B' : 'A';
+        String tamperedSignature = parts[2].substring(0, parts[2].length() - 1) + replacement;
+        return parts[0] + "." + parts[1] + "." + tamperedSignature;
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
JWT 서명 검증 실패 시 예외가 정상적으로 포착되지 않던 문제를 수정하였습니다.

`JwtProvider.validateToken()`에서 `import io.jsonwebtoken.*;` 와일드카드 임포트로 인해 catch 절의 `SecurityException`이 `java.lang.SecurityException`으로 해석되고 있었습니다. JJWT 0.12.6에서는 `io.jsonwebtoken.SecurityException`(구버전 최상위 클래스)이 더 이상 존재하지 않고 `io.jsonwebtoken.security.SecurityException`으로 완전히 이전되었는데, 이 사실이 반영되지 않아 실제 서명 불일치 시 던져지는 `io.jsonwebtoken.security.SignatureException`이 catch절에 걸리지 않았습니다.

`io.jsonwebtoken.security.SecurityException`을 명시적으로 import하여 catch절이 올바른 예외를 포착하도록 수정하였습니다.

---

## 🔍 리뷰 시 참고사항
- `validateToken()` 호출부인 `JwtFilter`는 해당 호출을 try/catch로 감싸지 않고 있어, 위 예외가 새어나갈 경우 필터 체인 밖으로 전파되어 500 에러로 이어질 수 있는 구조였습니다.
- 서명이 변조된 토큰에 대해 예외 없이 `false`를 반환하는지 검증하는 회귀 테스트(`JwtProviderTest`)를 추가하였습니다. 수정 전 코드에서는 해당 테스트가 실패하는 것을 직접 확인했습니다.
- 전체 테스트 스위트 실행 결과 JWT 관련 테스트는 모두 통과했으며, 실패한 3건은 `ApplicationContext` 로딩 실패(로컬 DB/Redis 인프라 문제)로 이번 변경과 무관합니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #