### PR TITLE
세부 항목 순위에 최고·최저 제외 평균 적용

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgingSummaryExcelServiceImpl.java
@@ -6,16 +6,16 @@ import org.springframework.stereotype.Service;
 import team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgingSummaryExcelService;
 import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
+import team.startup.gwangjutalentfestival.domain.judge.util.JudgeRankingCalculator;
+import team.startup.gwangjutalentfestival.domain.judge.util.JudgeScoreCalculator;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
-import team.startup.gwangjutalentfestival.domain.judge.util.JudgeScoreCalculator;
 import team.startup.gwangjutalentfestival.global.thirdparty.google.adapter.GoogleExcelAdapter;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -52,7 +52,10 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
                 TeamEntity::getId,
                 team -> JudgeScoreCalculator.calculate(scoreMap.getOrDefault(team.getId(), Collections.emptyMap()).values())
         ));
-        Map<Long, Integer> rankMap = ranks(teams, judgements, judgeIds, teamTotalMap);
+        List<JudgementEntity> judgeJudgements = judgements.stream()
+                .filter(judgement -> judgeIds.contains(judgement.getUser().getId()))
+                .toList();
+        Map<Long, Integer> rankMap = JudgeRankingCalculator.calculate(teams, judgeJudgements, teamTotalMap);
 
         List<List<Object>> rows = new ArrayList<>();
         rows.add(buildHeaderRow(judgeIds.size()));
@@ -108,36 +111,4 @@ public class DownloadJudgingSummaryExcelServiceImpl implements DownloadJudgingSu
         return Optional.ofNullable(v).orElse(0);
     }
 
-    private Map<Long, Integer> ranks(
-            List<TeamEntity> teams,
-            List<JudgementEntity> judgements,
-            List<Long> judgeIds,
-            Map<Long, Integer> teamTotalMap) {
-        List<TeamEntity> sorted = new ArrayList<>(teams);
-        sorted.sort(Comparator
-                .comparing((TeamEntity team) -> teamTotalMap.get(team.getId()), Comparator.reverseOrder())
-                .thenComparing((TeamEntity team) -> average(team, judgements, judgeIds, JudgementEntity::getCompletenessExpressionScore), Comparator.reverseOrder())
-                .thenComparing((TeamEntity team) -> average(team, judgements, judgeIds, JudgementEntity::getCreativityCompositionScore), Comparator.reverseOrder())
-                .thenComparing((TeamEntity team) -> average(team, judgements, judgeIds, JudgementEntity::getStagePerformanceTeamworkScore), Comparator.reverseOrder())
-                .thenComparing(TeamEntity::getId));
-
-        Map<Long, Integer> result = new HashMap<>();
-        for (int index = 0; index < sorted.size(); index++) {
-            result.put(sorted.get(index).getId(), index + 1);
-        }
-        return result;
-    }
-
-    private double average(
-            TeamEntity team,
-            List<JudgementEntity> judgements,
-            List<Long> judgeIds,
-            Function<JudgementEntity, Integer> score) {
-        return judgements.stream()
-                .filter(judgement -> judgeIds.contains(judgement.getUser().getId()))
-                .filter(judgement -> judgement.getTeam().getId().equals(team.getId()))
-                .mapToInt(score::apply)
-                .average()
-                .orElse(0);
-    }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeMonitoringServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/service/impl/GetJudgeMonitoringServiceImpl.java
@@ -9,6 +9,7 @@ import team.startup.gwangjutalentfestival.domain.judge.presentation.data.respons
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgeCommentRepository;
 import team.startup.gwangjutalentfestival.domain.judge.repository.JudgementRepository;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeMonitoringService;
+import team.startup.gwangjutalentfestival.domain.judge.util.JudgeRankingCalculator;
 import team.startup.gwangjutalentfestival.domain.judge.util.JudgeScoreCalculator;
 import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.repository.TeamRepository;
@@ -17,7 +18,6 @@ import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +53,8 @@ public class GetJudgeMonitoringServiceImpl implements GetJudgeMonitoringService 
                 ));
 
         Map<Long, Integer> calculatedScores = calculateScores(teams, judges, judgements);
-        Map<Long, Integer> ranks = ranks(teams, judgements, calculatedScores);
+        Map<Long, Integer> ranks = JudgeRankingCalculator.calculate(
+                teams, judgements.values(), calculatedScores);
         List<JudgeMonitoringResponse.JudgeHeader> headers = headers(judges);
 
         return new JudgeMonitoringResponse(
@@ -85,33 +86,6 @@ public class GetJudgeMonitoringServiceImpl implements GetJudgeMonitoringService 
             result.put(team.getId(), JudgeScoreCalculator.calculate(scores));
         }
         return result;
-    }
-
-    private Map<Long, Integer> ranks(
-            List<TeamEntity> teams,
-            Map<JudgeTeamKey, JudgementEntity> judgements,
-            Map<Long, Integer> calculatedScores) {
-        List<TeamEntity> sorted = new ArrayList<>(teams);
-        sorted.sort(Comparator
-                .comparing((TeamEntity team) -> calculatedScores.get(team.getId()), Comparator.reverseOrder())
-                .thenComparing((TeamEntity team) -> average(team, judgements, JudgementEntity::getCompletenessExpressionScore), Comparator.reverseOrder())
-                .thenComparing((TeamEntity team) -> average(team, judgements, JudgementEntity::getCreativityCompositionScore), Comparator.reverseOrder())
-                .thenComparing((TeamEntity team) -> average(team, judgements, JudgementEntity::getStagePerformanceTeamworkScore), Comparator.reverseOrder())
-                .thenComparing(TeamEntity::getId));
-        Map<Long, Integer> result = new HashMap<>();
-        for (int index = 0; index < sorted.size(); index++) {
-            result.put(sorted.get(index).getId(), index + 1);
-        }
-        return result;
-    }
-
-    private double average(TeamEntity team, Map<JudgeTeamKey, JudgementEntity> judgements, java.util.function.Function<JudgementEntity, Integer> score) {
-        return judgements.entrySet().stream()
-                .filter(entry -> entry.getKey().teamId().equals(team.getId()))
-                .map(Map.Entry::getValue)
-                .mapToInt(score::apply)
-                .average()
-                .orElse(0);
     }
 
     private List<JudgeMonitoringResponse.ScoreRow> scoreRows(

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeRankingCalculator.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeRankingCalculator.java
@@ -1,0 +1,61 @@
+package team.startup.gwangjutalentfestival.domain.judge.util;
+
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
+
+public final class JudgeRankingCalculator {
+
+    private JudgeRankingCalculator() {
+    }
+
+    public static Map<Long, Integer> calculate(
+            List<TeamEntity> teams,
+            Collection<JudgementEntity> judgements,
+            Map<Long, Integer> calculatedScores) {
+        Map<Long, List<JudgementEntity>> judgementsByTeam = judgements.stream()
+                .collect(Collectors.groupingBy(judgement -> judgement.getTeam().getId()));
+        List<TeamEntity> sorted = new ArrayList<>(teams);
+        sorted.sort(Comparator
+                .comparing(
+                        (TeamEntity team) -> calculatedScores.getOrDefault(team.getId(), 0),
+                        Comparator.reverseOrder())
+                .thenComparing(
+                        team -> average(
+                                judgementsByTeam.getOrDefault(team.getId(), List.of()),
+                                JudgementEntity::getCompletenessExpressionScore),
+                        Comparator.reverseOrder())
+                .thenComparing(
+                        team -> average(
+                                judgementsByTeam.getOrDefault(team.getId(), List.of()),
+                                JudgementEntity::getCreativityCompositionScore),
+                        Comparator.reverseOrder())
+                .thenComparing(
+                        team -> average(
+                                judgementsByTeam.getOrDefault(team.getId(), List.of()),
+                                JudgementEntity::getStagePerformanceTeamworkScore),
+                        Comparator.reverseOrder())
+                .thenComparing(TeamEntity::getId));
+
+        Map<Long, Integer> result = new HashMap<>();
+        for (int index = 0; index < sorted.size(); index++) {
+            result.put(sorted.get(index).getId(), index + 1);
+        }
+        return result;
+    }
+
+    private static double average(
+            List<JudgementEntity> judgements,
+            ToIntFunction<JudgementEntity> score) {
+        return JudgeScoreCalculator.calculateAverage(
+                judgements.stream().map(score::applyAsInt).toList());
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeScoreCalculator.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeScoreCalculator.java
@@ -8,15 +8,19 @@ public final class JudgeScoreCalculator {
     }
 
     public static int calculate(Collection<Integer> scores) {
+        return (int) Math.round(calculateAverage(scores));
+    }
+
+    public static double calculateAverage(Collection<Integer> scores) {
         if (scores.isEmpty()) {
             return 0;
         }
         int sum = scores.stream().mapToInt(Integer::intValue).sum();
         if (scores.size() < 3) {
-            return Math.round(sum / (float) scores.size());
+            return sum / (double) scores.size();
         }
         int min = scores.stream().mapToInt(Integer::intValue).min().orElseThrow();
         int max = scores.stream().mapToInt(Integer::intValue).max().orElseThrow();
-        return Math.round((sum - min - max) / (float) (scores.size() - 2));
+        return (sum - min - max) / (double) (scores.size() - 2);
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepositoryCustomImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/repository/TeamRepositoryCustomImpl.java
@@ -3,12 +3,18 @@ package team.startup.gwangjutalentfestival.domain.team.repository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
 import team.startup.gwangjutalentfestival.domain.judge.entity.QJudgementEntity;
+import team.startup.gwangjutalentfestival.domain.judge.util.JudgeRankingCalculator;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.entity.QTeamEntity;
 import team.startup.gwangjutalentfestival.domain.team.presentation.data.response.GetTeamRankingResponse;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
+import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * {@link TeamRepositoryCustom}의 QueryDSL 구현체.
@@ -24,32 +30,26 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
     private static final QJudgementEntity judgement = QJudgementEntity.judgementEntity;
 
     /**
-     * 총점 내림차순, 세부 심사 점수 평균 순으로 팀 랭킹을 조회한다.
-     * 동점일 경우 완성도/표현력 점수, 창의력/구성 점수, 무대매너/퍼포먼스 점수, ID 오름차순으로 순위를 결정한다.
-     *
-     * @return 순위가 부여된 팀 랭킹 목록
+     * 총점 내림차순, 세부 심사 점수의 최고·최저 제외 평균 순으로 팀 랭킹을 조회한다.
      */
     @Override
     public List<GetTeamRankingResponse> getRanking() {
-        List<String> teamNames = queryFactory
-                .select(team.teamName)
-                .from(team)
-                .leftJoin(judgement).on(judgement.team.id.eq(team.id))
-                .groupBy(team.id, team.teamName)
-                .orderBy(
-                        team.totalScore.desc(),
-                        judgement.completenessExpressionScore.avg().desc(),
-                        judgement.creativityCompositionScore.avg().desc(),
-                        judgement.stagePerformanceTeamworkScore.avg().desc(),
-                        team.id.asc()
-                )
+        List<TeamEntity> teams = queryFactory.selectFrom(team).fetch();
+        List<JudgementEntity> judgements = queryFactory
+                .selectFrom(judgement)
+                .join(judgement.user).fetchJoin()
+                .where(judgement.user.role.eq(Role.JUDGE))
                 .fetch();
+        Map<Long, Integer> calculatedScores = teams.stream()
+                .collect(Collectors.toMap(TeamEntity::getId, TeamEntity::getTotalScore));
+        Map<Long, Integer> ranks = JudgeRankingCalculator.calculate(
+                teams, judgements, calculatedScores);
 
-        AtomicInteger rank = new AtomicInteger(1);
-        return teamNames.stream()
-                .map(name -> new GetTeamRankingResponse(
-                        rank.getAndIncrement(),
-                        name
+        return teams.stream()
+                .sorted(Comparator.comparing(team -> ranks.get(team.getId())))
+                .map(team -> new GetTeamRankingResponse(
+                        ranks.get(team.getId()),
+                        team.getTeamName()
                 ))
                 .toList();
     }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgingSummaryExcelServiceImplTest.java
@@ -82,15 +82,23 @@ class DownloadJudgingSummaryExcelServiceImplTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void 산출점수가_같으면_완성도_평균이_높은_팀을_먼저_순위로_매긴다() {
+    void 산출점수가_같으면_완성도_최고최저_제외평균이_높은_팀을_먼저_순위로_매긴다() {
         TeamEntity teamA = team(2L, 1, "팀A");
         TeamEntity teamB = team(1L, 2, "팀B");
-        UserEntity judge = user(1L, Role.JUDGE);
+        List<UserEntity> judges = java.util.stream.LongStream.rangeClosed(1, 4)
+                .mapToObj(id -> user(id, Role.JUDGE))
+                .toList();
         given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB));
-        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judge));
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(judges);
         given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
-                judgement(teamA, judge, 30, 20, 20),
-                judgement(teamB, judge, 25, 25, 20)
+                judgement(teamA, judges.get(0), 0, 30, 30),
+                judgement(teamA, judges.get(1), 20, 20, 20),
+                judgement(teamA, judges.get(2), 20, 20, 20),
+                judgement(teamA, judges.get(3), 20, 20, 20),
+                judgement(teamB, judges.get(0), 18, 21, 21),
+                judgement(teamB, judges.get(1), 18, 21, 21),
+                judgement(teamB, judges.get(2), 18, 21, 21),
+                judgement(teamB, judges.get(3), 30, 15, 15)
         ));
 
         service.execute();
@@ -98,8 +106,8 @@ class DownloadJudgingSummaryExcelServiceImplTest {
         ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
         verify(googleExcelAdapter).exportSummary(captor.capture());
         List<List<Object>> rows = captor.getValue();
-        assertThat(rows.get(1)).containsExactly(1, "팀A", 70, 70, 1);
-        assertThat(rows.get(2)).containsExactly(2, "팀B", 70, 70, 2);
+        assertThat(rows.get(1)).containsExactly(1, "팀A", 60, 60, 60, 60, 60, 1);
+        assertThat(rows.get(2)).containsExactly(2, "팀B", 60, 60, 60, 60, 60, 2);
     }
 
     @Test

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeMonitoringServiceTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/service/GetJudgeMonitoringServiceTest.java
@@ -69,6 +69,37 @@ class GetJudgeMonitoringServiceTest {
                 .containsExactly(strokes, null);
     }
 
+    @Test
+    void 산출점수가_같으면_세부항목의_최고최저_제외평균으로_순위를_정한다() {
+        GetJudgeMonitoringService service = new GetJudgeMonitoringServiceImpl(
+                userRepository, teamRepository, judgementRepository, judgeCommentRepository);
+        List<UserEntity> judges = java.util.stream.LongStream.rangeClosed(1, 4)
+                .mapToObj(id -> user(id, Role.JUDGE))
+                .toList();
+        TeamEntity teamA = team(10L, 1, "팀A");
+        TeamEntity teamB = team(20L, 2, "팀B");
+        given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(judges);
+        given(teamRepository.findAllByOrderByPerformOrderAsc()).willReturn(List.of(teamA, teamB));
+        given(judgementRepository.findAllWithUserAndTeam()).willReturn(List.of(
+                judgement(teamA, judges.get(0), 0, 30, 30),
+                judgement(teamA, judges.get(1), 20, 20, 20),
+                judgement(teamA, judges.get(2), 20, 20, 20),
+                judgement(teamA, judges.get(3), 20, 20, 20),
+                judgement(teamB, judges.get(0), 18, 21, 21),
+                judgement(teamB, judges.get(1), 18, 21, 21),
+                judgement(teamB, judges.get(2), 18, 21, 21),
+                judgement(teamB, judges.get(3), 30, 15, 15)
+        ));
+        given(judgeCommentRepository.findAllWithUserAndTeam()).willReturn(List.of());
+
+        JudgeMonitoringResponse result = service.execute();
+
+        assertThat(result.scoreRows()).extracting(JudgeMonitoringResponse.ScoreRow::calculatedScore)
+                .containsExactly(60, 60);
+        assertThat(result.scoreRows()).extracting(JudgeMonitoringResponse.ScoreRow::rank)
+                .containsExactly(1, 2);
+    }
+
     private UserEntity user(long id, Role role) {
         return UserEntity.builder().id(id).role(role).build();
     }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeRankingCalculatorTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeRankingCalculatorTest.java
@@ -1,0 +1,81 @@
+package team.startup.gwangjutalentfestival.domain.judge.util;
+
+import org.junit.jupiter.api.Test;
+import team.startup.gwangjutalentfestival.domain.judge.entity.JudgementEntity;
+import team.startup.gwangjutalentfestival.domain.team.entity.TeamEntity;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JudgeRankingCalculatorTest {
+
+    @Test
+    void 단순평균이_낮아도_완성도_최고최저_제외평균이_높은_팀이_앞선다() {
+        TeamEntity teamA = team(2L);
+        TeamEntity teamB = team(1L);
+        List<JudgementEntity> judgements = new ArrayList<>();
+        int[] teamACompleteness = {0, 20, 20, 20};
+        int[] teamBCompleteness = {18, 18, 18, 30};
+        for (int index = 0; index < 4; index++) {
+            UserEntity judge = judge(index + 1L);
+            judgements.add(judgement(teamA, judge, teamACompleteness[index], 10, 10));
+            judgements.add(judgement(teamB, judge, teamBCompleteness[index], 10, 10));
+        }
+
+        Map<Long, Integer> ranks = JudgeRankingCalculator.calculate(
+                List.of(teamA, teamB), judgements, Map.of(teamA.getId(), 70, teamB.getId(), 70));
+
+        assertThat(ranks).containsEntry(teamA.getId(), 1).containsEntry(teamB.getId(), 2);
+    }
+
+    @Test
+    void 완성도가_같으면_창의력_이후_무대점수와_팀ID_순으로_비교한다() {
+        TeamEntity teamA = team(3L);
+        TeamEntity teamB = team(2L);
+        TeamEntity teamC = team(1L);
+        UserEntity judge = judge(1L);
+        List<JudgementEntity> judgements = List.of(
+                judgement(teamA, judge, 20, 11, 10),
+                judgement(teamB, judge, 20, 10, 11),
+                judgement(teamC, judge, 20, 10, 11)
+        );
+
+        Map<Long, Integer> ranks = JudgeRankingCalculator.calculate(
+                List.of(teamA, teamB, teamC),
+                judgements,
+                Map.of(teamA.getId(), 70, teamB.getId(), 70, teamC.getId(), 70));
+
+        assertThat(ranks)
+                .containsEntry(teamA.getId(), 1)
+                .containsEntry(teamC.getId(), 2)
+                .containsEntry(teamB.getId(), 3);
+    }
+
+    private TeamEntity team(long id) {
+        return TeamEntity.builder().id(id).totalScore(70).build();
+    }
+
+    private UserEntity judge(long id) {
+        return UserEntity.builder().id(id).role(Role.JUDGE).build();
+    }
+
+    private JudgementEntity judgement(
+            TeamEntity team,
+            UserEntity judge,
+            int completeness,
+            int creativity,
+            int stage) {
+        return JudgementEntity.builder()
+                .team(team)
+                .user(judge)
+                .completenessExpressionScore(completeness)
+                .creativityCompositionScore(creativity)
+                .stagePerformanceTeamworkScore(stage)
+                .build();
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeScoreCalculatorTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/judge/util/JudgeScoreCalculatorTest.java
@@ -1,0 +1,34 @@
+package team.startup.gwangjutalentfestival.domain.judge.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JudgeScoreCalculatorTest {
+
+    @Test
+    void 세건_이상이면_최고점과_최저점_한건씩_제외한_실수_평균을_계산한다() {
+        assertThat(JudgeScoreCalculator.calculateAverage(List.of(0, 10, 11, 20)))
+                .isEqualTo(10.5);
+    }
+
+    @Test
+    void 최고점과_최저점이_동점이어도_한건씩만_제외한다() {
+        assertThat(JudgeScoreCalculator.calculateAverage(List.of(0, 0, 10, 10)))
+                .isEqualTo(5);
+    }
+
+    @Test
+    void 두건_이하면_전체_평균을_사용하고_빈값은_0이다() {
+        assertThat(JudgeScoreCalculator.calculateAverage(List.of())).isZero();
+        assertThat(JudgeScoreCalculator.calculateAverage(List.of(7))).isEqualTo(7);
+        assertThat(JudgeScoreCalculator.calculateAverage(List.of(10, 11))).isEqualTo(10.5);
+    }
+
+    @Test
+    void 산출점수는_제외_평균을_정수로_반올림한다() {
+        assertThat(JudgeScoreCalculator.calculate(List.of(0, 10, 11, 20))).isEqualTo(11);
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/global/security/RoleBasedApiAuthorizationTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/security/RoleBasedApiAuthorizationTest.java
@@ -31,6 +31,7 @@ import team.startup.gwangjutalentfestival.domain.judge.service.ConnectSseJudgeMo
 import team.startup.gwangjutalentfestival.domain.judge.service.GetAllJudgementService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgeCommentService;
 import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgementService;
+import team.startup.gwangjutalentfestival.domain.judge.service.JudgeProfileService;
 import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgeCommentService;
 import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgementScoreService;
 import team.startup.gwangjutalentfestival.domain.monitoring.presentation.controller.MonitoringController;
@@ -138,6 +139,8 @@ class RoleBasedApiAuthorizationTest {
     private GetJudgeCommentService getJudgeCommentService;
     @MockBean
     private SaveJudgeCommentService saveJudgeCommentService;
+    @MockBean
+    private JudgeProfileService judgeProfileService;
 
     @MockBean
     private GetAnomalyEventListService getAnomalyEventListService;


### PR DESCRIPTION
## ✨ 작업 내용
> 산출점수 동점 시 세부 항목도 최고·최저를 제외한 평균으로 비교하도록 순위 기준을 통일했습니다.

- 완성도·창의력·무대점수별 최고·최저 한 건씩 독립 제외
- 세부 항목은 반올림하지 않은 평균으로 비교
- Excel 집계표, 관리자 모니터링, 팀 랭킹 API가 공통 순위 계산기 사용
- 0~2건, 동점 극값, 세부 항목 우선순위 회귀 테스트 추가
- 최신 develop 병합 순서로 누락된 권한 테스트의 JudgeProfileService mock 보완

---

## 🔍 리뷰 시 참고사항
- 산출점수는 기존처럼 최고·최저 제외 평균을 정수 반올림합니다.
- 세부 항목과 팀 ID까지 모두 같을 때 ID 오름차순으로 고유 순위를 부여하는 기존 동작을 유지합니다.
- DB 및 API 스키마 변경은 없습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #203
