### PR TITLE
심사위원 필기 정보 저장 및 개별 심사표 반영

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
@@ -13,8 +13,10 @@ import org.springframework.stereotype.Service;
 import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgeSheetsService;
 import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgingSummaryExcelService;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeCommentEntity;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeProfileEntity;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeProfileRepository;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
@@ -44,14 +46,19 @@ import java.util.zip.ZipOutputStream;
 @RequiredArgsConstructor
 public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsService {
 
-    private static final int COMMENT_WIDTH = 1000;
-    private static final int COMMENT_HEIGHT = 500;
-    private static final int COMMENT_PADDING = 10;
+    private static final int IMAGE_WIDTH = 1000;
+    private static final int IMAGE_HEIGHT = 500;
+    private static final int IMAGE_PADDING = 10;
     private static final int COMMENT_CELL_WIDTH = 100;
     private static final int COMMENT_CELL_HEIGHT = 50;
-    private static final int HEADER_ROW = 2;
-    private static final int FIRST_DATA_ROW = 3;
-    private static final int PRESERVED_ROW = 11;
+    private static final int PROFILE_ROW = 2;
+    private static final int HEADER_ROW = 3;
+    private static final int FIRST_DATA_ROW = 4;
+    private static final int PRESERVED_ROW = 12;
+    private static final int AFFILIATION_COLUMN = 1;
+    private static final int POSITION_COLUMN = 3;
+    private static final int NAME_COLUMN = 5;
+    private static final int PROFILE_COLUMN_SPAN = 2;
     private static final int TEAM_NAME_COLUMN = 1;
     private static final int SCORE_COLUMN = 2;
     private static final int COMMENT_COLUMN = 3;
@@ -59,6 +66,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
     private final TeamRepository teamRepository;
     private final JudgementRepository judgementRepository;
     private final JudgeCommentRepository judgeCommentRepository;
+    private final JudgeProfileRepository judgeProfileRepository;
     private final UserRepository userRepository;
     private final DownloadJudgingSummaryExcelService downloadJudgingSummaryExcelService;
     private final GoogleExcelAdapter googleExcelAdapter;
@@ -69,6 +77,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
         List<TeamEntity> teams = teamRepository.findAllByOrderByPerformOrderAsc();
         List<JudgementEntity> judgements = judgementRepository.findAllWithUserAndTeam();
         Map<JudgeTeamKey, JudgeCommentEntity> comments = commentMap(judgeCommentRepository.findAllWithUserAndTeam());
+        Map<Long, JudgeProfileEntity> profiles = profileMap(judgeProfileRepository.findAllWithUser());
         byte[] judgeTemplate = googleExcelAdapter.exportJudgeTemplate();
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -81,7 +90,8 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             for (int index = 0; index < judgeIds.size(); index++) {
                 Long judgeId = judgeIds.get(index);
                 writeZipEntry(zip, "심사위원_" + judgeLabel(index) + "_개별심사표.xlsx",
-                        createJudgeSheet(judgeTemplate, teams, judgements, comments, judgeId, judgeLabel(index)));
+                        createJudgeSheet(
+                                judgeTemplate, teams, judgements, comments, profiles.get(judgeId), judgeId, judgeLabel(index)));
             }
         } catch (IOException e) {
             throw new IllegalStateException("심사표 ZIP을 생성할 수 없습니다.", e);
@@ -94,6 +104,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             List<TeamEntity> teams,
             List<JudgementEntity> judgements,
             Map<JudgeTeamKey, JudgeCommentEntity> comments,
+            JudgeProfileEntity profile,
             Long judgeId,
             String judgeLabel) throws IOException {
         Map<Long, JudgementEntity> scoreMap = new HashMap<>();
@@ -118,6 +129,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             if (drawing == null) {
                 drawing = sheet.createDrawingPatriarch();
             }
+            addProfileImages(workbook, drawing, sheet, profile);
             for (int index = 0; index < teams.size(); index++) {
                 TeamEntity team = teams.get(index);
                 JudgementEntity judgement = scoreMap.get(team.getId());
@@ -133,7 +145,14 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
 
                 JudgeCommentEntity comment = comments.get(new JudgeTeamKey(judgeId, team.getId()));
                 if (comment != null && hasPoints(comment.getStrokes())) {
-                    addCommentImage(workbook, drawing, sheet, rowIndex, renderComment(comment.getStrokes()));
+                    addImage(
+                            workbook,
+                            drawing,
+                            COMMENT_COLUMN,
+                            rowIndex,
+                            Math.round(sheet.getColumnWidthInPixels(COMMENT_COLUMN)),
+                            Units.pointsToPixel(row.getHeightInPoints()),
+                            renderStrokes(comment.getStrokes()));
                 }
             }
             workbook.write(output);
@@ -141,30 +160,67 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
         }
     }
 
