### PR TITLE
Excel 다운로드 ADMIN 권한 제한 및 로그아웃 인증 정리

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/controller/ExcelController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/controller/ExcelController.java
@@ -3,6 +3,7 @@ package team.startup.gwangjutalentfestival.domain.excel.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ContentDisposition;
@@ -17,7 +18,7 @@ import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgeShee
 
 import java.nio.charset.StandardCharsets;
 
-@Tag(name = "Excel", description = "엑셀 다운로드 API")
+@Tag(name = "Excel", description = "엑셀 다운로드 API (ADMIN 전용)")
 @RestController
 @RequestMapping("/excel")
 @RequiredArgsConstructor
@@ -27,8 +28,11 @@ public class ExcelController {
     private final DownloadJudgeSheetsService downloadJudgeSheetsService;
 
     @Operation(summary = "심사 집계표 다운로드", description = "전체 팀의 심사 집계 결과를 xlsx 파일로 다운로드합니다.")
+    @SecurityRequirement(name = "Authorization")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "다운로드 성공")
+            @ApiResponse(responseCode = "200", description = "다운로드 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @GetMapping("/summary")
     public ResponseEntity<byte[]> downloadSummary() {
@@ -48,8 +52,11 @@ public class ExcelController {
     }
 
     @Operation(summary = "심사위원별 심사표 다운로드", description = "집계표와 심사위원별 개별 심사표가 담긴 ZIP 파일을 다운로드합니다.")
+    @SecurityRequirement(name = "Authorization")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "다운로드 성공")
+            @ApiResponse(responseCode = "200", description = "다운로드 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @GetMapping("/judge-sheets")
     public ResponseEntity<byte[]> downloadJudgeSheets() {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcher.java
@@ -10,8 +10,10 @@ import java.util.List;
 public final class PublicEndpointMatcher {
 
     private static final List<RequestMatcher> PUBLIC_ENDPOINTS = List.of(
-            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/auth(?:/.*)?")),
-            RegexRequestMatcher.regexMatcher(withOptionalQuery("^/excel(?:/.*)?")),
+            RegexRequestMatcher.regexMatcher(HttpMethod.POST, withOptionalQuery("^/auth/verify")),
+            RegexRequestMatcher.regexMatcher(HttpMethod.POST, withOptionalQuery("^/auth/join")),
+            RegexRequestMatcher.regexMatcher(HttpMethod.POST, withOptionalQuery("^/auth/login")),
+            RegexRequestMatcher.regexMatcher(HttpMethod.PATCH, withOptionalQuery("^/auth/refresh")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/actuator/health(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/actuator/prometheus(?:/.*)?")),
             RegexRequestMatcher.regexMatcher(withOptionalQuery("^/vote/[^/]+")),

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
@@ -86,6 +86,9 @@ public class SecurityConfig {
                         // monitoring
                         .requestMatchers("/monitoring/**").hasAnyAuthority(Role.ADMIN.name())
 
+                        // excel
+                        .requestMatchers("/excel/**").hasAnyAuthority(Role.ADMIN.name())
+
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/test/java/team/startup/gwangjutalentfestival/global/security/RoleBasedApiAuthorizationTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/security/RoleBasedApiAuthorizationTest.java
@@ -1,0 +1,250 @@
+package team.startup.gwangjutalentfestival.global.security;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import team.startup.gwangjutalentfestival.domain.auth.presentation.controller.AuthController;
+import team.startup.gwangjutalentfestival.domain.auth.repository.TokenBlacklistRepository;
+import team.startup.gwangjutalentfestival.domain.auth.service.LoginService;
+import team.startup.gwangjutalentfestival.domain.auth.service.LogoutService;
+import team.startup.gwangjutalentfestival.domain.auth.service.ReissueTokenService;
+import team.startup.gwangjutalentfestival.domain.auth.service.SendVerifyCodeService;
+import team.startup.gwangjutalentfestival.domain.auth.service.SignUpService;
+import team.startup.gwangjutalentfestival.domain.excel.controller.ExcelController;
+import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgeSheetsService;
+import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgingSummaryExcelService;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.controller.JudgeController;
+import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeEventService;
+import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeMonitoringService;
+import team.startup.gwangjutalentfestival.domain.judge.service.GetAllJudgementService;
+import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeCommentService;
+import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgementService;
+import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgeCommentService;
+import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgementScoreService;
+import team.startup.gwangjutalentfestival.domain.monitoring.presentation.controller.MonitoringController;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.CreateIncidentFeedbackService;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.ExportDatasetService;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventDetailService;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventListService;
+import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventSummaryService;
+import team.startup.gwangjutalentfestival.domain.seat.presentation.controller.SeatController;
+import team.startup.gwangjutalentfestival.domain.seat.service.CancelSeatReservationService;
+import team.startup.gwangjutalentfestival.domain.seat.service.ConnectSseSeatEventService;
+import team.startup.gwangjutalentfestival.domain.seat.service.GetAllSeatsService;
+import team.startup.gwangjutalentfestival.domain.seat.service.GetByCurrentPerformerSeatsService;
+import team.startup.gwangjutalentfestival.domain.seat.service.GetCurrentUserSeatService;
+import team.startup.gwangjutalentfestival.domain.seat.service.GetSeatsBySectionService;
+import team.startup.gwangjutalentfestival.domain.seat.service.PerformerCancelSeatReservationService;
+import team.startup.gwangjutalentfestival.domain.seat.service.ReservationSeatService;
+import team.startup.gwangjutalentfestival.domain.team.presentation.controller.TeamController;
+import team.startup.gwangjutalentfestival.domain.team.service.GetAllTeamService;
+import team.startup.gwangjutalentfestival.domain.team.service.GetTeamRankingService;
+import team.startup.gwangjutalentfestival.domain.team.service.UpdateTeamOrderService;
+import team.startup.gwangjutalentfestival.domain.team.service.UpdateTeamPerformanceService;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.jwt.JwtProperties;
+import team.startup.gwangjutalentfestival.global.jwt.JwtProvider;
+import team.startup.gwangjutalentfestival.global.security.config.SecurityConfig;
+import team.startup.gwangjutalentfestival.global.security.filter.JwtFilter;
+import team.startup.gwangjutalentfestival.global.security.handler.JwtAccessDeniedHandler;
+import team.startup.gwangjutalentfestival.global.security.handler.JwtAuthenticationEntryPoint;
+import team.startup.gwangjutalentfestival.global.security.properties.CorsProperties;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * USER, ADMIN, JUDGE, PERFORMER 역할별 API 접근 허용 상태를 회귀 테스트로 고정한다.
+ * <p>실제 {@link SecurityConfig}, {@link JwtFilter}를 통과시켜 인가 규칙을 검증하며,
+ * 도메인 서비스는 인가 통과 이후 동작에 영향받지 않도록 Mock으로 대체한다.</p>
+ */
+@WebMvcTest(controllers = {
+        TeamController.class,
+        SeatController.class,
+        JudgeController.class,
+        MonitoringController.class,
+        ExcelController.class,
+        AuthController.class
+})
+@Import({SecurityConfig.class, JwtFilter.class, JwtProvider.class, JwtAccessDeniedHandler.class, JwtAuthenticationEntryPoint.class})
+@EnableConfigurationProperties({JwtProperties.class, CorsProperties.class})
+@TestPropertySource(properties = {
+        "jwt.secret=test-secret-key-for-junit-testing-only-32bytes!!",
+        "jwt.access-token-expiration=180000000",
+        "jwt.refresh-token-expiration=1209600",
+        "cors.allowed-origins=http://localhost:3000"
+})
+class RoleBasedApiAuthorizationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private GetAllTeamService getAllTeamService;
+    @MockBean
+    private GetTeamRankingService getTeamRankingService;
+    @MockBean
+    private UpdateTeamPerformanceService updateTeamPerformanceService;
+    @MockBean
+    private UpdateTeamOrderService updateTeamOrderService;
+
+    @MockBean
+    private ReservationSeatService reservationSeatService;
+    @MockBean
+    private CancelSeatReservationService cancelSeatReservationService;
+    @MockBean
+    private PerformerCancelSeatReservationService performerCancelSeatReservationService;
+    @MockBean
+    private GetCurrentUserSeatService getCurrentUserSeatService;
+    @MockBean
+    private GetByCurrentPerformerSeatsService getByCurrentPerformerSeatsService;
+    @MockBean
+    private GetSeatsBySectionService getSeatsBySectionService;
+    @MockBean
+    private GetAllSeatsService getAllSeatsService;
+    @MockBean
+    private ConnectSseSeatEventService connectSseSeatEventService;
+
+    @MockBean
+    private SaveJudgementScoreService saveJudgementScoreService;
+    @MockBean
+    private GetAllJudgementService getAllJudgementService;
+    @MockBean
+    private GetJudgementService getJudgementService;
+    @MockBean
+    private ConnectSseJudgeEventService connectSseJudgeEventService;
+    @MockBean
+    private ConnectSseJudgeMonitoringService connectSseJudgeMonitoringService;
+    @MockBean
+    private GetJudgeCommentService getJudgeCommentService;
+    @MockBean
+    private SaveJudgeCommentService saveJudgeCommentService;
+
+    @MockBean
+    private GetAnomalyEventListService getAnomalyEventListService;
+    @MockBean
+    private GetAnomalyEventDetailService getAnomalyEventDetailService;
+    @MockBean
+    private CreateIncidentFeedbackService createIncidentFeedbackService;
+    @MockBean
+    private GetAnomalyEventSummaryService getAnomalyEventSummaryService;
+    @MockBean
+    private ExportDatasetService exportDatasetService;
+
+    @MockBean
+    private DownloadJudgingSummaryExcelService downloadJudgingSummaryExcelService;
+    @MockBean
+    private DownloadJudgeSheetsService downloadJudgeSheetsService;
+
+    @MockBean
+    private SendVerifyCodeService sendVerifyCodeService;
+    @MockBean
+    private SignUpService signUpService;
+    @MockBean
+    private LoginService loginService;
+    @MockBean
+    private LogoutService logoutService;
+    @MockBean
+    private ReissueTokenService reissueTokenService;
+    @MockBean
+    private TokenBlacklistRepository tokenBlacklistRepository;
+    @MockBean
+    private StringRedisTemplate stringRedisTemplate;
+
+    private record Endpoint(
+            String description,
+            HttpMethod method,
+            String path,
+            String[] params,
+            String jsonBody,
+            int successStatus,
+            Set<Role> allowedRoles
+    ) {
+        MockHttpServletRequestBuilder request() {
+            MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.request(method, path);
+            for (int i = 0; i + 1 < params.length; i += 2) {
+                builder.param(params[i], params[i + 1]);
+            }
+            if (jsonBody != null) {
+                builder.contentType(MediaType.APPLICATION_JSON).content(jsonBody);
+            }
+            return builder;
+        }
+    }
+
+    private static final List<Endpoint> ENDPOINTS = List.of(
+            new Endpoint("팀 공연 순서 변경", HttpMethod.PATCH, "/team/order", new String[0],
+                    "{\"orderItems\":[{\"teamId\":1,\"order\":1}]}", 204, Set.of(Role.ADMIN)),
+            new Endpoint("구역별 좌석 조회", HttpMethod.GET, "/seat", new String[]{"section", "A"}, null, 200,
+                    Set.of(Role.ADMIN, Role.USER, Role.PERFORMER)),
+            new Endpoint("내 좌석 조회", HttpMethod.GET, "/seat/myself", new String[0], null, 200,
+                    Set.of(Role.ADMIN, Role.USER)),
+            new Endpoint("공연자 예약 좌석 조회", HttpMethod.GET, "/seat/myself/performer", new String[0], null, 200,
+                    Set.of(Role.PERFORMER)),
+            new Endpoint("전체 좌석 조회", HttpMethod.GET, "/seat/all", new String[0], null, 200,
+                    Set.of(Role.ADMIN, Role.USER, Role.PERFORMER)),
+            new Endpoint("좌석 예약 취소", HttpMethod.DELETE, "/seat", new String[0], null, 204,
+                    Set.of(Role.ADMIN, Role.USER)),
+            new Endpoint("심사위원 전체 심사 조회", HttpMethod.GET, "/judge", new String[0], null, 200,
+                    Set.of(Role.JUDGE)),
+            new Endpoint("이상 탐지 요약 조회", HttpMethod.GET, "/monitoring/anomalies/summary", new String[0], null, 200,
+                    Set.of(Role.ADMIN)),
+            new Endpoint("심사 집계표 다운로드", HttpMethod.GET, "/excel/summary", new String[0], null, 200,
+                    Set.of(Role.ADMIN)),
+            new Endpoint("심사위원별 심사표 다운로드", HttpMethod.GET, "/excel/judge-sheets", new String[0], null, 200,
+                    Set.of(Role.ADMIN)),
+            new Endpoint("로그아웃", HttpMethod.DELETE, "/auth/logout", new String[0], null, 204,
+                    EnumSet.allOf(Role.class))
+    );
+
+    @TestFactory
+    Stream<DynamicTest> 역할별_API_접근_허용_상태가_고정된다() {
+        return ENDPOINTS.stream().flatMap(endpoint ->
+                Stream.concat(
+                        Stream.of(DynamicTest.dynamicTest(
+                                endpoint.description() + " - 토큰 없이 요청하면 401을 반환한다",
+                                () -> mockMvc.perform(endpoint.request())
+                                        .andExpect(status().isUnauthorized())
+                        )),
+                        Stream.of(Role.values()).map(role ->
+                                DynamicTest.dynamicTest(
+                                        endpoint.description() + " - " + role + " 역할로 요청하면 "
+                                                + (endpoint.allowedRoles().contains(role)
+                                                ? endpoint.successStatus() + "을 반환한다"
+                                                : "403을 반환한다"),
+                                        () -> {
+                                            String token = jwtProvider.generateAccessToken(1L, role);
+                                            var result = mockMvc.perform(endpoint.request()
+                                                    .header("Authorization", "Bearer " + token));
+
+                                            if (endpoint.allowedRoles().contains(role)) {
+                                                result.andExpect(status().is(endpoint.successStatus()));
+                                            } else {
+                                                result.andExpect(status().isForbidden());
+                                            }
+                                        }
+                                )
+                        )
+                )
+        );
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcherTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/security/config/PublicEndpointMatcherTest.java
@@ -1,0 +1,56 @@
+package team.startup.gwangjutalentfestival.global.security.config;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PublicEndpointMatcherTest {
+
+    @ParameterizedTest(name = "{0} {1} 은 공개 엔드포인트이다")
+    @CsvSource({
+            "POST, /auth/verify",
+            "POST, /auth/join",
+            "POST, /auth/login",
+            "PATCH, /auth/refresh",
+            "GET, /actuator/health",
+            "GET, /actuator/prometheus",
+            "GET, /vote/team-1",
+            "GET, /error",
+            "GET, /swagger-ui/index.html",
+            "GET, /v3/api-docs",
+            "GET, /team",
+            "POST, /apply",
+            "POST, /apply/upload/initiate",
+            "GET, /apply/123/video",
+            "POST, /slogan"
+    })
+    void 명시된_경로는_공개_엔드포인트로_분류된다(String method, String path) {
+        MockHttpServletRequest request = request(method, path);
+
+        assertThat(PublicEndpointMatcher.matcher().matches(request)).isTrue();
+    }
+
+    @ParameterizedTest(name = "{0} {1} 은 공개 엔드포인트가 아니다")
+    @CsvSource({
+            "DELETE, /auth/logout",
+            "GET, /excel/summary",
+            "GET, /excel/judge-sheets",
+            "GET, /judge",
+            "GET, /seat",
+            "GET, /monitoring/anomalies",
+            "DELETE, /team/1"
+    })
+    void 명시되지_않은_경로는_공개_엔드포인트가_아니다(String method, String path) {
+        MockHttpServletRequest request = request(method, path);
+
+        assertThat(PublicEndpointMatcher.matcher().matches(request)).isFalse();
+    }
+
+    private MockHttpServletRequest request(String method, String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+        request.setServletPath(path);
+        return request;
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- `/excel/summary`, `/excel/judge-sheets`를 `ADMIN` 전용으로 제한하였습니다.
- 공개 엔드포인트 매처에서 `/excel/**` 전체를 제거하였습니다.
- `/auth/**` 블랭킷 공개 규칙을 `/auth/verify`, `/auth/join`, `/auth/login`, `/auth/refresh`로 좁혀 `/auth/logout`이 JWT 인증을 정상적으로 거치도록 정리하였습니다.
- Excel API Swagger 문서에 인증 요구사항과 401·403 응답을 추가하였습니다.
- USER, ADMIN, JUDGE, PERFORMER 역할별 API 접근 허용 상태를 회귀 테스트로 고정하였습니다.

---

## 🔍 리뷰 시 참고사항
- `/auth/logout`은 기존에 공개 엔드포인트로 분류되어 있어 JWT 필터를 건너뛰었습니다. 이번 변경으로 인증이 필요한 엔드포인트가 되어 유효하지 않은 토큰 요청과 블랙리스트 처리가 일관되게 적용됩니다.
- Excel 외 도메인(team, seat, judge, monitoring)의 기존 역할 정책은 변경하지 않았습니다.
- `PublicEndpointMatcherTest`로 공개/비공개 경로 분류를 검증하고, `RoleBasedApiAuthorizationTest`로 실제 `SecurityConfig` + `JwtFilter`를 통과시켜 역할별 접근 허용 여부를 회귀 테스트로 고정하였습니다.

---

## ✅ 체크리스트
- [ ] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #198
