### PR TITLE
actuator health 엔드포인트 인증 예외 처리 추가

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
@@ -11,9 +11,8 @@ public final class PublicEndpointMatcher {
 
     private static final List<RequestMatcher> PUBLIC_ENDPOINTS = List.of(
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/auth(?:/.*)?")),
-            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/health(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/excel(?:/.*)?")),
-            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/prometheus(?:/.*)?")),
+            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/actuator/health(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/actuator/prometheus(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/vote/[^/]+")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/error")),


### PR DESCRIPTION
## ✨ 작업 내용
`GET /actuator/health`가 인증 없이 호출해도 401을 반환하던 문제 수정. `PublicEndpointMatcher`에 `/actuator/health` 매처를 추가하고, base-path 변경(`/` → `/actuator`) 이후 더 이상 매칭되지 않던 죽은 매처(`/health`, `/prometheus`)를 정리함.

---

## 🔍 리뷰 시 참고사항
- 원인: `0edab88` 커밋에서 `management.endpoints.web.base-path`를 `/actuator`로 변경했지만, `PublicEndpointMatcher`에는 `/actuator/prometheus`만 추가되고 `/actuator/health`는 누락되어 `anyRequest().authenticated()`에 걸려 401 발생
- `^/health(?:/.*)?`, `^/prometheus(?:/.*)?`는 현재 base-path 설정 하에서는 실제 요청과 매칭되지 않는 죽은 코드라 함께 삭제함
- `compileJava`는 확인했으나, 실제 서버 기동 후 `/actuator/health` 200 응답 여부는 로컬에서 재확인 필요

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [ ] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #181