### PR TITLE
동일 계정 SSE 다중 연결 충돌 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/sse/AbstractSseEmitterManager.java
@@ -4,16 +4,15 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
 /**
  * SSE Emitter를 관리하는 추상 기반 클래스.
- * <p>키 타입({@code K}) 별로 {@link SseEmitter}를 {@link ConcurrentHashMap}으로 저장하며,
+ * <p>키 타입({@code K}) 별로 여러 {@link SseEmitter}를 {@link ConcurrentHashMap}으로 저장하며,
  * 연결 완료·타임아웃·에러 발생 시 자동으로 제거한다.
- * 동일 키로 재연결 시 기존 Emitter를 완료 처리하여 리소스 누수를 방지한다.
  * 가상 스레드 환경에서 carrier thread pinning 없이 안전한 전송을 위해
  * {@link ReentrantLock}을 Emitter별로 관리한다.</p>
  *
@@ -23,12 +22,11 @@ public abstract class AbstractSseEmitterManager<K> {
 
     private static final long SSE_TIMEOUT_MILLIS = 30 * 60 * 1000L;
 
-    private final Map<K, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<K, Set<SseEmitter>> emitters = new ConcurrentHashMap<>();
     private final Map<SseEmitter, ReentrantLock> locks = new ConcurrentHashMap<>();
 
     /**
      * 새 {@link SseEmitter}를 생성하고 등록한다.
-     * <p>동일 키에 기존 Emitter가 있으면 완료 처리 후 교체한다.</p>
      *
      * @param key       Emitter를 식별하는 키
      * @param onCleanup 연결 종료 시 실행할 콜백
@@ -39,7 +37,10 @@ public abstract class AbstractSseEmitterManager<K> {
         locks.put(emitter, new ReentrantLock());
 
         Runnable cleanup = () -> {
-            emitters.remove(key, emitter);
+            emitters.computeIfPresent(key, (ignored, connections) -> {
+                connections.remove(emitter);
+                return connections.isEmpty() ? null : connections;
+            });
             locks.remove(emitter);
             if (onCleanup != null) onCleanup.run();
         };
@@ -48,32 +49,13 @@ public abstract class AbstractSseEmitterManager<K> {
         emitter.onTimeout(() -> emitter.complete());
         emitter.onError(e -> cleanup.run());
 
-        SseEmitter oldEmitter = emitters.put(key, emitter);
-        if (oldEmitter != null) {
-            locks.remove(oldEmitter);
-            oldEmitter.complete();
-        }
+        emitters.compute(key, (ignored, connections) -> {
+            Set<SseEmitter> current = connections == null ? ConcurrentHashMap.newKeySet() : connections;
+            current.add(emitter);
+            return current;
+        });
 
         return emitter;
-    }
-
-    /**
-     * 키에 해당하는 Emitter를 락을 획득한 상태로 안전하게 실행한다.
-     *
-     * @param key    조회할 키
-     * @param action Emitter에 수행할 작업
-     */
-    public void executeSafe(K key, Consumer<SseEmitter> action) {
-        SseEmitter emitter = emitters.get(key);
-        if (emitter == null) return;
-        ReentrantLock lock = locks.get(emitter);
-        if (lock == null) return;
-        lock.lock();
-        try {
-            action.accept(emitter);
-        } finally {
-            lock.unlock();
-        }
     }
 
     /**
@@ -82,7 +64,7 @@ public abstract class AbstractSseEmitterManager<K> {
      * @param action 각 Emitter에 수행할 작업
      */
     public void forEachEmitterSafe(Consumer<SseEmitter> action) {
-        emitters.values().forEach(emitter -> {
+        emitters.values().stream().flatMap(Collection::stream).forEach(emitter -> {
             ReentrantLock lock = locks.get(emitter);
             if (lock == null) return;
             lock.lock();
@@ -95,21 +77,13 @@ public abstract class AbstractSseEmitterManager<K> {
     }
 
     /**
-     * 키에 해당하는 {@link SseEmitter}를 조회한다.
-     *
-     * @param key 조회할 키
-     * @return {@link SseEmitter}를 감싼 {@link Optional}, 없으면 empty
-     */
-    public Optional<SseEmitter> getEmitter(K key) {
-        return Optional.ofNullable(emitters.get(key));
-    }
-
-    /**
      * 현재 등록된 모든 {@link SseEmitter}를 반환한다.
      *
      * @return 등록된 Emitter 컬렉션
      */
     public Collection<SseEmitter> getAllEmitters() {
-        return emitters.values();
+        return emitters.values().stream()
+                .flatMap(Collection::stream)
+                .toList();
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/global/sse/JudgeSseEmitterManagerTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/sse/JudgeSseEmitterManagerTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,20 +26,11 @@ class JudgeSseEmitterManagerTest {
     }
 
     @Test
-    void addEmitter_후_getEmitter로_동일한_emitter를_조회할_수_있다() {
-        SseEmitter emitter = manager.addEmitter(1L, null);
+    void 동일한_userId로_여러_연결을_등록하면_모두_유지된다() {
+        SseEmitter first = manager.addEmitter(1L, null);
+        SseEmitter second = manager.addEmitter(1L, null);
 
-        Optional<SseEmitter> found = manager.getEmitter(1L);
-
-        assertThat(found).isPresent();
-        assertThat(found.get()).isSameAs(emitter);
-    }
-
-    @Test
-    void 등록되지_않은_userId로_getEmitter를_호출하면_empty가_반환된다() {
-        Optional<SseEmitter> found = manager.getEmitter(999L);
-
-        assertThat(found).isEmpty();
+        assertThat(manager.getAllEmitters()).containsExactlyInAnyOrder(first, second);
     }
 
     @Test
@@ -51,15 +43,22 @@ class JudgeSseEmitterManagerTest {
     }
 
     @Test
-    void 동일한_userId로_재연결하면_새로운_emitter로_교체된다() {
-        SseEmitter first = manager.addEmitter(1L, null);
-        SseEmitter second = manager.addEmitter(1L, null);
+    void 동일한_userId의_모든_emitter에_이벤트를_전송한다() {
+        manager.addEmitter(1L, null);
+        manager.addEmitter(1L, null);
+        AtomicInteger sent = new AtomicInteger();
 
-        Optional<SseEmitter> found = manager.getEmitter(1L);
+        manager.forEachEmitterSafe(ignored -> sent.incrementAndGet());
 
-        assertThat(found).isPresent();
-        assertThat(found.get()).isSameAs(second);
-        assertThat(found.get()).isNotSameAs(first);
+        assertThat(sent).hasValue(2);
+    }
+
+    @Test
+    void 동일한_userId로_동시에_연결해도_모든_emitter가_등록된다() {
+        IntStream.range(0, 100).parallel()
+                .forEach(ignored -> manager.addEmitter(1L, null));
+
+        assertThat(manager.getAllEmitters()).hasSize(100);
     }
 
     @Test


### PR DESCRIPTION
## ✨ 작업 내용
> 동일 계정으로 여러 SSE 연결을 맺어도 기존 연결이 종료되지 않도록 수정했습니다.

- 사용자별 `SseEmitter`를 단일 값이 아닌 연결 집합으로 관리
- 동시 등록 시 모든 연결을 유지하고 이벤트를 각 연결에 전송
- 연결 종료 시 해당 emitter만 제거
- 동일 계정 다중·동시 연결 회귀 테스트 추가

---

## 🔍 리뷰 시 참고사항
- 공통 SSE 매니저 변경으로 심사, 좌석, 심사 모니터링 SSE에 함께 적용됩니다.
- 전체 테스트는 로컬 MariaDB가 실행 중이지 않아 컨텍스트 테스트 3건이 실패했습니다. SSE 집중 테스트는 통과했습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [ ] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #197