-    private void addCommentImage(Workbook workbook, Drawing<?> drawing, Sheet sheet, int rowIndex, byte[] image) {
+    private void addProfileImages(
+            Workbook workbook,
+            Drawing<?> drawing,
+            Sheet sheet,
+            JudgeProfileEntity profile) throws IOException {
+        if (profile == null) {
+            return;
+        }
+        addProfileImage(workbook, drawing, sheet, AFFILIATION_COLUMN, profile.getAffiliationStrokes());
+        addProfileImage(workbook, drawing, sheet, POSITION_COLUMN, profile.getPositionStrokes());
+        addProfileImage(workbook, drawing, sheet, NAME_COLUMN, profile.getNameStrokes());
+    }
+
+    private void addProfileImage(
+            Workbook workbook,
+            Drawing<?> drawing,
+            Sheet sheet,
+            int column,
+            JsonNode strokes) throws IOException {
+        if (!hasPoints(strokes)) {
+            return;
+        }
+        int width = 0;
+        for (int current = column; current < column + PROFILE_COLUMN_SPAN; current++) {
+            width += Math.round(sheet.getColumnWidthInPixels(current));
+        }
+        int height = Units.pointsToPixel(row(sheet, PROFILE_ROW).getHeightInPoints());
+        addImage(workbook, drawing, column, PROFILE_ROW, width, height, renderStrokes(strokes));
+    }
+
+    private void addImage(
+            Workbook workbook,
+            Drawing<?> drawing,
+            int column,
+            int row,
+            int width,
+            int height,
+            byte[] image) {
         int pictureIndex = workbook.addPicture(image, Workbook.PICTURE_TYPE_PNG);
         ClientAnchor anchor = workbook.getCreationHelper().createClientAnchor();
-        anchor.setCol1(COMMENT_COLUMN);
-        anchor.setCol2(COMMENT_COLUMN);
-        anchor.setRow1(rowIndex);
-        anchor.setRow2(rowIndex);
-        anchor.setDx2(Units.pixelToEMU(Math.round(sheet.getColumnWidthInPixels(COMMENT_COLUMN))));
-        anchor.setDy2(Units.pixelToEMU(Units.pointsToPixel(sheet.getRow(rowIndex).getHeightInPoints())));
+        anchor.setCol1(column);
+        anchor.setCol2(column);
+        anchor.setRow1(row);
+        anchor.setRow2(row);
+        anchor.setDx2(Units.pixelToEMU(width));
+        anchor.setDy2(Units.pixelToEMU(height));
         anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_DONT_RESIZE);
         drawing.createPicture(anchor, pictureIndex);
     }
 
-    private byte[] renderComment(JsonNode strokes) throws IOException {
+    private byte[] renderStrokes(JsonNode strokes) throws IOException {
         double scale = Math.min(
-                (COMMENT_WIDTH - COMMENT_PADDING * 2d) / COMMENT_WIDTH,
-                (COMMENT_HEIGHT - COMMENT_PADDING * 2d) / COMMENT_HEIGHT);
-        double offsetX = (COMMENT_WIDTH - COMMENT_WIDTH * scale) / 2;
-        double offsetY = (COMMENT_HEIGHT - COMMENT_HEIGHT * scale) / 2;
-        BufferedImage image = new BufferedImage(COMMENT_WIDTH, COMMENT_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+                (IMAGE_WIDTH - IMAGE_PADDING * 2d) / IMAGE_WIDTH,
+                (IMAGE_HEIGHT - IMAGE_PADDING * 2d) / IMAGE_HEIGHT);
+        double offsetX = (IMAGE_WIDTH - IMAGE_WIDTH * scale) / 2;
+        double offsetY = (IMAGE_HEIGHT - IMAGE_HEIGHT * scale) / 2;
+        BufferedImage image = new BufferedImage(IMAGE_WIDTH, IMAGE_HEIGHT, BufferedImage.TYPE_INT_ARGB);
         Graphics2D graphics = image.createGraphics();
         try {
             graphics.setColor(Color.WHITE);
-            graphics.fillRect(0, 0, COMMENT_WIDTH, COMMENT_HEIGHT);
+            graphics.fillRect(0, 0, IMAGE_WIDTH, IMAGE_HEIGHT);
             graphics.setStroke(new BasicStroke(2f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
             graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
             for (JsonNode stroke : strokes) {
@@ -179,8 +235,8 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
                     if (!isPoint(point)) {
                         continue;
                     }
-                    double x = offsetX + Math.clamp(point.path("x").asDouble(), 0, 1) * COMMENT_WIDTH * scale;
-                    double y = offsetY + Math.clamp(point.path("y").asDouble(), 0, 1) * COMMENT_HEIGHT * scale;
+                    double x = offsetX + Math.clamp(point.path("x").asDouble(), 0, 1) * IMAGE_WIDTH * scale;
+                    double y = offsetY + Math.clamp(point.path("y").asDouble(), 0, 1) * IMAGE_HEIGHT * scale;
                     if (started) {
                         path.lineTo(x, y);
                     } else {
@@ -226,6 +282,12 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
     private Map<JudgeTeamKey, JudgeCommentEntity> commentMap(List<JudgeCommentEntity> comments) {
         Map<JudgeTeamKey, JudgeCommentEntity> result = new HashMap<>();
         comments.forEach(comment -> result.put(new JudgeTeamKey(comment.getUser().getId(), comment.getTeam().getId()), comment));
+        return result;
+    }
+
+    private Map<Long, JudgeProfileEntity> profileMap(List<JudgeProfileEntity> profiles) {
+        Map<Long, JudgeProfileEntity> result = new HashMap<>();
+        profiles.forEach(profile -> result.put(profile.getUser().getId(), profile));
         return result;
     }
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgeProfileEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/entity/JudgeProfileEntity.java
@@ -1,0 +1,42 @@
+package team.startup.gwangjutalentfestival.domain.judge.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import team.startup.gwangjutalentfestival.domain.judge.converter.JsonNodeAttributeConverter;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "judge_profile", uniqueConstraints = @UniqueConstraint(columnNames = "user_id"))
+public class JudgeProfileEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Convert(converter = JsonNodeAttributeConverter.class)
+    @Column(name = "affiliation_strokes", columnDefinition = "JSON", nullable = false)
+    private JsonNode affiliationStrokes;
+
+    @Convert(converter = JsonNodeAttributeConverter.class)
+    @Column(name = "position_strokes", columnDefinition = "JSON", nullable = false)
+    private JsonNode positionStrokes;
+
+    @Convert(converter = JsonNodeAttributeConverter.class)
+    @Column(name = "name_strokes", columnDefinition = "JSON", nullable = false)
+    private JsonNode nameStrokes;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/controller/JudgeController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/controller/JudgeController.java
@@ -12,14 +12,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeCommentRequest;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeProfileRequest;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgementScoreRequest;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeCommentResponse;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeProfileResponse;
 import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgementResponse;
 import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeEventService;
 import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeMonitoringService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetAllJudgementService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeCommentService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgementService;
+import team.startup.gwangjutalentfestival.domain.judge.service.JudgeProfileService;
 import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgeCommentService;
 import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgementScoreService;
 
@@ -42,6 +45,22 @@ public class JudgeController {
     private final ConnectSseJudgeMonitoringService connectSseJudgeMonitoringService;
     private final GetJudgeCommentService getJudgeCommentService;
     private final SaveJudgeCommentService saveJudgeCommentService;
+    private final JudgeProfileService judgeProfileService;
+
+    @Operation(summary = "심사위원 필기 정보 조회", description = "현재 심사위원의 소속, 직위, 이름 필기를 조회합니다.")
+    @SecurityRequirement(name = "Authorization")
+    @GetMapping("/profile")
+    public ResponseEntity<GetJudgeProfileResponse> getProfile() {
+        return ResponseEntity.ok(judgeProfileService.get());
+    }
+
+    @Operation(summary = "심사위원 필기 정보 저장", description = "현재 심사위원의 소속, 직위, 이름 필기를 저장하거나 덮어씁니다.")
+    @SecurityRequirement(name = "Authorization")
+    @PutMapping("/profile")
+    public ResponseEntity<Void> saveProfile(@RequestBody @Valid SaveJudgeProfileRequest request) {
+        judgeProfileService.save(request);
+        return ResponseEntity.noContent().build();
+    }
 
     @Operation(summary = "SSE 연결", description = "심사 이벤트 수신을 위한 SSE 연결을 맺습니다.")
     @ApiResponses({

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgeProfileRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgeProfileRequest.java
@@ -1,0 +1,11 @@
+package team.startup.gwangjutalentfestival.domain.judge.presentation.data.request;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import jakarta.validation.constraints.NotNull;
+
+public record SaveJudgeProfileRequest(
+        @NotNull ArrayNode affiliationStrokes,
+        @NotNull ArrayNode positionStrokes,
+        @NotNull ArrayNode nameStrokes
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/GetJudgeProfileResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/response/GetJudgeProfileResponse.java
@@ -1,0 +1,10 @@
+package team.startup.gwangjutalentfestival.domain.judge.presentation.data.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record GetJudgeProfileResponse(
+        JsonNode affiliationStrokes,
+        JsonNode positionStrokes,
+        JsonNode nameStrokes
+) {
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgeProfileRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/repository/JudgeProfileRepository.java
@@ -1,0 +1,34 @@
+package team.startup.gwangjutalentfestival.domain.judge.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeProfileEntity;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface JudgeProfileRepository extends JpaRepository<JudgeProfileEntity, Long> {
+
+    Optional<JudgeProfileEntity> findByUser(UserEntity user);
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO judge_profile (user_id, affiliation_strokes, position_strokes, name_strokes)
+            VALUES (:userId, :affiliationStrokes, :positionStrokes, :nameStrokes)
+            ON DUPLICATE KEY UPDATE
+                affiliation_strokes = :affiliationStrokes,
+                position_strokes = :positionStrokes,
+                name_strokes = :nameStrokes
+            """, nativeQuery = true)
+    void upsert(
+            @Param("userId") Long userId,
+            @Param("affiliationStrokes") String affiliationStrokes,
+            @Param("positionStrokes") String positionStrokes,
+            @Param("nameStrokes") String nameStrokes);
+
+    @Query("SELECT p FROM JudgeProfileEntity p JOIN FETCH p.user")
+    List<JudgeProfileEntity> findAllWithUser();
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/JudgeProfileService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/JudgeProfileService.java
@@ -1,0 +1,67 @@
+package team.startup.gwangjutalentfestival.domain.judge.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangjutalentfestival.domain.judge.exception.JudgeCommentTooLargeException;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeProfileRequest;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeProfileResponse;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeProfileRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+public class JudgeProfileService {
+
+    private static final int MAX_STROKES_BYTES = 500_000;
+
+    private final UserUtil userUtil;
+    private final JudgeProfileRepository judgeProfileRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public GetJudgeProfileResponse get() {
+        UserEntity user = userUtil.getCurrentUserRef();
+        return judgeProfileRepository.findByUser(user)
+                .map(profile -> new GetJudgeProfileResponse(
+                        strokesOrEmpty(profile.getAffiliationStrokes()),
+                        strokesOrEmpty(profile.getPositionStrokes()),
+                        strokesOrEmpty(profile.getNameStrokes())))
+                .orElseGet(() -> new GetJudgeProfileResponse(
+                        objectMapper.createArrayNode(),
+                        objectMapper.createArrayNode(),
+                        objectMapper.createArrayNode()));
+    }
+
+    @Transactional
+    public void save(SaveJudgeProfileRequest request) {
+        UserEntity user = userUtil.getCurrentUserRef();
+        String affiliationStrokes = serialize(request.affiliationStrokes());
+        String positionStrokes = serialize(request.positionStrokes());
+        String nameStrokes = serialize(request.nameStrokes());
+
+        judgeProfileRepository.upsert(user.getId(), affiliationStrokes, positionStrokes, nameStrokes);
+    }
+
+    private JsonNode strokesOrEmpty(JsonNode strokes) {
+        return strokes == null || strokes.isNull() ? objectMapper.createArrayNode() : strokes;
+    }
+
+    private String serialize(JsonNode strokes) {
+        try {
+            String value = objectMapper.writeValueAsString(strokes);
+            if (value.getBytes(StandardCharsets.UTF_8).length > MAX_STROKES_BYTES) {
+                throw new JudgeCommentTooLargeException();
+            }
+            return value;
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("strokes 데이터를 직렬화할 수 없습니다.", e);
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
@@ -8,6 +8,7 @@ import org.apache.poi.util.Units;
 import org.apache.poi.xssf.usermodel.XSSFDrawing;
 import org.apache.poi.xssf.usermodel.XSSFPicture;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.ss.util.CellRangeAddress;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,8 +16,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangjutalentfestival.domain.excel.service.impl.DownloadJudgeSheetsServiceImpl;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeCommentEntity;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeProfileEntity;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeProfileRepository;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.enums.TeamGenre;
@@ -50,6 +53,7 @@ class DownloadJudgeSheetsServiceImplTest {
     @Mock private TeamRepository teamRepository;
     @Mock private JudgementRepository judgementRepository;
     @Mock private JudgeCommentRepository judgeCommentRepository;
+    @Mock private JudgeProfileRepository judgeProfileRepository;
     @Mock private UserRepository userRepository;
     @Mock private DownloadJudgingSummaryExcelService summaryExcelService;
     @Mock private GoogleExcelAdapter googleExcelAdapter;
@@ -61,8 +65,8 @@ class DownloadJudgeSheetsServiceImplTest {
     @BeforeEach
     void setUp() {
         service = new DownloadJudgeSheetsServiceImpl(
-                teamRepository, judgementRepository, judgeCommentRepository, userRepository, summaryExcelService,
-                googleExcelAdapter, googleExcelProperties);
+                teamRepository, judgementRepository, judgeCommentRepository, judgeProfileRepository, userRepository,
+                summaryExcelService, googleExcelAdapter, googleExcelProperties);
         given(summaryExcelService.execute()).willReturn(new byte[]{1, 2, 3});
         given(googleExcelAdapter.exportJudgeTemplate()).willReturn(template());
         given(googleExcelProperties.judgeTemplatePage()).willReturn("개별 심사표");
@@ -92,23 +96,24 @@ class DownloadJudgeSheetsServiceImplTest {
         try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_A_개별심사표.xlsx")))) {
             var sheet = workbook.getSheet("개별 심사표");
             assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("원본 제목");
-            assertThat(sheet.getRow(2).getCell(0).getStringCellValue()).isEqualTo("심사순서");
-            assertThat(sheet.getRow(2).getCell(1).getStringCellValue()).isEqualTo("팀명");
-            assertThat(sheet.getRow(2).getCell(2).getStringCellValue()).isEqualTo("심사위원 A");
-            assertThat(sheet.getRow(2).getCell(3).getStringCellValue()).isEqualTo("코멘트");
-            assertThat(sheet.getRow(3).getCell(0).getNumericCellValue()).isEqualTo(1);
-            assertThat(sheet.getRow(3).getCell(1).getStringCellValue()).isEqualTo("팀1");
-            assertThat(sheet.getRow(3).getCell(2).getNumericCellValue()).isEqualTo(60);
-            assertThat(sheet.getRow(4).getCell(0).getNumericCellValue()).isEqualTo(2);
-            assertThat(sheet.getRow(4).getCell(1).getStringCellValue()).isEqualTo("팀2");
-            assertThat(sheet.getRow(4).getCell(2).getNumericCellValue()).isZero();
+            assertThat(sheet.getRow(2).getCell(0).getStringCellValue()).isEqualTo("소속/직위/이름");
+            assertThat(sheet.getRow(3).getCell(0).getStringCellValue()).isEqualTo("심사순서");
+            assertThat(sheet.getRow(3).getCell(1).getStringCellValue()).isEqualTo("팀명");
+            assertThat(sheet.getRow(3).getCell(2).getStringCellValue()).isEqualTo("심사위원 A");
+            assertThat(sheet.getRow(3).getCell(3).getStringCellValue()).isEqualTo("코멘트");
+            assertThat(sheet.getRow(4).getCell(0).getNumericCellValue()).isEqualTo(1);
+            assertThat(sheet.getRow(4).getCell(1).getStringCellValue()).isEqualTo("팀1");
+            assertThat(sheet.getRow(4).getCell(2).getNumericCellValue()).isEqualTo(60);
+            assertThat(sheet.getRow(5).getCell(0).getNumericCellValue()).isEqualTo(2);
+            assertThat(sheet.getRow(5).getCell(1).getStringCellValue()).isEqualTo("팀2");
+            assertThat(sheet.getRow(5).getCell(2).getNumericCellValue()).isZero();
             assertThat(workbook.getAllPictures()).hasSize(1);
             assertThat(renderedImageHasColor(workbook.getAllPictures().getFirst(), Color.RED)).isTrue();
             assertThat(renderedImageHasColor(workbook.getAllPictures().getFirst(), new Color(0x12, 0x12, 0x12))).isTrue();
-            assertCommentPicture(workbook, 3);
+            assertCommentPicture(workbook, 4);
         }
         try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_B_개별심사표.xlsx")))) {
-            assertCommentPicture(workbook, 3);
+            assertCommentPicture(workbook, 4);
         }
     }
 
@@ -166,13 +171,53 @@ class DownloadJudgeSheetsServiceImplTest {
             assertThat(renderedImageHasColor(pictures.get(4).getPictureData(), Color.RED)).isTrue();
             assertThat(renderedImageHasColor(pictures.get(4).getPictureData(), new Color(0x12, 0x12, 0x12))).isTrue();
             assertThat(pictures).extracting(picture -> picture.getClientAnchor().getRow1())
-                    .containsExactly(3, 4, 5, 6, 7);
-            assertThat(sheet.getRow(8).getHeightInPoints()).isEqualTo(37.5f);
+                    .containsExactly(4, 5, 6, 7, 8);
+            assertThat(sheet.getRow(9).getHeightInPoints()).isEqualTo(37.5f);
         }
     }
 
     @Test
-    void 열두번째_행은_보존하고_아홉번째_팀은_열세번째_행부터_작성한다() throws Exception {
+    void 심사위원별_소속_직위_이름을_각_병합셀에_삽입한다() throws Exception {
+        UserEntity judgeA = user(10L);
+        UserEntity judgeB = user(20L);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of());
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of());
+        given(judgeCommentRepository.findAllWithUserAndTeam()).willReturn(List.of());
+        given(judgeProfileRepository.findAllWithUser()).willReturn(List.of(
+                profile(judgeA,
+                        stroke("#ff0000", 0.1, 0.5, 0.9, 0.5),
+                        emptyStroke(),
+                        stroke("#121212", 0.5, 0.1, 0.5, 0.9)),
+                profile(judgeB,
+                        stroke("#0000ff", 0.1, 0.5, 0.9, 0.5),
+                        objectMapper.createArrayNode(),
+                        objectMapper.createArrayNode())
+        ));
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judgeA, judgeB));
+
+        Map<String, byte[]> files = zipEntries(service.execute());
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_A_개별심사표.xlsx")))) {
+            var sheet = workbook.getSheet("개별 심사표");
+            var pictures = sheet.getDrawingPatriarch().getShapes().stream()
+                    .map(XSSFPicture.class::cast)
+                    .toList();
+            assertThat(pictures).hasSize(2);
+            assertProfilePicture(sheet, pictures.get(0), 1);
+            assertProfilePicture(sheet, pictures.get(1), 5);
+            assertThat(renderedImageHasColor(pictures.get(0).getPictureData(), Color.RED)).isTrue();
+            assertThat(renderedImageHasColor(pictures.get(1).getPictureData(), new Color(0x12, 0x12, 0x12))).isTrue();
+        }
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_B_개별심사표.xlsx")))) {
+            var pictures = workbook.getSheet("개별 심사표").getDrawingPatriarch().getShapes();
+            assertThat(pictures).hasSize(1);
+            assertThat(renderedImageHasColor(
+                    ((XSSFPicture) pictures.getFirst()).getPictureData(), Color.BLUE)).isTrue();
+        }
+    }
+
+    @Test
+    void 열세번째_행은_보존하고_아홉번째_팀은_열네번째_행부터_작성한다() throws Exception {
         List<TeamEntity> teams = java.util.stream.IntStream.rangeClosed(1, 9)
                 .mapToObj(index -> team(index, index))
                 .toList();
@@ -186,22 +231,26 @@ class DownloadJudgeSheetsServiceImplTest {
 
         try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_A_개별심사표.xlsx")))) {
             var sheet = workbook.getSheet("개별 심사표");
-            assertThat(sheet.getRow(11).getCell(0).getStringCellValue()).isEqualTo("12행 보존");
-            assertThat(sheet.getRow(12).getCell(0).getNumericCellValue()).isEqualTo(9);
+            assertThat(sheet.getRow(12).getCell(0).getStringCellValue()).isEqualTo("13행 보존");
+            assertThat(sheet.getRow(13).getCell(0).getNumericCellValue()).isEqualTo(9);
         }
     }
 
     private byte[] template() {
         try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream output = new ByteArrayOutputStream()) {
             var sheet = workbook.createSheet("개별 심사표");
-            for (int rowIndex = 0; rowIndex < 14; rowIndex++) {
+            for (int rowIndex = 0; rowIndex < 15; rowIndex++) {
                 var row = sheet.createRow(rowIndex);
-                for (int column = 0; column < 4; column++) {
+                for (int column = 0; column < 7; column++) {
                     row.createCell(column);
                 }
             }
             sheet.getRow(0).getCell(0).setCellValue("원본 제목");
-            sheet.getRow(11).getCell(0).setCellValue("12행 보존");
+            sheet.getRow(2).getCell(0).setCellValue("소속/직위/이름");
+            sheet.addMergedRegion(new CellRangeAddress(2, 2, 1, 2));
+            sheet.addMergedRegion(new CellRangeAddress(2, 2, 3, 4));
+            sheet.addMergedRegion(new CellRangeAddress(2, 2, 5, 6));
+            sheet.getRow(12).getCell(0).setCellValue("13행 보존");
             workbook.write(output);
             return output.toByteArray();
         } catch (IOException e) {
@@ -265,6 +314,28 @@ class DownloadJudgeSheetsServiceImplTest {
         assertThat(image.getHeight()).isEqualTo(500);
     }
 
+    private void assertProfilePicture(
+            org.apache.poi.ss.usermodel.Sheet sheet,
+            XSSFPicture picture,
+            int column) throws IOException {
+        ClientAnchor anchor = picture.getClientAnchor();
+        int width = Math.round(sheet.getColumnWidthInPixels(column))
+                + Math.round(sheet.getColumnWidthInPixels(column + 1));
+        int height = Units.pointsToPixel(sheet.getRow(2).getHeightInPoints());
+        assertThat(anchor.getCol1()).isEqualTo((short) column);
+        assertThat(anchor.getCol2()).isEqualTo((short) column);
+        assertThat(anchor.getRow1()).isEqualTo(2);
+        assertThat(anchor.getRow2()).isEqualTo(2);
+        assertThat(anchor.getDx1()).isZero();
+        assertThat(anchor.getDy1()).isZero();
+        assertThat(anchor.getDx2()).isEqualTo(Units.pixelToEMU(width));
+        assertThat(anchor.getDy2()).isEqualTo(Units.pixelToEMU(height));
+
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(picture.getPictureData().getData()));
+        assertThat(image.getWidth()).isEqualTo(1000);
+        assertThat(image.getHeight()).isEqualTo(500);
+    }
+
     private Map<String, byte[]> zipEntries(byte[] zip) throws IOException {
         Map<String, byte[]> files = new java.util.HashMap<>();
         try (ZipInputStream input = new ZipInputStream(new ByteArrayInputStream(zip))) {
@@ -306,6 +377,19 @@ class DownloadJudgeSheetsServiceImplTest {
 
     private JudgeCommentEntity comment(TeamEntity team, UserEntity user, ArrayNode strokes) {
         return JudgeCommentEntity.builder().team(team).user(user).strokes(strokes).build();
+    }
+
+    private JudgeProfileEntity profile(
+            UserEntity user,
+            ArrayNode affiliation,
+            ArrayNode position,
+            ArrayNode name) {
+        return JudgeProfileEntity.builder()
+                .user(user)
+                .affiliationStrokes(affiliation)
+                .positionStrokes(position)
+                .nameStrokes(name)
+                .build();
     }
 
     private ArrayNode strokes() {

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgeProfileRequestTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/presentation/data/request/SaveJudgeProfileRequestTest.java
@@ -1,0 +1,40 @@
+package team.startup.gwangjutalentfestival.domain.judge.presentation.data.request;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SaveJudgeProfileRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void 세_필기값을_배열로_역직렬화한다() throws Exception {
+        SaveJudgeProfileRequest request = objectMapper.readValue("""
+                {
+                  "affiliationStrokes": [{"value": "소속"}],
+                  "positionStrokes": [],
+                  "nameStrokes": [{"value": "이름"}]
+                }
+                """, SaveJudgeProfileRequest.class);
+
+        assertThat(request.affiliationStrokes()).hasSize(1);
+        assertThat(request.positionStrokes()).isEmpty();
+        assertThat(request.nameStrokes()).hasSize(1);
+    }
+
+    @Test
+    void 필기값이_배열이_아니면_역직렬화에_실패한다() {
+        assertThatThrownBy(() -> objectMapper.readValue("""
+                {
+                  "affiliationStrokes": {},
+                  "positionStrokes": [],
+                  "nameStrokes": []
+                }
+                """, SaveJudgeProfileRequest.class))
+                .isInstanceOf(MismatchedInputException.class);
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/JudgeProfileServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/JudgeProfileServiceTest.java
@@ -1,0 +1,117 @@
+package team.startup.gwangjutalentfestival.domain.judge.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgeProfileEntity;
+import team.startup.gwangjutalentfestival.domain.judge.exception.JudgeCommentTooLargeException;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.request.SaveJudgeProfileRequest;
+import team.startup.gwangjutalentfestival.domain.judge.presentation.data.response.GetJudgeProfileResponse;
+import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeProfileRepository;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.util.UserUtil;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JudgeProfileServiceTest {
+
+    @Mock
+    private UserUtil userUtil;
+
+    @Mock
+    private JudgeProfileRepository judgeProfileRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private JudgeProfileService service;
+    private UserEntity judge;
+
+    @BeforeEach
+    void setUp() {
+        service = new JudgeProfileService(userUtil, judgeProfileRepository, objectMapper);
+        judge = UserEntity.builder().id(1L).role(Role.JUDGE).build();
+        given(userUtil.getCurrentUserRef()).willReturn(judge);
+    }
+
+    @Test
+    void 소속_직위_이름_필기를_한번에_upsert한다() {
+        SaveJudgeProfileRequest request = new SaveJudgeProfileRequest(
+                strokes("소속"), strokes("직위"), strokes("이름"));
+
+        service.save(request);
+
+        ArgumentCaptor<String> affiliation = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> position = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> name = ArgumentCaptor.forClass(String.class);
+        verify(judgeProfileRepository).upsert(
+                eq(1L), affiliation.capture(), position.capture(), name.capture());
+        assertThat(affiliation.getValue()).contains("소속");
+        assertThat(position.getValue()).contains("직위");
+        assertThat(name.getValue()).contains("이름");
+    }
+
+    @Test
+    void 저장된_필기_정보를_조회한다() {
+        given(judgeProfileRepository.findByUser(judge)).willReturn(Optional.of(
+                JudgeProfileEntity.builder()
+                        .user(judge)
+                        .affiliationStrokes(strokes("소속"))
+                        .positionStrokes(strokes("직위"))
+                        .nameStrokes(strokes("이름"))
+                        .build()));
+
+        GetJudgeProfileResponse response = service.get();
+
+        assertThat(response.affiliationStrokes().get(0).path("value").asText()).isEqualTo("소속");
+        assertThat(response.positionStrokes().get(0).path("value").asText()).isEqualTo("직위");
+        assertThat(response.nameStrokes().get(0).path("value").asText()).isEqualTo("이름");
+    }
+
+    @Test
+    void 저장된_정보가_없으면_세_필드_모두_빈_배열을_반환한다() {
+        given(judgeProfileRepository.findByUser(judge)).willReturn(Optional.empty());
+
+        GetJudgeProfileResponse response = service.get();
+
+        assertThat(response.affiliationStrokes()).isEmpty();
+        assertThat(response.positionStrokes()).isEmpty();
+        assertThat(response.nameStrokes()).isEmpty();
+    }
+
+    @Test
+    void 각_필기는_빈_배열로_초기화할_수_있다() {
+        ArrayNode empty = objectMapper.createArrayNode();
+
+        service.save(new SaveJudgeProfileRequest(empty, empty, empty));
+
+        verify(judgeProfileRepository).upsert(1L, "[]", "[]", "[]");
+    }
+
+    @Test
+    void 필기_하나가_크기_제한을_초과하면_저장하지_않는다() {
+        ArrayNode large = objectMapper.createArrayNode();
+        large.addObject().put("data", "a".repeat(500_000));
+
+        assertThatThrownBy(() -> service.save(new SaveJudgeProfileRequest(
+                large, objectMapper.createArrayNode(), objectMapper.createArrayNode())))
+                .isInstanceOf(JudgeCommentTooLargeException.class);
+    }
+
+    private ArrayNode strokes(String value) {
+        ArrayNode strokes = objectMapper.createArrayNode();
+        strokes.addObject().put("value", value);
+        return strokes;
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
> 심사위원이 소속·직위·이름을 펜으로 저장·조회하고, 개인별 심사표에서 확인할 수 있도록 구현했습니다.

- `GET/PUT /judge/profile` 추가
- 계정별 세 필기값을 `judge_profile`에 원자적으로 저장
- 개인별 심사표 `B3:C3`, `D3:E3`, `F3:G3`에 필기 이미지 삽입
- 기존 표 헤더·데이터·보존 행을 한 행 아래로 이동
- 빈 stroke 이미지 생략 및 기존 D열 코멘트 규격 유지

---

## 🔍 리뷰 시 참고사항
- 각 필기는 기존 코멘트와 같은 정규화 stroke JSON과 필드별 500KB 제한을 사용합니다.
- 이미지는 1000×500 PNG로 렌더링하고 병합 셀의 실제 크기를 EMU 앵커로 계산합니다.
- 실제 Google 템플릿 인증값은 로컬에 없어 직접 export하지 못했으며, 제공된 셀 구조를 재현한 XLSX 테스트로 검증했습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #200
