### PR TITLE
에러/지연 요청 디스코드 알림 필터 추가

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/GwangjutalentfestivalApplication.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import team.startup.gwangjutalentfestival.domain.monitoring.properties.DatasetProperties;
 import team.startup.gwangjutalentfestival.domain.monitoring.properties.MlProperties;
 import team.startup.gwangjutalentfestival.domain.monitoring.properties.MonitoringProperties;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.RequestAlertProperties;
 import team.startup.gwangjutalentfestival.domain.slogan.properties.SloganSubmissionProperties;
 import team.startup.gwangjutalentfestival.global.jwt.JwtProperties;
 import team.startup.gwangjutalentfestival.global.s3.properties.AwsS3Properties;
@@ -23,7 +24,7 @@ import team.startup.gwangjutalentfestival.global.sms.properties.SolapiProperties
 @EnableFeignClients
 @EnableAsync
 @EnableScheduling
-@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class, SolapiProperties.class, SmsVerifyProperties.class, SloganSubmissionProperties.class, MonitoringProperties.class, DatasetProperties.class, MlProperties.class, AwsS3Properties.class})
+@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class, SolapiProperties.class, SmsVerifyProperties.class, SloganSubmissionProperties.class, MonitoringProperties.class, DatasetProperties.class, MlProperties.class, AwsS3Properties.class, RequestAlertProperties.class})
 @SpringBootApplication
 public class GwangjutalentfestivalApplication {
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/filter/RequestAlertFilter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/filter/RequestAlertFilter.java
@@ -1,0 +1,69 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.DiscordWebhookClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.RequestAlertProperties;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 요청당 한 번 실행되며, 에러 응답이거나 지정된 임계값을 넘는 지연 요청을 즉시 디스코드로 알린다.
+ * <p>Spring Security 필터 체인보다 앞서 동작하도록 최우선 순위로 등록되어, 인증 실패(401/403)를 포함한
+ * 전체 요청 처리 시간을 측정한다.</p>
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class RequestAlertFilter extends OncePerRequestFilter {
+
+    private static final ZoneId ZONE_SEOUL = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final RequestAlertProperties requestAlertProperties;
+    private final DiscordWebhookClient discordWebhookClient;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        if (!requestAlertProperties.enabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        long start = System.currentTimeMillis();
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long durationMillis = System.currentTimeMillis() - start;
+            int status = response.getStatus();
+            boolean isError = status >= 400;
+            boolean isSlow = durationMillis >= requestAlertProperties.slowThresholdMillis();
+
+            if (isError || isSlow) {
+                discordWebhookClient.send(buildMessage(request, status, durationMillis, isError));
+            }
+        }
+    }
+
+    private String buildMessage(HttpServletRequest request, int status, long durationMillis, boolean isError) {
+        String emoji = isError ? "🔥" : "🐢";
+        String tag = isError ? "ERROR" : "SLOW";
+        String time = LocalDateTime.now(ZONE_SEOUL).format(TIME_FORMATTER);
+        return "%s [%s] %s | %s %s → %d (%dms)".formatted(
+                emoji, tag, time, request.getMethod(), request.getRequestURI(), status, durationMillis
+        );
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/properties/RequestAlertProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/monitoring/properties/RequestAlertProperties.java
@@ -1,0 +1,9 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("monitoring.request-alert")
+public record RequestAlertProperties(
+        boolean enabled,
+        long slowThresholdMillis
+) {}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -120,6 +120,9 @@ monitoring:
     enabled: ${ANOMALY_DETECTOR_ENABLED:false}
     prometheus-base-url: ${PROMETHEUS_BASE_URL:http://localhost:9090}
     discord-webhook-url: ${DISCORD_WEBHOOK_URL:}
+  request-alert:
+    enabled: ${REQUEST_ALERT_ENABLED:false}
+    slow-threshold-millis: ${REQUEST_ALERT_SLOW_THRESHOLD_MILLIS:3000}
   ml:
     enabled: ${ML_ANOMALY_SCORE_ENABLED:false}
     base-url: ${ML_SERVER_BASE_URL:}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/filter/RequestAlertFilterTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/monitoring/filter/RequestAlertFilterTest.java
@@ -1,0 +1,96 @@
+package team.startup.gwangjutalentfestival.domain.monitoring.filter;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.DiscordWebhookClient;
+import team.startup.gwangjutalentfestival.domain.monitoring.properties.RequestAlertProperties;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RequestAlertFilterTest {
+
+    @Mock
+    private DiscordWebhookClient discordWebhookClient;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest("GET", "/team");
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    void 알림이_비활성화되어_있으면_에러가_발생해도_전송하지_않는다() throws Exception {
+        RequestAlertFilter filter = new RequestAlertFilter(
+                new RequestAlertProperties(false, 3_000), discordWebhookClient
+        );
+        doAnswer(invocation -> {
+            response.setStatus(500);
+            return null;
+        }).when(filterChain).doFilter(request, response);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(discordWebhookClient, never()).send(anyString());
+    }
+
+    @Test
+    void 정상_응답이고_임계값보다_빠르면_전송하지_않는다() throws Exception {
+        RequestAlertFilter filter = new RequestAlertFilter(
+                new RequestAlertProperties(true, 3_000), discordWebhookClient
+        );
+        doAnswer(invocation -> {
+            response.setStatus(200);
+            return null;
+        }).when(filterChain).doFilter(request, response);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(discordWebhookClient, never()).send(anyString());
+    }
+
+    @Test
+    void 에러_응답이면_디스코드로_전송한다() throws Exception {
+        RequestAlertFilter filter = new RequestAlertFilter(
+                new RequestAlertProperties(true, 999_999), discordWebhookClient
+        );
+        doAnswer(invocation -> {
+            response.setStatus(500);
+            return null;
+        }).when(filterChain).doFilter(request, response);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(discordWebhookClient).send(anyString());
+    }
+
+    @Test
+    void 임계값을_초과하는_느린_요청이면_디스코드로_전송한다() throws Exception {
+        RequestAlertFilter filter = new RequestAlertFilter(
+                new RequestAlertProperties(true, 0), discordWebhookClient
+        );
+        doAnswer(invocation -> {
+            response.setStatus(200);
+            return null;
+        }).when(filterChain).doFilter(request, response);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(discordWebhookClient).send(anyString());
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -76,6 +76,9 @@ monitoring:
     enabled: false
     prometheus-base-url: http://localhost:9090
     discord-webhook-url: ""
+  request-alert:
+    enabled: false
+    slow-threshold-millis: 3000
   ml:
     enabled: false
     base-url: ""


### PR DESCRIPTION
## Summary
- 요청 처리 중 에러(4xx/5xx) 응답이거나 응답 시간이 임계값을 초과하는 경우, 기존 Discord 웹훅(`DiscordWebhookClient`, `monitoring.anomaly.discord-webhook-url`)으로 즉시 알림을 전송하는 `RequestAlertFilter`를 추가했습니다.
- 정상 요청은 알림을 보내지 않아 채널 스팸을 방지하며, `monitoring.request-alert.enabled` 로 기능 자체를 끄고 켤 수 있습니다.
- 기존 60초 주기 집계 기반 이상탐지(`AnomalyDetector`)와는 별개의 실시간 요청 단위 알림 기능입니다.

## 변경 사항
- `RequestAlertFilter` (신규): `OncePerRequestFilter` 기반, `@Order(Ordered.HIGHEST_PRECEDENCE)`로 Spring Security 필터보다 먼저 동작하여 인증 실패(401/403)를 포함한 전체 요청 처리 시간을 측정
- `RequestAlertProperties` (신규): `monitoring.request-alert.enabled`, `monitoring.request-alert.slow-threshold-millis` 바인딩
- `application.yaml` / 테스트 `application.yaml`: 새 프로퍼티 섹션 추가 (`REQUEST_ALERT_ENABLED`, `REQUEST_ALERT_SLOW_THRESHOLD_MILLIS` 환경변수, 기본값 각각 `false`, `3000`)
- `GwangjutalentfestivalApplication`: `RequestAlertProperties` 를 `@EnableConfigurationProperties` 에 등록

## Test plan
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `RequestAlertFilterTest` (4개 케이스: 비활성화 시 미전송 / 정상 응답 미전송 / 에러 응답 전송 / 임계값 초과 지연 응답 전송) 통과
- [x] 전체 회귀 테스트(`./gradlew test`) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)