### PR TITLE
심사위원 역할 분리 및 실시간 모니터링

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
@@ -17,6 +17,9 @@ import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRe
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.properties.GoogleExcelProperties;
 
@@ -50,6 +53,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
     private final TeamRepository teamRepository;
     private final JudgementRepository judgementRepository;
     private final JudgeCommentRepository judgeCommentRepository;
+    private final UserRepository userRepository;
     private final DownloadJudgingSummaryExcelService downloadJudgingSummaryExcelService;
     private final GoogleExcelAdapter googleExcelAdapter;
     private final GoogleExcelProperties googleExcelProperties;
@@ -65,10 +69,8 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
         try (ZipOutputStream zip = new ZipOutputStream(output)) {
             writeZipEntry(zip, "심사집계표.xlsx", downloadJudgingSummaryExcelService.execute());
 
-            List<Long> judgeIds = judgements.stream()
-                    .map(judgement -> judgement.getUser().getId())
-                    .distinct()
-                    .sorted()
+            List<Long> judgeIds = userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE).stream()
+                    .map(UserEntity::getId)
                     .toList();
             for (int index = 0; index < judgeIds.size(); index++) {
                 Long judgeId = judgeIds.get(index);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
@@ -8,6 +8,10 @@ import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
+import team.startup.gwangjutalentfestival.domain.judge.util.JudgeScoreCalculator;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
 
 import java.util.*;
@@ -23,28 +27,30 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
 
     private final TeamRepository teamRepository;
     private final JudgementRepository judgementRepository;
+    private final UserRepository userRepository;
     private final GoogleExcelAdapter googleExcelAdapter;
 
     @Override
     public byte[] execute() {
         List<TeamEntity> teams = teamRepository.findAllByOrderByPerformOrderAsc();
         List<JudgementEntity> judgements = judgementRepository.findAllWithUserAndTeam();
+        List<Long> allJudgeIds = userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE).stream()
+                .map(UserEntity::getId)
+                .toList();
+        List<Long> judgeIds = allJudgeIds.stream()
+                .limit(MAX_JUDGE_COLUMNS)
+                .toList();
 
-        long totalJudgeCount = judgements.stream().map(j -> j.getUser().getId()).distinct().count();
+        long totalJudgeCount = allJudgeIds.size();
         if (totalJudgeCount > MAX_JUDGE_COLUMNS) {
             log.warn("심사위원 수가 최대 허용 인원을 초과하였습니다. - total: {}, max: {}", totalJudgeCount, MAX_JUDGE_COLUMNS);
         }
 
-        List<Long> judgeIds = judgements.stream()
-                .map(j -> j.getUser().getId())
-                .distinct()
-                .sorted()
-                .limit(MAX_JUDGE_COLUMNS)
-                .toList();
-
-        Map<Long, Map<Long, Integer>> scoreMap = buildScoreMap(judgements);
-        Map<Long, Integer> teamTotalMap = teams.stream()
-                .collect(Collectors.toMap(TeamEntity::getId, t -> nz(t.getTotalScore())));
+        Map<Long, Map<Long, Integer>> scoreMap = buildScoreMap(judgements, judgeIds);
+        Map<Long, Integer> teamTotalMap = teams.stream().collect(Collectors.toMap(
+                TeamEntity::getId,
+                team -> JudgeScoreCalculator.calculate(scoreMap.getOrDefault(team.getId(), Collections.emptyMap()).values())
+        ));
         Map<Long, Integer> rankMap = denseRank(teamTotalMap);
 
         List<List<Object>> rows = new ArrayList<>();
@@ -54,9 +60,12 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
         return googleExcelAdapter.exportSummary(rows);
     }
 
