### PR TITLE
fix: DEV MySQL을 MariaDB로 교체 - CPU 호환성 + DB 인스턴스 삭제 대응

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,17 +2,17 @@ name: gwangjutalentfestival
 
 services:
   mysql:
-    image: mysql:8.0
+    image: mariadb:10.11
     container_name: mysql
     environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE:-}
-      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-}
+      MARIADB_DATABASE: ${MYSQL_DATABASE:-}
+      MARIADB_ROOT_PASSWORD: ${DB_PASSWORD:-}
     ports:
       - "3306:3306"
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$$MYSQL_ROOT_PASSWORD"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$$MARIADB_ROOT_PASSWORD"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## 배경
DEV가 의존하던 외부 DB 인스턴스(`10.0.0.79`)가 삭제되어 완전히 죽어있었음.

로컬 mysql 컨테이너로 대체하려 했으나, gsmsv 서버의 가상 CPU가 x86-64-v2를 지원하지 않아서 `mysql:8.0` 이미지가 계속 크래시:
```
Fatal glibc error: CPU does not support x86-64-v2
```

## 수정
- `mysql:8.0` → `mariadb:10.11`로 교체 (이 CPU에서 정상 동작 확인)
- `ENV_FILE_DEV` secret의 `DB_URL`을 로컬 컨테이너(`mysql:3306`)로 변경, `MYSQL_DATABASE` 추가

## 테스트
서버에서 직접 확인:
- MariaDB 컨테이너 healthy
- 앱 컨테이너 정상 기동, `/actuator/health` 200
- 테이블 전부 정상 생성

## ⚠️ 데이터 관련
기존 DB 인스턴스(`10.0.0.79`)가 삭제되면서 팀 24개, 심사 기록 등 기존 데이터는 백업 없이 소실됨. 완전히 빈 DB로 새로 시작.