### PR TITLE
심사표 코멘트 이미지를 D 셀에 고정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
@@ -7,6 +7,7 @@ import org.apache.poi.ss.usermodel.Drawing;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.util.Units;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Service;
 import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgeSheetsService;
@@ -43,8 +44,11 @@ import java.util.zip.ZipOutputStream;
 @RequiredArgsConstructor
 public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsService {
 
-    private static final int COMMENT_WIDTH = 360;
-    private static final int COMMENT_HEIGHT = 160;
+    private static final int COMMENT_WIDTH = 1000;
+    private static final int COMMENT_HEIGHT = 500;
+    private static final int COMMENT_PADDING = 10;
+    private static final int COMMENT_CELL_WIDTH = 100;
+    private static final int COMMENT_CELL_HEIGHT = 50;
     private static final int HEADER_ROW = 2;
     private static final int FIRST_DATA_ROW = 3;
     private static final int PRESERVED_ROW = 11;
@@ -107,6 +111,8 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             cell(headerRow, TEAM_NAME_COLUMN).setCellValue("팀명");
             cell(headerRow, SCORE_COLUMN).setCellValue("심사위원 " + judgeLabel);
             cell(headerRow, COMMENT_COLUMN).setCellValue("코멘트");
+            sheet.setColumnWidth(COMMENT_COLUMN,
+                    Math.round(COMMENT_CELL_WIDTH / Units.DEFAULT_CHARACTER_WIDTH * 256));
 
             Drawing<?> drawing = sheet.getDrawingPatriarch();
             if (drawing == null) {
@@ -117,6 +123,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
                 JudgementEntity judgement = scoreMap.get(team.getId());
                 int rowIndex = dataRow(index);
                 Row row = row(sheet, rowIndex);
+                row.setHeightInPoints((float) Units.pixelToPoints(COMMENT_CELL_HEIGHT));
                 cell(row, 0).setCellValue(orZero(team.getPerformOrder()));
                 cell(row, TEAM_NAME_COLUMN).setCellValue(team.getTeamName());
                 int completeness = judgement == null ? 0 : orZero(judgement.getCompletenessExpressionScore());
@@ -125,8 +132,8 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
                 cell(row, SCORE_COLUMN).setCellValue(completeness + creativity + stage);
 
                 JudgeCommentEntity comment = comments.get(new JudgeTeamKey(judgeId, team.getId()));
-                if (comment != null && comment.getStrokes() != null && comment.getStrokes().isArray() && !comment.getStrokes().isEmpty()) {
-                    addCommentImage(workbook, drawing, rowIndex, renderComment(comment.getStrokes()));
+                if (comment != null && hasPoints(comment.getStrokes())) {
+                    addCommentImage(workbook, drawing, sheet, rowIndex, renderComment(comment.getStrokes()));
                 }
             }
             workbook.write(output);
@@ -134,17 +141,25 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
         }
     }
 
-    private void addCommentImage(Workbook workbook, Drawing<?> drawing, int rowIndex, byte[] image) {
+    private void addCommentImage(Workbook workbook, Drawing<?> drawing, Sheet sheet, int rowIndex, byte[] image) {
         int pictureIndex = workbook.addPicture(image, Workbook.PICTURE_TYPE_PNG);
         ClientAnchor anchor = workbook.getCreationHelper().createClientAnchor();
         anchor.setCol1(COMMENT_COLUMN);
-        anchor.setCol2(COMMENT_COLUMN + 2);
+        anchor.setCol2(COMMENT_COLUMN);
         anchor.setRow1(rowIndex);
-        anchor.setRow2(rowIndex + 1);
+        anchor.setRow2(rowIndex);
+        anchor.setDx2(Units.pixelToEMU(Math.round(sheet.getColumnWidthInPixels(COMMENT_COLUMN))));
+        anchor.setDy2(Units.pixelToEMU(Units.pointsToPixel(sheet.getRow(rowIndex).getHeightInPoints())));
+        anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_DONT_RESIZE);
         drawing.createPicture(anchor, pictureIndex);
     }
 
     private byte[] renderComment(JsonNode strokes) throws IOException {
+        double scale = Math.min(
+                (COMMENT_WIDTH - COMMENT_PADDING * 2d) / COMMENT_WIDTH,
+                (COMMENT_HEIGHT - COMMENT_PADDING * 2d) / COMMENT_HEIGHT);
+        double offsetX = (COMMENT_WIDTH - COMMENT_WIDTH * scale) / 2;
+        double offsetY = (COMMENT_HEIGHT - COMMENT_HEIGHT * scale) / 2;
         BufferedImage image = new BufferedImage(COMMENT_WIDTH, COMMENT_HEIGHT, BufferedImage.TYPE_INT_ARGB);
         Graphics2D graphics = image.createGraphics();
         try {
@@ -161,15 +176,16 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
                 Path2D path = new Path2D.Double();
                 boolean started = false;
                 for (JsonNode point : points) {
-                    if (!point.has("x") || !point.has("y")) {
+                    if (!isPoint(point)) {
                         continue;
                     }
-                    double x = Math.clamp(point.path("x").asDouble(), 0, 1) * (COMMENT_WIDTH - 1);
-                    double y = Math.clamp(point.path("y").asDouble(), 0, 1) * (COMMENT_HEIGHT - 1);
+                    double x = offsetX + Math.clamp(point.path("x").asDouble(), 0, 1) * COMMENT_WIDTH * scale;
+                    double y = offsetY + Math.clamp(point.path("y").asDouble(), 0, 1) * COMMENT_HEIGHT * scale;
                     if (started) {
                         path.lineTo(x, y);
                     } else {
                         path.moveTo(x, y);
+                        path.lineTo(x, y);
                         started = true;
                     }
                 }
@@ -184,6 +200,27 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ImageIO.write(image, "png", output);
         return output.toByteArray();
+    }
+
+    private boolean hasPoints(JsonNode strokes) {
+        if (strokes == null || !strokes.isArray()) {
+            return false;
+        }
+        for (JsonNode stroke : strokes) {
+            for (JsonNode point : stroke.path("points")) {
+                if (isPoint(point)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isPoint(JsonNode point) {
+        return point.path("x").isNumber()
+                && point.path("y").isNumber()
+                && Double.isFinite(point.path("x").asDouble())
+                && Double.isFinite(point.path("y").asDouble());
     }
 
     private Map<JudgeTeamKey, JudgeCommentEntity> commentMap(List<JudgeCommentEntity> comments) {

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
@@ -2,7 +2,11 @@ package team.startup.gwangjutalentfestival.domain.excel.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.PictureData;
+import org.apache.poi.util.Units;
+import org.apache.poi.xssf.usermodel.XSSFDrawing;
+import org.apache.poi.xssf.usermodel.XSSFPicture;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,11 +27,13 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.properties.GoogleExcelProperties;
+import org.openxmlformats.schemas.drawingml.x2006.spreadsheetDrawing.STEditAs;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.awt.Color;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
 import java.util.List;
@@ -75,7 +81,8 @@ class DownloadJudgeSheetsServiceImplTest {
         ));
         given(judgeCommentRepository.findAllWithUserAndTeam()).willReturn(List.of(
                 comment(teamA, judgeA, strokes()),
-                comment(teamB, judgeA, objectMapper.createArrayNode())
+                comment(teamB, judgeA, objectMapper.createArrayNode()),
+                comment(teamA, judgeB, strokes())
         ));
         given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judgeA, judgeB));
         Map<String, byte[]> files = zipEntries(service.execute());
@@ -98,6 +105,69 @@ class DownloadJudgeSheetsServiceImplTest {
             assertThat(workbook.getAllPictures()).hasSize(1);
             assertThat(renderedImageHasColor(workbook.getAllPictures().getFirst(), Color.RED)).isTrue();
             assertThat(renderedImageHasColor(workbook.getAllPictures().getFirst(), new Color(0x12, 0x12, 0x12))).isTrue();
+            assertCommentPicture(workbook, 3);
+        }
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_B_개별심사표.xlsx")))) {
+            assertCommentPicture(workbook, 3);
+        }
+    }
+
+    @Test
+    void 코멘트를_1000x500_PNG로_렌더링하고_D셀_100x50_안에_고정한다() throws Exception {
+        List<TeamEntity> teams = java.util.stream.IntStream.rangeClosed(1, 6)
+                .mapToObj(index -> team(index, index))
+                .toList();
+        UserEntity judge = user(10L);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(teams);
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
+        given(judgeCommentRepository.findAllWithUserAndTeam()).willReturn(List.of(
+                comment(teams.get(0), judge, stroke("#ff0000", 0.1, 0.5, 0.9, 0.5)),
+                comment(teams.get(1), judge, stroke("#121212", 0.5, 0.1, 0.5, 0.9)),
+                comment(teams.get(2), judge, stroke("#0000ff", 0.45, 0.45, 0.55, 0.55)),
+                comment(teams.get(3), judge, stroke("#00ff00", 0, 0, 1, 1)),
+                comment(teams.get(4), judge, strokes()),
+                comment(teams.get(5), judge, emptyStroke())
+        ));
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judge));
+
+        Map<String, byte[]> files = zipEntries(service.execute());
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_A_개별심사표.xlsx")))) {
+            var sheet = workbook.getSheet("개별 심사표");
+            var pictures = sheet.getDrawingPatriarch().getShapes().stream()
+                    .map(XSSFPicture.class::cast)
+                    .toList();
+            assertThat(pictures).hasSize(5);
+            pictures.forEach(picture -> {
+                BufferedImage image;
+                try {
+                    image = ImageIO.read(new ByteArrayInputStream(picture.getPictureData().getData()));
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+                assertThat(image.getWidth()).isEqualTo(1000);
+                assertThat(image.getHeight()).isEqualTo(500);
+            });
+
+            Rectangle horizontal = renderedBounds(pictures.get(0).getPictureData());
+            Rectangle vertical = renderedBounds(pictures.get(1).getPictureData());
+            Rectangle center = renderedBounds(pictures.get(2).getPictureData());
+            Rectangle corner = renderedBounds(pictures.get(3).getPictureData());
+            assertThat(horizontal.width).isGreaterThan(horizontal.height);
+            assertThat(horizontal.getCenterY()).isBetween(249d, 251d);
+            assertThat(vertical.height).isGreaterThan(vertical.width);
+            assertThat(vertical.getCenterX()).isBetween(499d, 501d);
+            assertThat(center.getCenterX()).isBetween(499d, 501d);
+            assertThat(center.getCenterY()).isBetween(249d, 251d);
+            assertThat(corner.x).isGreaterThanOrEqualTo(18);
+            assertThat(corner.y).isGreaterThanOrEqualTo(8);
+            assertThat(corner.getMaxX()).isLessThanOrEqualTo(982);
+            assertThat(corner.getMaxY()).isLessThanOrEqualTo(492);
+            assertThat(renderedImageHasColor(pictures.get(4).getPictureData(), Color.RED)).isTrue();
+            assertThat(renderedImageHasColor(pictures.get(4).getPictureData(), new Color(0x12, 0x12, 0x12))).isTrue();
+            assertThat(pictures).extracting(picture -> picture.getClientAnchor().getRow1())
+                    .containsExactly(3, 4, 5, 6, 7);
+            assertThat(sheet.getRow(8).getHeightInPoints()).isEqualTo(37.5f);
         }
     }
 
@@ -152,6 +222,49 @@ class DownloadJudgeSheetsServiceImplTest {
         return false;
     }
 
+    private Rectangle renderedBounds(PictureData picture) throws IOException {
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(picture.getData()));
+        int minX = image.getWidth();
+        int minY = image.getHeight();
+        int maxX = -1;
+        int maxY = -1;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if ((image.getRGB(x, y) & 0x00ffffff) != 0x00ffffff) {
+                    minX = Math.min(minX, x);
+                    minY = Math.min(minY, y);
+                    maxX = Math.max(maxX, x);
+                    maxY = Math.max(maxY, y);
+                }
+            }
+        }
+        return new Rectangle(minX, minY, maxX - minX + 1, maxY - minY + 1);
+    }
+
+    private void assertCommentPicture(XSSFWorkbook workbook, int rowIndex) throws IOException {
+        var sheet = workbook.getSheet("개별 심사표");
+        assertThat(sheet.getColumnWidthInPixels(3)).isBetween(99.9f, 100.1f);
+        assertThat(sheet.getRow(rowIndex).getHeightInPoints()).isEqualTo(37.5f);
+        assertThat(sheet.getMergedRegions()).noneMatch(region -> region.isInRange(rowIndex, 3));
+
+        XSSFPicture picture = (XSSFPicture) sheet.getDrawingPatriarch().getShapes().getFirst();
+        ClientAnchor anchor = picture.getClientAnchor();
+        assertThat(anchor.getCol1()).isEqualTo((short) 3);
+        assertThat(anchor.getCol2()).isEqualTo((short) 3);
+        assertThat(anchor.getRow1()).isEqualTo(rowIndex);
+        assertThat(anchor.getRow2()).isEqualTo(rowIndex);
+        assertThat(anchor.getDx1()).isZero();
+        assertThat(anchor.getDy1()).isZero();
+        assertThat(anchor.getDx2()).isEqualTo(Units.pixelToEMU(100));
+        assertThat(anchor.getDy2()).isEqualTo(Units.pixelToEMU(50));
+        XSSFDrawing drawing = sheet.getDrawingPatriarch();
+        assertThat(drawing.getCTDrawing().getTwoCellAnchorArray(0).getEditAs()).isEqualTo(STEditAs.ONE_CELL);
+
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(picture.getPictureData().getData()));
+        assertThat(image.getWidth()).isEqualTo(1000);
+        assertThat(image.getHeight()).isEqualTo(500);
+    }
+
     private Map<String, byte[]> zipEntries(byte[] zip) throws IOException {
         Map<String, byte[]> files = new java.util.HashMap<>();
         try (ZipInputStream input = new ZipInputStream(new ByteArrayInputStream(zip))) {
@@ -203,6 +316,20 @@ class DownloadJudgeSheetsServiceImplTest {
         points = strokes.addObject().put("color", "#121212").putArray("points");
         points.addObject().put("x", 0.2).put("y", 0.3);
         points.addObject().put("x", 0.7).put("y", 0.4);
+        return strokes;
+    }
+
+    private ArrayNode stroke(String color, double x1, double y1, double x2, double y2) {
+        ArrayNode strokes = objectMapper.createArrayNode();
+        var points = strokes.addObject().put("color", color).putArray("points");
+        points.addObject().put("x", x1).put("y", y1);
+        points.addObject().put("x", x2).put("y", y2);
+        return strokes;
+    }
+
+    private ArrayNode emptyStroke() {
+        ArrayNode strokes = objectMapper.createArrayNode();
+        strokes.addObject().put("color", "#000000").putArray("points");
         return strokes;
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 개별 심사표의 D 열을 100px, 심사 데이터 행을 37.5pt(50px)로 고정했습니다.
- 필기 코멘트를 1000×500 PNG로 렌더링하고 단일 scale, 중앙 정렬, 최소 10px 내부 여백을 적용했습니다.
- 이미지를 D 셀 내부 100×50px 앵커에 고정하고 `MOVE_DONT_RESIZE`로 설정했습니다.
- 유효한 점이 없는 빈 stroke는 PNG 생성과 Excel 이미지 삽입을 생략했습니다.

---

## 🔍 리뷰 시 참고사항
- 기존 점수·팀명·심사순서·12행 보존 구조는 변경하지 않았습니다.
- 저장된 XLSX에서 `MOVE_DONT_RESIZE`가 OOXML `editAs="oneCell"`로 기록되는지 검증합니다.
- Microsoft Excel과 LibreOffice가 현재 실행 환경에 없어 애플리케이션별 수동 확인은 별도로 필요합니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요? (해당 없음)
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

### 테스트
- `./gradlew test --tests 'team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgeSheetsServiceImplTest'`
- `./gradlew test`

---

## 📎 관련 이슈
- Close #195