-    private Map<Long, Map<Long, Integer>> buildScoreMap(List<JudgementEntity> judgements) {
+    private Map<Long, Map<Long, Integer>> buildScoreMap(List<JudgementEntity> judgements, List<Long> judgeIds) {
         Map<Long, Map<Long, Integer>> scoreMap = new HashMap<>();
         for (JudgementEntity j : judgements) {
+            if (!judgeIds.contains(j.getUser().getId())) {
+                continue;
+            }
             int score = nz(j.getCompletenessExpressionScore())
                     + nz(j.getCreativityCompositionScore())
                     + nz(j.getStagePerformanceTeamworkScore());
@@ -69,6 +78,7 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
     private List<Object> buildHeaderRow(int judgeCount) {
         List<Object> header = new ArrayList<>();
         header.add("심사번호");
+        header.add("팀명");
         for (int i = 0; i < judgeCount; i++) {
             header.add("심사위원 (" + (char) ('A' + i) + ")");
         }
@@ -85,6 +95,7 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
             Map<Long, Integer> rankMap) {
         List<Object> row = new ArrayList<>();
         row.add(nz(team.getPerformOrder()));
+        row.add(team.getTeamName());
         Map<Long, Integer> teamScores = scoreMap.getOrDefault(team.getId(), Collections.emptyMap());
         judgeIds.forEach(judgeId -> row.add(teamScores.getOrDefault(judgeId, 0)));
         row.add(nz(teamTotalMap.get(team.getId())));

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/event/JudgeMonitoringChangedEvent.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/event/JudgeMonitoringChangedEvent.java
@@ -1,0 +1,4 @@
+package team.startup.gwangjutalentfestival.domain.judge.event;
+
+public record JudgeMonitoringChangedEvent() {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/event/handler/JudgeMonitoringChangedEventListener.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/event/handler/JudgeMonitoringChangedEventListener.java
@@ -1,0 +1,37 @@
+package team.startup.gwangjutalentfestival.domain.judge.event.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import team.startup.gwangjutalentfestival.domain.judge.event.JudgeMonitoringChangedEvent;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.JudgeMonitoringResponse;
+import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeMonitoringService;
+import team.startup.gwangjutalentfestival.global.sse.AbstractSseEmitterManager;
+import team.startup.gwangjutalentfestival.global.sse.AbstractSseEventListener;
+import team.startup.gwangjutalentfestival.global.sse.JudgeMonitoringSseEmitterManager;
+
+@Component
+@RequiredArgsConstructor
+public class JudgeMonitoringChangedEventListener extends AbstractSseEventListener<JudgeMonitoringResponse> {
+
+    private final JudgeMonitoringSseEmitterManager emitterManager;
+    private final GetJudgeMonitoringService getJudgeMonitoringService;
+
+    @Override
+    protected AbstractSseEmitterManager<?> getEmitterManager() {
+        return emitterManager;
+    }
+
+    @Override
+    protected String getEventName() {
+        return "judge-monitoring";
+    }
+
+    @Async("asyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void execute(JudgeMonitoringChangedEvent event) {
+        sendToAll(getJudgeMonitoringService.execute());
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/controller/JudgeController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/controller/JudgeController.java
@@ -16,6 +16,7 @@ import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeCommentResponse;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgementResponse;
 import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeEventService;
+import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeMonitoringService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetAllJudgementService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeCommentService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgementService;
@@ -38,6 +39,7 @@ public class JudgeController {
     private final GetAllJudgementService getAllJudgementService;
     private final GetJudgementService getJudgementService;
     private final ConnectSseJudgeEventService connectSseJudgeEventService;
+    private final ConnectSseJudgeMonitoringService connectSseJudgeMonitoringService;
     private final GetJudgeCommentService getJudgeCommentService;
     private final SaveJudgeCommentService saveJudgeCommentService;
 
@@ -54,6 +56,12 @@ public class JudgeController {
     @GetMapping(value = "/changes", produces = "text/event-stream")
     public SseEmitter connect() {
         return connectSseJudgeEventService.execute();
+    }
+
+    @SecurityRequirement(name = "Authorization")
+    @GetMapping(value = "/monitor/changes", produces = "text/event-stream")
+    public SseEmitter connectMonitoring() {
+        return connectSseJudgeMonitoringService.execute();
     }
 
     @Operation(summary = "심사 점수 저장", description = "팀에 대한 심사 점수를 저장하거나 수정합니다.")

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/JudgeMonitoringResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/JudgeMonitoringResponse.java
@@ -1,0 +1,38 @@
+package team.startup.gwangjutalentfestival.domain.judge.presentation.data.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
+public record JudgeMonitoringResponse(
+        List<JudgeHeader> judges,
+        List<ScoreRow> scoreRows,
+        List<CommentRow> commentRows
+) {
+    public record JudgeHeader(Long judgeId, String label) {
+    }
+
+    public record ScoreRow(
+            Long teamId,
+            Integer performOrder,
+            String teamName,
+            List<ScoreCell> scores,
+            int calculatedScore,
+            int rank
+    ) {
+    }
+
+    public record ScoreCell(Long judgeId, Integer score) {
+    }
+
+    public record CommentRow(
+            Long teamId,
+            Integer performOrder,
+            String teamName,
+            List<CommentCell> comments
+    ) {
+    }
+
+    public record CommentCell(Long judgeId, JsonNode strokes) {
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgementRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgementRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,8 +35,8 @@ public interface JudgementRepository extends JpaRepository<JudgementEntity, Long
     @Query("""
             SELECT (j.completenessExpressionScore + j.creativityCompositionScore + j.stagePerformanceTeamworkScore)
             FROM JudgementEntity j
-            WHERE j.team = :team""")
-    List<Integer> findAllJudgeTotalScoresByTeam(@Param("team") TeamEntity team);
+            WHERE j.team = :team AND j.user.role = :role""")
+    List<Integer> findAllJudgeTotalScoresByTeam(@Param("team") TeamEntity team, @Param("role") Role role);
 
     /**
      * 특정 심사위원이 입력한 모든 심사 목록을 조회한다.

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/ConnectSseJudgeMonitoringService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/ConnectSseJudgeMonitoringService.java
@@ -1,0 +1,7 @@
+package team.startup.gwangjutalentfestival.domain.judge.service;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface ConnectSseJudgeMonitoringService {
+    SseEmitter execute();
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeMonitoringService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeMonitoringService.java
@@ -1,0 +1,7 @@
+package team.startup.gwangjutalentfestival.domain.judge.service;
+
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.JudgeMonitoringResponse;
+
+public interface GetJudgeMonitoringService {
+    JudgeMonitoringResponse execute();
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeMonitoringServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/ConnectSseJudgeMonitoringServiceImpl.java
@@ -1,0 +1,55 @@
+package team.startup.gwangjutalentfestival.domain.judge.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeMonitoringService;
+import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeMonitoringService;
+import team.startup.gwangjutalentfestival.global.sse.JudgeMonitoringSseEmitterManager;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Service
+@RequiredArgsConstructor
+public class ConnectSseJudgeMonitoringServiceImpl implements ConnectSseJudgeMonitoringService {
+
+    private final JudgeMonitoringSseEmitterManager emitterManager;
+    private final GetJudgeMonitoringService getJudgeMonitoringService;
+    private final TaskScheduler taskScheduler;
+
+    @Override
+    public SseEmitter execute() {
+        Long userId = UserUtil.getCurrentUserId();
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        AtomicReference<ScheduledFuture<?>> heartbeat = new AtomicReference<>();
+        SseEmitter emitter = emitterManager.addEmitter(userId, () -> {
+            cancelled.set(true);
+            ScheduledFuture<?> scheduled = heartbeat.get();
+            if (scheduled != null) scheduled.cancel(true);
+        });
+
+        try {
+            emitter.send(SseEmitter.event().name("judge-monitoring").data(getJudgeMonitoringService.execute()));
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+            return emitter;
+        }
+
+        ScheduledFuture<?> scheduled = taskScheduler.scheduleAtFixedRate(() -> {
+            try {
+                emitter.send(SseEmitter.event().name("heartbeat").data("ok"));
+            } catch (IOException e) {
+                emitter.completeWithError(e);
+            }
+        }, Duration.ofSeconds(15));
+        heartbeat.set(scheduled);
+        if (cancelled.get()) scheduled.cancel(true);
+        return emitter;
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeMonitoringServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeMonitoringServiceImpl.java
@@ -1,0 +1,154 @@
+package team.startup.gwangjutalentfestival.domain.judge.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeCommentEntity;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.JudgeMonitoringResponse;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
+import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeMonitoringService;
+import team.startup.gwangjutalentfestival.domain.judge.util.JudgeScoreCalculator;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GetJudgeMonitoringServiceImpl implements GetJudgeMonitoringService {
+
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final JudgementRepository judgementRepository;
+    private final JudgeCommentRepository judgeCommentRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public JudgeMonitoringResponse execute() {
+        List<UserEntity> judges = userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE);
+        List<TeamEntity> teams = teamRepository.findAllByOrderByPerformOrderAsc();
+        Set<Long> judgeIds = judges.stream().map(UserEntity::getId).collect(Collectors.toSet());
+        Map<JudgeTeamKey, JudgementEntity> judgements = judgementRepository.findAllWithUserAndTeam().stream()
+                .filter(judgement -> judgeIds.contains(judgement.getUser().getId()))
+                .collect(Collectors.toMap(
+                        judgement -> new JudgeTeamKey(judgement.getUser().getId(), judgement.getTeam().getId()),
+                        judgement -> judgement
+                ));
+        Map<JudgeTeamKey, JudgeCommentEntity> comments = judgeCommentRepository.findAllWithUserAndTeam().stream()
+                .filter(comment -> judgeIds.contains(comment.getUser().getId()))
+                .collect(Collectors.toMap(
+                        comment -> new JudgeTeamKey(comment.getUser().getId(), comment.getTeam().getId()),
+                        comment -> comment
+                ));
+
+        Map<Long, Integer> calculatedScores = calculateScores(teams, judges, judgements);
+        Map<Long, Integer> ranks = ranks(teams, judgements, calculatedScores);
+        List<JudgeMonitoringResponse.JudgeHeader> headers = headers(judges);
+
+        return new JudgeMonitoringResponse(
+                headers,
+                scoreRows(teams, judges, judgements, calculatedScores, ranks),
+                commentRows(teams, judges, comments)
+        );
+    }
+
+    private List<JudgeMonitoringResponse.JudgeHeader> headers(List<UserEntity> judges) {
+        List<JudgeMonitoringResponse.JudgeHeader> result = new ArrayList<>();
+        for (int index = 0; index < judges.size(); index++) {
+            result.add(new JudgeMonitoringResponse.JudgeHeader(judges.get(index).getId(), "심사위원 " + (char) ('A' + index)));
+        }
+        return result;
+    }
+
+    private Map<Long, Integer> calculateScores(
+            List<TeamEntity> teams,
+            List<UserEntity> judges,
+            Map<JudgeTeamKey, JudgementEntity> judgements) {
+        Map<Long, Integer> result = new HashMap<>();
+        for (TeamEntity team : teams) {
+            List<Integer> scores = judges.stream()
+                    .map(judge -> judgements.get(new JudgeTeamKey(judge.getId(), team.getId())))
+                    .filter(judgement -> judgement != null)
+                    .map(this::total)
+                    .toList();
+            result.put(team.getId(), JudgeScoreCalculator.calculate(scores));
+        }
+        return result;
+    }
+
+    private Map<Long, Integer> ranks(
+            List<TeamEntity> teams,
+            Map<JudgeTeamKey, JudgementEntity> judgements,
+            Map<Long, Integer> calculatedScores) {
+        List<TeamEntity> sorted = new ArrayList<>(teams);
+        sorted.sort(Comparator
+                .comparing((TeamEntity team) -> calculatedScores.get(team.getId()), Comparator.reverseOrder())
+                .thenComparing((TeamEntity team) -> average(team, judgements, JudgementEntity::getCompletenessExpressionScore), Comparator.reverseOrder())
+                .thenComparing((TeamEntity team) -> average(team, judgements, JudgementEntity::getCreativityCompositionScore), Comparator.reverseOrder())
+                .thenComparing((TeamEntity team) -> average(team, judgements, JudgementEntity::getStagePerformanceTeamworkScore), Comparator.reverseOrder())
+                .thenComparing(TeamEntity::getId));
+        Map<Long, Integer> result = new HashMap<>();
+        for (int index = 0; index < sorted.size(); index++) {
+            result.put(sorted.get(index).getId(), index + 1);
+        }
+        return result;
+    }
+
+    private double average(TeamEntity team, Map<JudgeTeamKey, JudgementEntity> judgements, java.util.function.Function<JudgementEntity, Integer> score) {
+        return judgements.entrySet().stream()
+                .filter(entry -> entry.getKey().teamId().equals(team.getId()))
+                .map(Map.Entry::getValue)
+                .mapToInt(score::apply)
+                .average()
+                .orElse(0);
+    }
+
+    private List<JudgeMonitoringResponse.ScoreRow> scoreRows(
+            List<TeamEntity> teams,
+            List<UserEntity> judges,
+            Map<JudgeTeamKey, JudgementEntity> judgements,
+            Map<Long, Integer> calculatedScores,
+            Map<Long, Integer> ranks) {
+        return teams.stream().map(team -> new JudgeMonitoringResponse.ScoreRow(
+                team.getId(), team.getPerformOrder(), team.getTeamName(),
+                judges.stream().map(judge -> {
+                    JudgementEntity judgement = judgements.get(new JudgeTeamKey(judge.getId(), team.getId()));
+                    return new JudgeMonitoringResponse.ScoreCell(judge.getId(), judgement == null ? null : total(judgement));
+                }).toList(),
+                calculatedScores.get(team.getId()), ranks.get(team.getId())
+        )).toList();
+    }
+
+    private List<JudgeMonitoringResponse.CommentRow> commentRows(
+            List<TeamEntity> teams,
+            List<UserEntity> judges,
+            Map<JudgeTeamKey, JudgeCommentEntity> comments) {
+        return teams.stream().map(team -> new JudgeMonitoringResponse.CommentRow(
+                team.getId(), team.getPerformOrder(), team.getTeamName(),
+                judges.stream().map(judge -> {
+                    JudgeCommentEntity comment = comments.get(new JudgeTeamKey(judge.getId(), team.getId()));
+                    return new JudgeMonitoringResponse.CommentCell(judge.getId(), comment == null ? null : comment.getStrokes());
+                }).toList()
+        )).toList();
+    }
+
+    private int total(JudgementEntity judgement) {
+        return judgement.getCompletenessExpressionScore()
+                + judgement.getCreativityCompositionScore()
+                + judgement.getStagePerformanceTeamworkScore();
+    }
+
+    private record JudgeTeamKey(Long judgeId, Long teamId) {
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgeCommentServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgeCommentServiceImpl.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangjutalentfestival.domain.judge.event.JudgeMonitoringChangedEvent;
 import team.startup.gwangjutalentfestival.domain.judge.exception.JudgeCommentTooLargeException;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeCommentRequest;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
@@ -33,6 +35,7 @@ public class SaveJudgeCommentServiceImpl implements SaveJudgeCommentService {
     private final TeamRepository teamRepository;
     private final JudgeCommentRepository judgeCommentRepository;
     private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
     @Transactional
@@ -45,6 +48,7 @@ public class SaveJudgeCommentServiceImpl implements SaveJudgeCommentService {
         validateSize(strokes);
 
         judgeCommentRepository.upsert(team.getId(), user.getId(), strokes);
+        applicationEventPublisher.publishEvent(new JudgeMonitoringChangedEvent());
     }
 
     private String writeValueAsString(Object strokes) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/SaveJudgementScoreServiceImpl.java
@@ -2,10 +2,12 @@ package team.startup.gwangjutalentfestival.domain.judge.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
+import team.startup.gwangjutalentfestival.domain.judge.event.JudgeMonitoringChangedEvent;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgementScoreRequest;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
 import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgementScoreService;
@@ -13,10 +15,10 @@ import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.exception.TeamNotFoundException;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.util.OperationMetricRecorder;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -32,6 +34,7 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
     private final TeamRepository teamRepository;
     private final UserUtil userUtil;
     private final OperationMetricRecorder metricRecorder;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * 현재 로그인한 심사위원의 특정 팀 심사 점수를 저장하거나 수정한다.
@@ -69,6 +72,7 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
                                             .user(user)
                                             .build()));
                     updateTotalScore(team);
+                    applicationEventPublisher.publishEvent(new JudgeMonitoringChangedEvent());
                 }
         );
     }
@@ -81,7 +85,7 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
      * @param team 총점을 갱신할 팀 엔티티
      */
     private void updateTotalScore(TeamEntity team) {
-        List<Integer> scores = judgementRepository.findAllJudgeTotalScoresByTeam(team);
+        List<Integer> scores = judgementRepository.findAllJudgeTotalScoresByTeam(team, Role.JUDGE);
         team.updateTotalScore(calculateTotalScore(scores));
     }
 
@@ -89,14 +93,6 @@ public class SaveJudgementScoreServiceImpl implements SaveJudgementScoreService 
         if (scores.isEmpty()) {
             return 0;
         }
-        int sum = scores.stream().mapToInt(Integer::intValue).sum();
-        // ponytail: 최고/최저를 제외하면 최소 1명은 남아야 트리밍이 의미 있으므로 3명 미만은 단순 평균
-        if (scores.size() < 3) {
-            return Math.round(sum / (float) scores.size());
-        }
-        int max = Collections.max(scores);
-        int min = Collections.min(scores);
-        int remainingCount = scores.size() - 2;
-        return Math.round((sum - max - min) / (float) remainingCount);
+        return team.startup.gwangjutalentfestival.domain.judge.util.JudgeScoreCalculator.calculate(scores);
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeScoreCalculator.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeScoreCalculator.java
@@ -1,0 +1,22 @@
+package team.startup.gwangjutalentfestival.domain.judge.util;
+
+import java.util.Collection;
+
+public final class JudgeScoreCalculator {
+
+    private JudgeScoreCalculator() {
+    }
+
+    public static int calculate(Collection<Integer> scores) {
+        if (scores.isEmpty()) {
+            return 0;
+        }
+        int sum = scores.stream().mapToInt(Integer::intValue).sum();
+        if (scores.size() < 3) {
+            return Math.round(sum / (float) scores.size());
+        }
+        int min = scores.stream().mapToInt(Integer::intValue).min().orElseThrow();
+        int max = scores.stream().mapToInt(Integer::intValue).max().orElseThrow();
+        return Math.round((sum - min - max) / (float) (scores.size() - 2));
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/user/enums/Role.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/user/enums/Role.java
@@ -11,5 +11,6 @@ package team.startup.gwangjutalentfestival.domain.user.enums;
 public enum Role {
     USER,
     ADMIN,
+    JUDGE,
     PERFORMER
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/user/repository/UserRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/user/repository/UserRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
 import java.util.Optional;
+import java.util.List;
 
 /**
  * 사용자 엔티티에 대한 데이터 접근 레이어.
@@ -29,6 +31,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
      * @return 사용자가 존재하면 {@code true}
      */
     boolean existsByPhoneNumber(String phoneNumber);
+
+    List<UserEntity> findAllByRoleOrderByIdAsc(Role role);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT u FROM UserEntity u WHERE u.id = :id")

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
@@ -80,10 +80,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/seat").hasAnyAuthority(Role.ADMIN.name(), Role.USER.name(), Role.PERFORMER.name())
 
                         // judge
-                        .requestMatchers(HttpMethod.GET, "/judge/changes").hasAnyAuthority(Role.ADMIN.name())
-                        .requestMatchers(HttpMethod.GET, "/judge").hasAnyAuthority(Role.ADMIN.name())
-                        .requestMatchers(HttpMethod.GET, "/judge/{teamId}").hasAnyAuthority(Role.ADMIN.name())
-                        .requestMatchers(HttpMethod.PATCH, "/judge/{teamId}").hasAnyAuthority(Role.ADMIN.name())
+                        .requestMatchers(HttpMethod.GET, "/judge/monitor/changes").hasAnyAuthority(Role.ADMIN.name())
+                        .requestMatchers("/judge/**").hasAnyAuthority(Role.JUDGE.name())
 
                         // monitoring
                         .requestMatchers("/monitoring/**").hasAnyAuthority(Role.ADMIN.name())

--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/JudgeMonitoringSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/JudgeMonitoringSseEmitterManager.java
@@ -1,0 +1,7 @@
+package team.startup.gwangjutalentfestival.global.sse;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class JudgeMonitoringSseEmitterManager extends AbstractSseEmitterManager<Long> {
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
@@ -20,6 +20,7 @@ import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.properties.GoogleExcelProperties;
 
@@ -43,6 +44,7 @@ class DownloadJudgeSheetsServiceImplTest {
     @Mock private TeamRepository teamRepository;
     @Mock private JudgementRepository judgementRepository;
     @Mock private JudgeCommentRepository judgeCommentRepository;
+    @Mock private UserRepository userRepository;
     @Mock private DownloadJudgingSummaryExcelService summaryExcelService;
     @Mock private GoogleExcelAdapter googleExcelAdapter;
     @Mock private GoogleExcelProperties googleExcelProperties;
@@ -53,7 +55,7 @@ class DownloadJudgeSheetsServiceImplTest {
     @BeforeEach
     void setUp() {
         service = new DownloadJudgeSheetsServiceImpl(
-                teamRepository, judgementRepository, judgeCommentRepository, summaryExcelService,
+                teamRepository, judgementRepository, judgeCommentRepository, userRepository, summaryExcelService,
                 googleExcelAdapter, googleExcelProperties);
         given(summaryExcelService.execute()).willReturn(new byte[]{1, 2, 3});
         given(googleExcelAdapter.exportJudgeTemplate()).willReturn(template());
@@ -75,6 +77,7 @@ class DownloadJudgeSheetsServiceImplTest {
                 comment(teamA, judgeA, strokes()),
                 comment(teamB, judgeA, objectMapper.createArrayNode())
         ));
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judgeA, judgeB));
         Map<String, byte[]> files = zipEntries(service.execute());
 
         assertThat(files).containsOnlyKeys("심사집계표.xlsx", "심사위원_A_개별심사표.xlsx", "심사위원_B_개별심사표.xlsx");
@@ -104,6 +107,7 @@ class DownloadJudgeSheetsServiceImplTest {
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(teams);
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(judgement(teams.getFirst(), judge, 20, 15, 25)));
         given(judgeCommentRepository.findAllWithUserAndTeam()).willReturn(List.of());
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judge));
 
         Map<String, byte[]> files = zipEntries(service.execute());
 
@@ -171,7 +175,7 @@ class DownloadJudgeSheetsServiceImplTest {
     }
 
     private UserEntity user(long id) {
-        return UserEntity.builder().id(id).role(Role.ADMIN).build();
+        return UserEntity.builder().id(id).role(Role.JUDGE).build();
     }
 
     private JudgementEntity judgement(TeamEntity team, UserEntity user, int first, int second, int third) {

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
@@ -15,10 +15,10 @@ import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
 
 import java.util.List;
-import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,237 +30,67 @@ class DownloadJudgingSummaryExcelServiceImplTest {
 
     @Mock private TeamRepository teamRepository;
     @Mock private JudgementRepository judgementRepository;
+    @Mock private UserRepository userRepository;
     @Mock private GoogleExcelAdapter googleExcelAdapter;
 
     private DownloadJudgingSummaryExcelServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        service = new DownloadJudgingSummaryExcelServiceImpl(teamRepository, judgementRepository, googleExcelAdapter);
+        service = new DownloadJudgingSummaryExcelServiceImpl(teamRepository, judgementRepository, userRepository, googleExcelAdapter);
         given(googleExcelAdapter.exportSummary(any())).willReturn(new byte[0]);
     }
 
-    private TeamEntity team(long id, int order, String name, int totalScore) {
-        return TeamEntity.builder()
-                .id(id)
-                .teamName(name)
-                .school("광주고")
-                .teamStatus(TeamStatus.PENDING)
-                .teamGenre(TeamGenre.SING)
-                .performOrder(order)
-                .totalScore(totalScore)
-                .build();
-    }
-
-    private UserEntity user(long id) {
-        return UserEntity.builder().id(id).role(Role.ADMIN).build();
-    }
-
-    private JudgementEntity judgement(TeamEntity team, UserEntity user, int s1, int s2, int s3) {
-        return JudgementEntity.builder()
-                .completenessExpressionScore(s1)
-                .creativityCompositionScore(s2)
-                .stagePerformanceTeamworkScore(s3)
-                .team(team)
-                .user(user)
-                .build();
-    }
-
     @Test
     @SuppressWarnings("unchecked")
-    void 팀_목록이_없으면_헤더행만_export된다() {
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of());
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
+    void JUDGE_전체를_심사위원_열로_포함하고_팀명을_출력한다() {
+        TeamEntity team = team(1L, 1, "팀A");
+        UserEntity judgeA = user(1L, Role.JUDGE);
+        UserEntity judgeB = user(2L, Role.JUDGE);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(team));
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judgeA, judgeB));
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(judgement(team, judgeA, 20, 20, 20)));
 
         service.execute();
 
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
-
-        assertThat(rows).hasSize(1);
-        assertThat(rows.get(0)).containsExactly("심사번호", "산출점수", "순위");
+        List<List<Object>> rows = captor.getValue();
+        assertThat(rows.get(0)).containsExactly("심사번호", "팀명", "심사위원 (A)", "심사위원 (B)", "산출점수", "순위");
+        assertThat(rows.get(1)).containsExactly(1, "팀A", 60, 0, 60, 1);
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    void 헤더행에_팀명_컬럼_없이_심사위원_수만큼_헤더가_생성된다() {
-        TeamEntity teamA = team(1L, 1, "팀A", 0);
-        UserEntity judge1 = user(1L);
-        UserEntity judge2 = user(2L);
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
+    void ADMIN의_기존_점수는_집계에서_제외한다() {
+        TeamEntity team = team(1L, 1, "팀A");
+        UserEntity judge = user(1L, Role.JUDGE);
+        UserEntity admin = user(2L, Role.ADMIN);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(team));
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judge));
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
-                judgement(teamA, judge1, 10, 10, 10),
-                judgement(teamA, judge2, 5, 5, 5)
+                judgement(team, judge, 20, 20, 20),
+                judgement(team, admin, 1, 1, 1)
         ));
 
         service.execute();
 
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
-
-        assertThat(rows.get(0)).containsExactly("심사번호", "심사위원 (A)", "심사위원 (B)", "산출점수", "순위");
+        assertThat(((List<List<Object>>) captor.getValue()).get(1)).containsExactly(1, "팀A", 60, 60, 1);
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    void 팀_데이터_행은_팀명_없이_심사번호_심사위원점수_산출점수_순위_순으로_구성된다() {
-        TeamEntity teamA = team(1L, 1, "팀A", 45);
-        UserEntity judge1 = user(1L);
-        UserEntity judge2 = user(2L);
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
-                judgement(teamA, judge1, 10, 10, 10),
-                judgement(teamA, judge2, 5, 5, 5)
-        ));
-
-        service.execute();
-
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
-        List<Object> dataRow = rows.get(1);
-
-        assertThat(dataRow).containsExactly(1, 30, 15, 45, 1);
+    private TeamEntity team(long id, int order, String name) {
+        return TeamEntity.builder().id(id).teamName(name).school("광주고")
+                .teamStatus(TeamStatus.PENDING).teamGenre(TeamGenre.SING).performOrder(order).totalScore(0).build();
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    void 산출점수는_team_totalScore를_그대로_재사용한다() {
-        TeamEntity teamA = team(1L, 1, "팀A", 80);
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
-
-        service.execute();
-
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<Object> dataRow = ((List<List<Object>>) captor.getValue()).get(1);
-
-        assertThat(dataRow).containsExactly(1, 80, 1);
+    private UserEntity user(long id, Role role) {
+        return UserEntity.builder().id(id).role(role).build();
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    void 동점_팀은_동일_순위가_부여된다() {
-        TeamEntity teamA = team(1L, 1, "팀A", 60);
-        TeamEntity teamB = team(2L, 2, "팀B", 60);
-        TeamEntity teamC = team(3L, 3, "팀C", 30);
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB, teamC));
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
-
-        service.execute();
-
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
-
-        assertThat(rows.get(1).get(2)).isEqualTo(1); // teamA 순위
-        assertThat(rows.get(2).get(2)).isEqualTo(1); // teamB 순위
-        assertThat(rows.get(3).get(2)).isEqualTo(2); // teamC 순위
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void 심사위원_수가_안전_상한을_초과하면_상한까지만_집계한다() {
-        TeamEntity teamA = team(1L, 1, "팀A", 0);
-        // judge ID 1~21 → 안전 상한(20) 적용 시 ID 1~20만 헤더/컬럼에 반영
-        List<JudgementEntity> judgements = LongStream.rangeClosed(1, 21)
-                .mapToObj(id -> judgement(teamA, user(id), 10, 10, 10))
-                .toList();
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(judgements);
-
-        service.execute();
-
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
-
-        // 헤더: 심사번호 + 심사위원 20명 + 산출점수 + 순위 = 23컬럼
-        assertThat(rows.get(0)).hasSize(23);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void 팀을_채점하지_않은_심사위원의_점수는_0으로_채워지고_뒤_컬럼이_밀리지_않는다() {
-        TeamEntity teamA = team(1L, 1, "팀A", 99);
-        TeamEntity teamB = team(2L, 2, "팀B", 10);
-        UserEntity judge1 = user(1L);
-        UserEntity judge2 = user(2L);
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB));
-        // judge2는 teamB만 채점하고 teamA는 채점하지 않음
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
-                judgement(teamA, judge1, 10, 5, 5),
-                judgement(teamB, judge1, 5, 5, 0),
-                judgement(teamB, judge2, 5, 5, 0)
-        ));
-
-        service.execute();
-
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<Object> teamARow = ((List<List<Object>>) captor.getValue()).get(1);
-
-        // 심사번호, 심사위원(A)=20, 심사위원(B)=0(null 아님, 밀리지 않음), 산출점수=99, 순위=1
-        assertThat(teamARow).containsExactly(1, 20, 0, 99, 1);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void performOrder가_null인_팀은_심사번호가_0으로_채워지고_뒤_컬럼이_밀리지_않는다() {
-        TeamEntity teamA = TeamEntity.builder()
-                .id(1L)
-                .teamName("팀A")
-                .school("광주고")
-                .teamStatus(TeamStatus.PENDING)
-                .teamGenre(TeamGenre.SING)
-                .performOrder(null)
-                .totalScore(50)
-                .build();
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA));
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
-
-        service.execute();
-
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<Object> dataRow = ((List<List<Object>>) captor.getValue()).get(1);
-
-        assertThat(dataRow).containsExactly(0, 50, 1);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    void 심사위원이_전체_팀_중_한_팀만_평가해도_나머지_팀은_0으로_채워지고_밀리지_않는다() {
-        TeamEntity teamA = team(1L, 1, "팀A", 0);
-        TeamEntity teamB = team(2L, 2, "팀B", 0);
-        TeamEntity teamC = team(3L, 3, "팀C", 0);
-        TeamEntity teamD = team(4L, 4, "팀D", 0);
-        UserEntity judge1 = user(1L);
-        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB, teamC, teamD));
-        // judge1이 teamB 한 팀만 평가하고 나머지는 아무 동작도 하지 않음(저장 자체가 없음)
-        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
-                judgement(teamB, judge1, 10, 10, 10)
-        ));
-
-        service.execute();
-
-        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-        verify(googleExcelAdapter).exportSummary(captor.capture());
-        List<List<Object>> rows = (List<List<Object>>) captor.getValue();
-
-        assertThat(rows.get(0)).containsExactly("심사번호", "심사위원 (A)", "산출점수", "순위");
-        int expectedColumnCount = rows.get(0).size();
-        rows.forEach(row -> {
-            assertThat(row).hasSize(expectedColumnCount);
-            assertThat(row).doesNotContainNull();
-        });
-
-        assertThat(rows.get(1)).containsExactly(1, 0, 0, 1); // teamA: 평가 안 받음 → 0
-        assertThat(rows.get(2)).containsExactly(2, 30, 0, 1); // teamB: judge1이 평가한 팀 → 실제 점수
-        assertThat(rows.get(3)).containsExactly(3, 0, 0, 1); // teamC: 평가 안 받음 → 0
-        assertThat(rows.get(4)).containsExactly(4, 0, 0, 1); // teamD: 평가 안 받음 → 0
+    private JudgementEntity judgement(TeamEntity team, UserEntity user, int first, int second, int third) {
+        return JudgementEntity.builder().team(team).user(user).completenessExpressionScore(first)
+                .creativityCompositionScore(second).stagePerformanceTeamworkScore(third).build();
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeMonitoringServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeMonitoringServiceTest.java
@@ -1,0 +1,89 @@
+package team.startup.gwangjutalentfestival.domain.judge.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeCommentEntity;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.JudgeMonitoringResponse;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
+import team.startup.gwangjutalentfestival.domain.judge.service.impl.GetJudgeMonitoringServiceImpl;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.team.enums.TeamGenre;
+import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
+import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GetJudgeMonitoringServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private TeamRepository teamRepository;
+    @Mock private JudgementRepository judgementRepository;
+    @Mock private JudgeCommentRepository judgeCommentRepository;
+
+    @Test
+    void JUDGE_전체를_열로_두고_점수_산출점수_순위와_코멘트를_반환한다() {
+        GetJudgeMonitoringService service = new GetJudgeMonitoringServiceImpl(
+                userRepository, teamRepository, judgementRepository, judgeCommentRepository);
+        UserEntity judgeA = user(1L, Role.JUDGE);
+        UserEntity judgeB = user(2L, Role.JUDGE);
+        UserEntity admin = user(3L, Role.ADMIN);
+        TeamEntity teamA = team(10L, 1, "팀A");
+        TeamEntity teamB = team(20L, 2, "팀B");
+        ArrayNode strokes = new ObjectMapper().createArrayNode();
+        strokes.addObject().put("x", 0.1);
+
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judgeA, judgeB));
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB));
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
+                judgement(teamA, judgeA, 40, 30, 30),
+                judgement(teamA, judgeB, 20, 20, 20),
+                judgement(teamA, admin, 1, 1, 1),
+                judgement(teamB, judgeA, 25, 25, 20),
+                judgement(teamB, judgeB, 25, 25, 20)
+        ));
+        given(judgeCommentRepository.findAllWithUserAndTeam()).willReturn(List.of(comment(teamA, judgeA, strokes)));
+
+        JudgeMonitoringResponse result = service.execute();
+
+        assertThat(result.judges()).extracting(JudgeMonitoringResponse.JudgeHeader::label)
+                .containsExactly("심사위원 A", "심사위원 B");
+        assertThat(result.scoreRows().getFirst().scores()).extracting(JudgeMonitoringResponse.ScoreCell::score)
+                .containsExactly(100, 60);
+        assertThat(result.scoreRows().getFirst().calculatedScore()).isEqualTo(80);
+        assertThat(result.scoreRows().getFirst().rank()).isEqualTo(1);
+        assertThat(result.scoreRows().get(1).rank()).isEqualTo(2);
+        assertThat(result.commentRows().getFirst().comments()).extracting(JudgeMonitoringResponse.CommentCell::strokes)
+                .containsExactly(strokes, null);
+    }
+
+    private UserEntity user(long id, Role role) {
+        return UserEntity.builder().id(id).role(role).build();
+    }
+
+    private TeamEntity team(long id, int order, String name) {
+        return TeamEntity.builder().id(id).teamName(name).school("광주고")
+                .teamStatus(TeamStatus.PENDING).teamGenre(TeamGenre.SING).performOrder(order).totalScore(0).build();
+    }
+
+    private JudgementEntity judgement(TeamEntity team, UserEntity user, int first, int second, int third) {
+        return JudgementEntity.builder().team(team).user(user).completenessExpressionScore(first)
+                .creativityCompositionScore(second).stagePerformanceTeamworkScore(third).build();
+    }
+
+    private JudgeCommentEntity comment(TeamEntity team, UserEntity user, ArrayNode strokes) {
+        return JudgeCommentEntity.builder().team(team).user(user).strokes(strokes).build();
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgeCommentServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.springframework.context.ApplicationEventPublisher;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangjutalentfestival.domain.judge.exception.JudgeCommentTooLargeException;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeCommentRequest;
@@ -45,6 +46,9 @@ class SaveJudgeCommentServiceTest {
     @Mock
     private JudgeCommentRepository judgeCommentRepository;
 
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private SaveJudgeCommentServiceImpl saveJudgeCommentService;
@@ -56,11 +60,11 @@ class SaveJudgeCommentServiceTest {
     @BeforeEach
     void setUp() {
         saveJudgeCommentService = new SaveJudgeCommentServiceImpl(
-                userUtil, teamRepository, judgeCommentRepository, objectMapper);
+                userUtil, teamRepository, judgeCommentRepository, objectMapper, applicationEventPublisher);
 
         user = UserEntity.builder()
                 .id(USER_ID)
-                .role(Role.ADMIN)
+                .role(Role.JUDGE)
                 .build();
 
         team = TeamEntity.builder()

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/SaveJudgementScoreServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.springframework.context.ApplicationEventPublisher;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgementScoreRequest;
@@ -44,6 +45,9 @@ class SaveJudgementScoreServiceTest {
     @Mock
     private UserUtil userUtil;
 
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
     private final OperationMetricRecorder metricRecorder =
             new OperationMetricRecorder(new SimpleMeterRegistry());
 
@@ -59,12 +63,13 @@ class SaveJudgementScoreServiceTest {
                 judgementRepository,
                 teamRepository,
                 userUtil,
-                metricRecorder
+                metricRecorder,
+                applicationEventPublisher
         );
 
         user = UserEntity.builder()
                 .id(1L)
-                .role(Role.ADMIN)
+                .role(Role.JUDGE)
                 .build();
 
         team = TeamEntity.builder()
@@ -85,7 +90,7 @@ class SaveJudgementScoreServiceTest {
         given(userUtil.getCurrentUser()).willReturn(user);
         given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
         given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
-        given(judgementRepository.findAllJudgeTotalScoresByTeam(team)).willReturn(List.of(50));
+        given(judgementRepository.findAllJudgeTotalScoresByTeam(team, Role.JUDGE)).willReturn(List.of(50));
 
         saveJudgementScoreService.execute(request, TEAM_ID);
 
@@ -106,7 +111,7 @@ class SaveJudgementScoreServiceTest {
         given(userUtil.getCurrentUser()).willReturn(user);
         given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
         given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.of(existing));
-        given(judgementRepository.findAllJudgeTotalScoresByTeam(team)).willReturn(List.of(50));
+        given(judgementRepository.findAllJudgeTotalScoresByTeam(team, Role.JUDGE)).willReturn(List.of(50));
 
         saveJudgementScoreService.execute(request, TEAM_ID);
 
@@ -121,7 +126,7 @@ class SaveJudgementScoreServiceTest {
         given(userUtil.getCurrentUser()).willReturn(user);
         given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
         given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
-        given(judgementRepository.findAllJudgeTotalScoresByTeam(team)).willReturn(List.of(80, 70));
+        given(judgementRepository.findAllJudgeTotalScoresByTeam(team, Role.JUDGE)).willReturn(List.of(80, 70));
 
         saveJudgementScoreService.execute(request, TEAM_ID);
 
@@ -133,7 +138,7 @@ class SaveJudgementScoreServiceTest {
         given(userUtil.getCurrentUser()).willReturn(user);
         given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
         given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
-        given(judgementRepository.findAllJudgeTotalScoresByTeam(team)).willReturn(List.of(90, 60, 30));
+        given(judgementRepository.findAllJudgeTotalScoresByTeam(team, Role.JUDGE)).willReturn(List.of(90, 60, 30));
 
         saveJudgementScoreService.execute(request, TEAM_ID);
 
@@ -145,7 +150,7 @@ class SaveJudgementScoreServiceTest {
         given(userUtil.getCurrentUser()).willReturn(user);
         given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
         given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
-        given(judgementRepository.findAllJudgeTotalScoresByTeam(team)).willReturn(List.of());
+        given(judgementRepository.findAllJudgeTotalScoresByTeam(team, Role.JUDGE)).willReturn(List.of());
 
         saveJudgementScoreService.execute(request, TEAM_ID);
 
@@ -157,7 +162,7 @@ class SaveJudgementScoreServiceTest {
         given(userUtil.getCurrentUser()).willReturn(user);
         given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
         given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
-        given(judgementRepository.findAllJudgeTotalScoresByTeam(team))
+        given(judgementRepository.findAllJudgeTotalScoresByTeam(team, Role.JUDGE))
                 .willReturn(List.of(100, 90, 80, 70, 60));
 
         saveJudgementScoreService.execute(request, TEAM_ID);
@@ -170,7 +175,7 @@ class SaveJudgementScoreServiceTest {
         given(userUtil.getCurrentUser()).willReturn(user);
         given(teamRepository.findByIdForUpdate(TEAM_ID)).willReturn(Optional.of(team));
         given(judgementRepository.findByTeamAndUser(team, user)).willReturn(Optional.empty());
-        given(judgementRepository.findAllJudgeTotalScoresByTeam(team))
+        given(judgementRepository.findAllJudgeTotalScoresByTeam(team, Role.JUDGE))
                 .willReturn(List.of(100, 90, 85, 70, 60));
 
         saveJudgementScoreService.execute(request, TEAM_ID);


### PR DESCRIPTION
## ✨ 작업 내용
- JUDGE 역할을 추가하고 심사 입력·코멘트 권한을 분리했습니다.
- 관리자 전용 `/judge/monitor/changes` SSE에서 팀별 점수표와 코멘트표 전체 스냅샷을 전송합니다.
- 심사집계표와 개별 심사표를 JUDGE 기준으로 만들고 팀명 열을 추가했습니다.

---

## 🔍 리뷰 시 참고사항
- 심사위원 A/B/C는 JUDGE 사용자 ID 오름차순으로 부여됩니다.
- 점수·코멘트 저장이 커밋된 뒤 모니터링 스냅샷을 전체 갱신합니다.
- 기존 심사 계정은 배포 전 JUDGE 역할로 수동 전환이 필요합니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #187