### PR TITLE
심사집계표 순위 기준 통일

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
@@ -15,6 +15,7 @@ import team.startup.gwangjutalentfestival.domain.judge.util.JudgeScoreCalculator
 import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -51,7 +52,7 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
                 TeamEntity::getId,
                 team -> JudgeScoreCalculator.calculate(scoreMap.getOrDefault(team.getId(), Collections.emptyMap()).values())
         ));
-        Map<Long, Integer> rankMap = denseRank(teamTotalMap);
+        Map<Long, Integer> rankMap = ranks(teams, judgements, judgeIds, teamTotalMap);
 
         List<List<Object>> rows = new ArrayList<>();
         rows.add(buildHeaderRow(judgeIds.size()));
@@ -107,16 +108,36 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
         return Optional.ofNullable(v).orElse(0);
     }
 
-    private Map<Long, Integer> denseRank(Map<Long, Integer> teamTotalMap) {
-        List<Integer> sortedScores = teamTotalMap.values().stream()
-                .distinct()
-                .sorted(Comparator.reverseOrder())
-                .toList();
-        Map<Integer, Integer> scoreToRank = new HashMap<>();
-        for (int i = 0; i < sortedScores.size(); i++) {
-            scoreToRank.put(sortedScores.get(i), i + 1);
+    private Map<Long, Integer> ranks(
+            List<TeamEntity> teams,
+            List<JudgementEntity> judgements,
+            List<Long> judgeIds,
+            Map<Long, Integer> teamTotalMap) {
+        List<TeamEntity> sorted = new ArrayList<>(teams);
+        sorted.sort(Comparator
+                .comparing((TeamEntity team) -> teamTotalMap.get(team.getId()), Comparator.reverseOrder())
+                .thenComparing((TeamEntity team) -> average(team, judgements, judgeIds, JudgementEntity::getCompletenessExpressionScore), Comparator.reverseOrder())
+                .thenComparing((TeamEntity team) -> average(team, judgements, judgeIds, JudgementEntity::getCreativityCompositionScore), Comparator.reverseOrder())
+                .thenComparing((TeamEntity team) -> average(team, judgements, judgeIds, JudgementEntity::getStagePerformanceTeamworkScore), Comparator.reverseOrder())
+                .thenComparing(TeamEntity::getId));
+
+        Map<Long, Integer> result = new HashMap<>();
+        for (int index = 0; index < sorted.size(); index++) {
+            result.put(sorted.get(index).getId(), index + 1);
         }
-        return teamTotalMap.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> scoreToRank.get(e.getValue())));
+        return result;
+    }
+
+    private double average(
+            TeamEntity team,
+            List<JudgementEntity> judgements,
+            List<Long> judgeIds,
+            Function<JudgementEntity, Integer> score) {
+        return judgements.stream()
+                .filter(judgement -> judgeIds.contains(judgement.getUser().getId()))
+                .filter(judgement -> judgement.getTeam().getId().equals(team.getId()))
+                .mapToInt(score::apply)
+                .average()
+                .orElse(0);
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
@@ -80,6 +80,50 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         assertThat(((List<List<Object>>) captor.getValue()).get(1)).containsExactly(1, "팀A", 60, 60, 1);
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void 산출점수가_같으면_완성도_평균이_높은_팀을_먼저_순위로_매긴다() {
+        TeamEntity teamA = team(2L, 1, "팀A");
+        TeamEntity teamB = team(1L, 2, "팀B");
+        UserEntity judge = user(1L, Role.JUDGE);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB));
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judge));
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
+                judgement(teamA, judge, 30, 20, 20),
+                judgement(teamB, judge, 25, 25, 20)
+        ));
+
+        service.execute();
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(googleExcelAdapter).exportSummary(captor.capture());
+        List<List<Object>> rows = captor.getValue();
+        assertThat(rows.get(1)).containsExactly(1, "팀A", 70, 70, 1);
+        assertThat(rows.get(2)).containsExactly(2, "팀B", 70, 70, 2);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void 모든_동점_기준이_같으면_팀_ID_오름차순으로_고유_순위를_매긴다() {
+        TeamEntity teamA = team(2L, 1, "팀A");
+        TeamEntity teamB = team(1L, 2, "팀B");
+        UserEntity judge = user(1L, Role.JUDGE);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB));
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judge));
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
+                judgement(teamA, judge, 30, 20, 20),
+                judgement(teamB, judge, 30, 20, 20)
+        ));
+
+        service.execute();
+
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(googleExcelAdapter).exportSummary(captor.capture());
+        List<List<Object>> rows = captor.getValue();
+        assertThat(rows.get(1)).containsExactly(1, "팀A", 70, 70, 2);
+        assertThat(rows.get(2)).containsExactly(2, "팀B", 70, 70, 1);
+    }
+
     private TeamEntity team(long id, int order, String name) {
         return TeamEntity.builder().id(id).teamName(name).school("광주고")
                 .teamStatus(TeamStatus.PENDING).teamGenre(TeamGenre.SING).performOrder(order).totalScore(0).build();


### PR DESCRIPTION
## ✨ 작업 내용
- 심사집계표의 순위를 실시간 모니터링과 동일한 기준으로 통일했습니다.
- 산출점수 동점 시 완성도·표현력, 창의력·구성, 무대 퍼포먼스·팀워크 평균과 팀 ID로 고유 순위를 산정합니다.

---

## 🔍 리뷰 시 참고사항
- 기존 공동 순위 방식(dense rank)을 제거해 모든 팀에 고유 순위를 부여합니다.
- 엑셀 행의 출력 순서는 기존 심사순서 기준으로 유지합니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #193