### PR TITLE
심사위원별 개별 심사표 다운로드 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.0
+        image: mariadb:10.11
         env:
-          MYSQL_ROOT_PASSWORD: "1234"
-          MYSQL_DATABASE: gwangjutalentfestival
+          MARIADB_ROOT_PASSWORD: "1234"
+          MARIADB_DATABASE: gwangjutalentfestival
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping -p1234"
+          --health-cmd="mariadb-admin ping -h localhost -uroot -p1234"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5

--- a/build.gradle
+++ b/build.gradle
@@ -77,8 +77,11 @@ dependencies {
     implementation 'com.google.api-client:google-api-client:2.5.0'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.24.0'
 
+    // Excel
+    implementation 'org.apache.poi:poi-ooxml:5.3.0'
+
     // Database
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/controller/ExcelController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/controller/ExcelController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgingSummaryExcelService;
+import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgeSheetsService;
 
 import java.nio.charset.StandardCharsets;
 
@@ -23,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 public class ExcelController {
 
     private final DownloadJudgingSummaryExcelService downloadJudgingSummaryExcelService;
+    private final DownloadJudgeSheetsService downloadJudgeSheetsService;
 
     @Operation(summary = "심사 집계표 다운로드", description = "전체 팀의 심사 집계 결과를 xlsx 파일로 다운로드합니다.")
     @ApiResponses({
@@ -37,6 +39,27 @@ public class ExcelController {
         headers.setContentDisposition(
                 ContentDisposition.attachment()
                         .filename("심사집계표.xlsx", StandardCharsets.UTF_8)
+                        .build()
+        );
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(file);
+    }
+
+    @Operation(summary = "심사위원별 심사표 다운로드", description = "집계표와 심사위원별 개별 심사표가 담긴 ZIP 파일을 다운로드합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "다운로드 성공")
+    })
+    @GetMapping("/judge-sheets")
+    public ResponseEntity<byte[]> downloadJudgeSheets() {
+        byte[] file = downloadJudgeSheetsService.execute();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("application/zip"));
+        headers.setContentDisposition(
+                ContentDisposition.attachment()
+                        .filename("심사결과.zip", StandardCharsets.UTF_8)
                         .build()
         );
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsService.java
@@ -1,0 +1,5 @@
+package team.startup.gwangjutalentfestival.domain.excel.service;
+
+public interface DownloadJudgeSheetsService {
+    byte[] execute();
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
@@ -61,7 +61,8 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
         Map<JudgeTeamKey, JudgeCommentEntity> comments = commentMap(judgeCommentRepository.findAllWithUserAndTeam());
         byte[] judgeTemplate = googleExcelAdapter.exportJudgeTemplate();
 
-        try (ByteArrayOutputStream output = new ByteArrayOutputStream(); ZipOutputStream zip = new ZipOutputStream(output)) {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(output)) {
             writeZipEntry(zip, "심사집계표.xlsx", downloadJudgingSummaryExcelService.execute());
 
             List<Long> judgeIds = judgements.stream()
@@ -74,11 +75,10 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
                 writeZipEntry(zip, "심사위원_" + judgeLabel(index) + "_개별심사표.xlsx",
                         createJudgeSheet(judgeTemplate, teams, judgements, comments, judgeId, judgeLabel(index)));
             }
-            zip.finish();
-            return output.toByteArray();
         } catch (IOException e) {
             throw new IllegalStateException("심사표 ZIP을 생성할 수 없습니다.", e);
         }
+        return output.toByteArray();
     }
 
     private byte[] createJudgeSheet(
@@ -103,7 +103,10 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             cell(headerRow, 1).setCellValue("심사위원 " + judgeLabel);
             cell(headerRow, COMMENT_COLUMN).setCellValue("코멘트");
 
-            Drawing<?> drawing = sheet.createDrawingPatriarch();
+            Drawing<?> drawing = sheet.getDrawingPatriarch();
+            if (drawing == null) {
+                drawing = sheet.createDrawingPatriarch();
+            }
             for (int index = 0; index < teams.size(); index++) {
                 TeamEntity team = teams.get(index);
                 JudgementEntity judgement = scoreMap.get(team.getId());
@@ -116,7 +119,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
                 cell(row, 1).setCellValue(completeness + creativity + stage);
 
                 JudgeCommentEntity comment = comments.get(new JudgeTeamKey(judgeId, team.getId()));
-                if (comment != null && comment.getStrokes().isArray() && !comment.getStrokes().isEmpty()) {
+                if (comment != null && comment.getStrokes() != null && comment.getStrokes().isArray() && !comment.getStrokes().isEmpty()) {
                     addCommentImage(workbook, drawing, rowIndex, renderComment(comment.getStrokes()));
                 }
             }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
@@ -1,0 +1,225 @@
+package team.startup.gwangjutalentfestival.domain.excel.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.Drawing;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgeSheetsService;
+import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgingSummaryExcelService;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeCommentEntity;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
+import team.startup.gwangjutalentfestival.global.thirdparty.google.properties.GoogleExcelProperties;
+
+import javax.imageio.ImageIO;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.geom.Path2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+@Service
+@RequiredArgsConstructor
+public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsService {
+
+    private static final int COMMENT_WIDTH = 360;
+    private static final int COMMENT_HEIGHT = 160;
+    private static final int HEADER_ROW = 2;
+    private static final int FIRST_DATA_ROW = 3;
+    private static final int PRESERVED_ROW = 11;
+    private static final int COMMENT_COLUMN = 2;
+
+    private final TeamRepository teamRepository;
+    private final JudgementRepository judgementRepository;
+    private final JudgeCommentRepository judgeCommentRepository;
+    private final DownloadJudgingSummaryExcelService downloadJudgingSummaryExcelService;
+    private final GoogleExcelAdapter googleExcelAdapter;
+    private final GoogleExcelProperties googleExcelProperties;
+
+    @Override
+    public byte[] execute() {
+        List<TeamEntity> teams = teamRepository.findAllByOrderByPerformOrderAsc();
+        List<JudgementEntity> judgements = judgementRepository.findAllWithUserAndTeam();
+        Map<JudgeTeamKey, JudgeCommentEntity> comments = commentMap(judgeCommentRepository.findAllWithUserAndTeam());
+        byte[] judgeTemplate = googleExcelAdapter.exportJudgeTemplate();
+
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream(); ZipOutputStream zip = new ZipOutputStream(output)) {
+            writeZipEntry(zip, "심사집계표.xlsx", downloadJudgingSummaryExcelService.execute());
+
+            List<Long> judgeIds = judgements.stream()
+                    .map(judgement -> judgement.getUser().getId())
+                    .distinct()
+                    .sorted()
+                    .toList();
+            for (int index = 0; index < judgeIds.size(); index++) {
+                Long judgeId = judgeIds.get(index);
+                writeZipEntry(zip, "심사위원_" + judgeLabel(index) + "_개별심사표.xlsx",
+                        createJudgeSheet(judgeTemplate, teams, judgements, comments, judgeId, judgeLabel(index)));
+            }
+            zip.finish();
+            return output.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException("심사표 ZIP을 생성할 수 없습니다.", e);
+        }
+    }
+
+    private byte[] createJudgeSheet(
+            byte[] template,
+            List<TeamEntity> teams,
+            List<JudgementEntity> judgements,
+            Map<JudgeTeamKey, JudgeCommentEntity> comments,
+            Long judgeId,
+            String judgeLabel) throws IOException {
+        Map<Long, JudgementEntity> scoreMap = new HashMap<>();
+        judgements.stream()
+                .filter(judgement -> judgeId.equals(judgement.getUser().getId()))
+                .forEach(judgement -> scoreMap.put(judgement.getTeam().getId(), judgement));
+
+        try (Workbook workbook = new XSSFWorkbook(new ByteArrayInputStream(template)); ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.getSheet(googleExcelProperties.judgeTemplatePage());
+            if (sheet == null) {
+                throw new IllegalStateException("개별 심사표 템플릿 탭을 찾을 수 없습니다.");
+            }
+            Row headerRow = row(sheet, HEADER_ROW);
+            cell(headerRow, 0).setCellValue("심사순서");
+            cell(headerRow, 1).setCellValue("심사위원 " + judgeLabel);
+            cell(headerRow, COMMENT_COLUMN).setCellValue("코멘트");
+
+            Drawing<?> drawing = sheet.createDrawingPatriarch();
+            for (int index = 0; index < teams.size(); index++) {
+                TeamEntity team = teams.get(index);
+                JudgementEntity judgement = scoreMap.get(team.getId());
+                int rowIndex = dataRow(index);
+                Row row = row(sheet, rowIndex);
+                cell(row, 0).setCellValue(orZero(team.getPerformOrder()));
+                int completeness = judgement == null ? 0 : orZero(judgement.getCompletenessExpressionScore());
+                int creativity = judgement == null ? 0 : orZero(judgement.getCreativityCompositionScore());
+                int stage = judgement == null ? 0 : orZero(judgement.getStagePerformanceTeamworkScore());
+                cell(row, 1).setCellValue(completeness + creativity + stage);
+
+                JudgeCommentEntity comment = comments.get(new JudgeTeamKey(judgeId, team.getId()));
+                if (comment != null && comment.getStrokes().isArray() && !comment.getStrokes().isEmpty()) {
+                    addCommentImage(workbook, drawing, rowIndex, renderComment(comment.getStrokes()));
+                }
+            }
+            workbook.write(output);
+            return output.toByteArray();
+        }
+    }
+
+    private void addCommentImage(Workbook workbook, Drawing<?> drawing, int rowIndex, byte[] image) {
+        int pictureIndex = workbook.addPicture(image, Workbook.PICTURE_TYPE_PNG);
+        ClientAnchor anchor = workbook.getCreationHelper().createClientAnchor();
+        anchor.setCol1(COMMENT_COLUMN);
+        anchor.setCol2(COMMENT_COLUMN + 2);
+        anchor.setRow1(rowIndex);
+        anchor.setRow2(rowIndex + 1);
+        drawing.createPicture(anchor, pictureIndex);
+    }
+
+    private byte[] renderComment(JsonNode strokes) throws IOException {
+        BufferedImage image = new BufferedImage(COMMENT_WIDTH, COMMENT_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, COMMENT_WIDTH, COMMENT_HEIGHT);
+            graphics.setStroke(new BasicStroke(2f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            for (JsonNode stroke : strokes) {
+                JsonNode points = stroke.path("points");
+                if (!points.isArray() || points.isEmpty()) {
+                    continue;
+                }
+                graphics.setColor(parseColor(stroke.path("color").asText()));
+                Path2D path = new Path2D.Double();
+                boolean started = false;
+                for (JsonNode point : points) {
+                    if (!point.has("x") || !point.has("y")) {
+                        continue;
+                    }
+                    double x = Math.clamp(point.path("x").asDouble(), 0, 1) * (COMMENT_WIDTH - 1);
+                    double y = Math.clamp(point.path("y").asDouble(), 0, 1) * (COMMENT_HEIGHT - 1);
+                    if (started) {
+                        path.lineTo(x, y);
+                    } else {
+                        path.moveTo(x, y);
+                        started = true;
+                    }
+                }
+                if (started) {
+                    graphics.draw(path);
+                }
+            }
+        } finally {
+            graphics.dispose();
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", output);
+        return output.toByteArray();
+    }
+
+    private Map<JudgeTeamKey, JudgeCommentEntity> commentMap(List<JudgeCommentEntity> comments) {
+        Map<JudgeTeamKey, JudgeCommentEntity> result = new HashMap<>();
+        comments.forEach(comment -> result.put(new JudgeTeamKey(comment.getUser().getId(), comment.getTeam().getId()), comment));
+        return result;
+    }
+
+    private void writeZipEntry(ZipOutputStream zip, String name, byte[] content) throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.write(content);
+        zip.closeEntry();
+    }
+
+    private Color parseColor(String value) {
+        try {
+            return Color.decode(value);
+        } catch (NumberFormatException e) {
+            return Color.BLACK;
+        }
+    }
+
+    private int orZero(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private Row row(Sheet sheet, int index) {
+        Row row = sheet.getRow(index);
+        return row == null ? sheet.createRow(index) : row;
+    }
+
+    private org.apache.poi.ss.usermodel.Cell cell(Row row, int index) {
+        org.apache.poi.ss.usermodel.Cell cell = row.getCell(index);
+        return cell == null ? row.createCell(index) : cell;
+    }
+
+    private int dataRow(int teamIndex) {
+        int row = FIRST_DATA_ROW + teamIndex;
+        return row >= PRESERVED_ROW ? row + 1 : row;
+    }
+
+    private String judgeLabel(int index) {
+        return String.valueOf((char) ('A' + index));
+    }
+
+    private record JudgeTeamKey(Long judgeId, Long teamId) {
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgeCommentRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgeCommentRepository.java
@@ -9,6 +9,7 @@ import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface JudgeCommentRepository extends JpaRepository<JudgeCommentEntity, Long> {
     Optional<JudgeCommentEntity> findByTeamAndUser(TeamEntity team, UserEntity user);
@@ -24,4 +25,7 @@ public interface JudgeCommentRepository extends JpaRepository<JudgeCommentEntity
             ON DUPLICATE KEY UPDATE strokes = :strokes
             """, nativeQuery = true)
     void upsert(@Param("teamId") Long teamId, @Param("userId") Long userId, @Param("strokes") String strokes);
+
+    @Query("SELECT c FROM JudgeCommentEntity c JOIN FETCH c.user JOIN FETCH c.team")
+    List<JudgeCommentEntity> findAllWithUserAndTeam();
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapter.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/adapter/GoogleExcelAdapter.java
@@ -103,6 +103,23 @@ public class GoogleExcelAdapter {
         }
     }
 
+    public byte[] exportJudgeTemplate() {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            drive.files().export(properties.judgeTemplateSheetId(), XLSX_MIME_TYPE)
+                    .executeMediaAndDownloadTo(outputStream);
+            return outputStream.toByteArray();
+        } catch (GoogleJsonResponseException e) {
+            log.error("개별 심사표 템플릿 export API 오류 - statusCode: {}, message: {}", e.getStatusCode(), e.getMessage());
+            throw new GoogleSheetsApiException();
+        } catch (IOException e) {
+            log.error("개별 심사표 템플릿 export IO 오류 - message: {}", e.getMessage());
+            throw new GoogleSheetsIoException();
+        } catch (Exception e) {
+            log.error("개별 심사표 템플릿 export 예기치 못한 오류 - message: {}", e.getMessage());
+            throw new GoogleSheetsException();
+        }
+    }
+
     private void formatTable(String spreadsheetId, String page, int columnCount, int lastDataRow) throws IOException {
         if (columnCount == 0) {
             return;

--- a/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/properties/GoogleExcelProperties.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/thirdparty/google/properties/GoogleExcelProperties.java
@@ -5,6 +5,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "google.excel")
 public record GoogleExcelProperties(
         String templateSheetId,
-        String summaryPage
+        String summaryPage,
+        String judgeTemplateSheetId,
+        String judgeTemplatePage
 ) {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,10 +12,9 @@ spring:
       max-request-size: ${MAX_REQUEST_SIZE:500MB}
 
   datasource:
-    url: ${DB_URL:jdbc:mysql://localhost:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    url: ${DB_URL:jdbc:mariadb://localhost:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:1234}
-    driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 20
       minimum-idle: 5
@@ -75,6 +74,8 @@ google:
   excel:
     template-sheet-id: ${GOOGLE_EXCEL_TEMPLATE_SHEET_ID}
     summary-page: ${GOOGLE_EXCEL_SUMMARY_PAGE}
+    judge-template-sheet-id: ${GOOGLE_EXCEL_JUDGE_TEMPLATE_SHEET_ID}
+    judge-template-page: ${GOOGLE_EXCEL_JUDGE_TEMPLATE_PAGE}
 
 slogan:
   submission:

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
@@ -1,0 +1,201 @@
+package team.startup.gwangjutalentfestival.domain.excel.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.poi.ss.usermodel.PictureData;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.excel.service.impl.DownloadJudgeSheetsServiceImpl;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeCommentEntity;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.team.enums.TeamGenre;
+import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
+import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
+import team.startup.gwangjutalentfestival.global.thirdparty.google.properties.GoogleExcelProperties;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DownloadJudgeSheetsServiceImplTest {
+
+    @Mock private TeamRepository teamRepository;
+    @Mock private JudgementRepository judgementRepository;
+    @Mock private JudgeCommentRepository judgeCommentRepository;
+    @Mock private DownloadJudgingSummaryExcelService summaryExcelService;
+    @Mock private GoogleExcelAdapter googleExcelAdapter;
+    @Mock private GoogleExcelProperties googleExcelProperties;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private DownloadJudgeSheetsServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DownloadJudgeSheetsServiceImpl(
+                teamRepository, judgementRepository, judgeCommentRepository, summaryExcelService,
+                googleExcelAdapter, googleExcelProperties);
+        given(summaryExcelService.execute()).willReturn(new byte[]{1, 2, 3});
+        given(googleExcelAdapter.exportJudgeTemplate()).willReturn(template());
+        given(googleExcelProperties.judgeTemplatePage()).willReturn("개별 심사표");
+    }
+
+    @Test
+    void 집계표와_심사위원별_개별표를_ZIP으로_생성하고_점수와_필기이미지를_넣는다() throws Exception {
+        TeamEntity teamA = team(1L, 1);
+        TeamEntity teamB = team(2L, 2);
+        UserEntity judgeA = user(10L);
+        UserEntity judgeB = user(20L);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB));
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
+                judgement(teamA, judgeA, 20, 15, 25),
+                judgement(teamA, judgeB, 10, 10, 10)
+        ));
+        given(judgeCommentRepository.findAllWithUserAndTeam()).willReturn(List.of(
+                comment(teamA, judgeA, strokes()),
+                comment(teamB, judgeA, objectMapper.createArrayNode())
+        ));
+        Map<String, byte[]> files = zipEntries(service.execute());
+
+        assertThat(files).containsOnlyKeys("심사집계표.xlsx", "심사위원_A_개별심사표.xlsx", "심사위원_B_개별심사표.xlsx");
+        assertThat(files.get("심사집계표.xlsx")).containsExactly(1, 2, 3);
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_A_개별심사표.xlsx")))) {
+            var sheet = workbook.getSheet("개별 심사표");
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("원본 제목");
+            assertThat(sheet.getRow(2).getCell(0).getStringCellValue()).isEqualTo("심사순서");
+            assertThat(sheet.getRow(2).getCell(1).getStringCellValue()).isEqualTo("심사위원 A");
+            assertThat(sheet.getRow(2).getCell(2).getStringCellValue()).isEqualTo("코멘트");
+            assertThat(sheet.getRow(3).getCell(0).getNumericCellValue()).isEqualTo(1);
+            assertThat(sheet.getRow(3).getCell(1).getNumericCellValue()).isEqualTo(60);
+            assertThat(sheet.getRow(4).getCell(0).getNumericCellValue()).isEqualTo(2);
+            assertThat(sheet.getRow(4).getCell(1).getNumericCellValue()).isZero();
+            assertThat(workbook.getAllPictures()).hasSize(1);
+            assertThat(renderedImageHasColor(workbook.getAllPictures().getFirst(), Color.RED)).isTrue();
+            assertThat(renderedImageHasColor(workbook.getAllPictures().getFirst(), new Color(0x12, 0x12, 0x12))).isTrue();
+        }
+    }
+
+    @Test
+    void 열두번째_행은_보존하고_아홉번째_팀은_열세번째_행부터_작성한다() throws Exception {
+        List<TeamEntity> teams = java.util.stream.IntStream.rangeClosed(1, 9)
+                .mapToObj(index -> team(index, index))
+                .toList();
+        UserEntity judge = user(10L);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(teams);
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(judgement(teams.getFirst(), judge, 20, 15, 25)));
+        given(judgeCommentRepository.findAllWithUserAndTeam()).willReturn(List.of());
+
+        Map<String, byte[]> files = zipEntries(service.execute());
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_A_개별심사표.xlsx")))) {
+            var sheet = workbook.getSheet("개별 심사표");
+            assertThat(sheet.getRow(11).getCell(0).getStringCellValue()).isEqualTo("12행 보존");
+            assertThat(sheet.getRow(12).getCell(0).getNumericCellValue()).isEqualTo(9);
+        }
+    }
+
+    private byte[] template() {
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            var sheet = workbook.createSheet("개별 심사표");
+            for (int rowIndex = 0; rowIndex < 14; rowIndex++) {
+                var row = sheet.createRow(rowIndex);
+                for (int column = 0; column < 4; column++) {
+                    row.createCell(column);
+                }
+            }
+            sheet.getRow(0).getCell(0).setCellValue("원본 제목");
+            sheet.getRow(11).getCell(0).setCellValue("12행 보존");
+            workbook.write(output);
+            return output.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private boolean renderedImageHasColor(PictureData picture, Color color) throws IOException {
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(picture.getData()));
+        int expected = color.getRGB() & 0x00ffffff;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if ((image.getRGB(x, y) & 0x00ffffff) == expected) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private Map<String, byte[]> zipEntries(byte[] zip) throws IOException {
+        Map<String, byte[]> files = new java.util.HashMap<>();
+        try (ZipInputStream input = new ZipInputStream(new ByteArrayInputStream(zip))) {
+            ZipEntry entry;
+            while ((entry = input.getNextEntry()) != null) {
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                input.transferTo(output);
+                files.put(entry.getName(), output.toByteArray());
+            }
+        }
+        return files;
+    }
+
+    private TeamEntity team(long id, int order) {
+        return TeamEntity.builder()
+                .id(id)
+                .teamName("팀" + id)
+                .school("광주고")
+                .teamStatus(TeamStatus.PENDING)
+                .teamGenre(TeamGenre.SING)
+                .performOrder(order)
+                .totalScore(0)
+                .build();
+    }
+
+    private UserEntity user(long id) {
+        return UserEntity.builder().id(id).role(Role.ADMIN).build();
+    }
+
+    private JudgementEntity judgement(TeamEntity team, UserEntity user, int first, int second, int third) {
+        return JudgementEntity.builder()
+                .team(team)
+                .user(user)
+                .completenessExpressionScore(first)
+                .creativityCompositionScore(second)
+                .stagePerformanceTeamworkScore(third)
+                .build();
+    }
+
+    private JudgeCommentEntity comment(TeamEntity team, UserEntity user, ArrayNode strokes) {
+        return JudgeCommentEntity.builder().team(team).user(user).strokes(strokes).build();
+    }
+
+    private ArrayNode strokes() {
+        ArrayNode strokes = objectMapper.createArrayNode();
+        var points = strokes.addObject().put("color", "#ff0000").putArray("points");
+        points.addObject().put("x", 0.1).put("y", 0.2);
+        points.addObject().put("x", 0.8).put("y", 0.7);
+        points = strokes.addObject().put("color", "#121212").putArray("points");
+        points.addObject().put("x", 0.2).put("y", 0.3);
+        points.addObject().put("x", 0.7).put("y", 0.4);
+        return strokes;
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,10 +3,9 @@ spring:
     name: gwangjutalentfestival
 
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    url: ${SPRING_DATASOURCE_URL:jdbc:mariadb://localhost:3306/gwangjutalentfestival?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${SPRING_DATASOURCE_USERNAME:root}
     password: ${SPRING_DATASOURCE_PASSWORD:1234}
-    driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 5
       minimum-idle: 1
@@ -58,6 +57,8 @@ google:
   excel:
     template-sheet-id: test
     summary-page: test
+    judge-template-sheet-id: test
+    judge-template-page: test
 
 slogan:
   submission:


### PR DESCRIPTION
## ✨ 작업 내용
> 심사위원별 개별 심사표 ZIP 다운로드 기능을 추가했습니다.

- `GET /excel/judge-sheets`가 기존 집계표와 심사위원별 XLSX를 ZIP으로 반환합니다.
- 전용 Google Sheets 템플릿을 XLSX로 내보낸 뒤 심사순서, 개인 총점, 필기 코멘트 PNG를 채웁니다.
- 12행은 보존하고 이후 팀 데이터는 13행부터 작성합니다.
- Docker Compose의 MariaDB 자동 연결에 맞춰 JDBC 드라이버를 정렬했습니다.

---

## 🔍 리뷰 시 참고사항
- 기존 `/excel/summary` 및 Google Sheets 기반 집계표 생성 로직은 변경하지 않았습니다.
- 개별 심사표 템플릿은 서비스 계정에 공유되어 있어야 합니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [ ] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요? (Google Sheets 인증 설정 후 E2E 다운로드 확인 필요)
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #185
