### PR TITLE
개별 심사표 프로필 이미지와 열 배치 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
@@ -54,14 +54,16 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
     private static final int PROFILE_ROW = 2;
     private static final int HEADER_ROW = 3;
     private static final int FIRST_DATA_ROW = 4;
-    private static final int PRESERVED_ROW = 12;
     private static final int AFFILIATION_COLUMN = 1;
     private static final int POSITION_COLUMN = 3;
     private static final int NAME_COLUMN = 5;
     private static final int PROFILE_COLUMN_SPAN = 2;
     private static final int TEAM_NAME_COLUMN = 1;
-    private static final int SCORE_COLUMN = 2;
-    private static final int COMMENT_COLUMN = 3;
+    private static final int COMPLETENESS_COLUMN = 2;
+    private static final int CREATIVITY_COLUMN = 3;
+    private static final int STAGE_COLUMN = 4;
+    private static final int CALCULATED_SCORE_COLUMN = 5;
+    private static final int COMMENT_COLUMN = 6;
 
     private final TeamRepository teamRepository;
     private final JudgementRepository judgementRepository;
@@ -91,7 +93,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
                 Long judgeId = judgeIds.get(index);
                 writeZipEntry(zip, "심사위원_" + judgeLabel(index) + "_개별심사표.xlsx",
                         createJudgeSheet(
-                                judgeTemplate, teams, judgements, comments, profiles.get(judgeId), judgeId, judgeLabel(index)));
+                                judgeTemplate, teams, judgements, comments, profiles.get(judgeId), judgeId));
             }
         } catch (IOException e) {
             throw new IllegalStateException("심사표 ZIP을 생성할 수 없습니다.", e);
@@ -105,8 +107,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             List<JudgementEntity> judgements,
             Map<JudgeTeamKey, JudgeCommentEntity> comments,
             JudgeProfileEntity profile,
-            Long judgeId,
-            String judgeLabel) throws IOException {
+            Long judgeId) throws IOException {
         Map<Long, JudgementEntity> scoreMap = new HashMap<>();
         judgements.stream()
                 .filter(judgement -> judgeId.equals(judgement.getUser().getId()))
@@ -120,8 +121,11 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             Row headerRow = row(sheet, HEADER_ROW);
             cell(headerRow, 0).setCellValue("심사순서");
             cell(headerRow, TEAM_NAME_COLUMN).setCellValue("팀명");
-            cell(headerRow, SCORE_COLUMN).setCellValue("심사위원 " + judgeLabel);
-            cell(headerRow, COMMENT_COLUMN).setCellValue("코멘트");
+            cell(headerRow, COMPLETENESS_COLUMN).setCellValue("완성도·표현력");
+            cell(headerRow, CREATIVITY_COLUMN).setCellValue("창의력·구성");
+            cell(headerRow, STAGE_COLUMN).setCellValue("무대매너·퍼포먼스");
+            cell(headerRow, CALCULATED_SCORE_COLUMN).setCellValue("산출 점수");
+            cell(headerRow, COMMENT_COLUMN).setCellValue("코멘트 이미지");
             sheet.setColumnWidth(COMMENT_COLUMN,
                     Math.round(COMMENT_CELL_WIDTH / Units.DEFAULT_CHARACTER_WIDTH * 256));
 
@@ -129,7 +133,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             if (drawing == null) {
                 drawing = sheet.createDrawingPatriarch();
             }
-            addProfileImages(workbook, drawing, sheet, profile);
+            addProfileImages(workbook, drawing, profile);
             for (int index = 0; index < teams.size(); index++) {
                 TeamEntity team = teams.get(index);
                 JudgementEntity judgement = scoreMap.get(team.getId());
@@ -141,13 +145,18 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
                 int completeness = judgement == null ? 0 : orZero(judgement.getCompletenessExpressionScore());
                 int creativity = judgement == null ? 0 : orZero(judgement.getCreativityCompositionScore());
                 int stage = judgement == null ? 0 : orZero(judgement.getStagePerformanceTeamworkScore());
-                cell(row, SCORE_COLUMN).setCellValue(completeness + creativity + stage);
+                cell(row, COMPLETENESS_COLUMN).setCellValue(completeness);
+                cell(row, CREATIVITY_COLUMN).setCellValue(creativity);
+                cell(row, STAGE_COLUMN).setCellValue(stage);
+                cell(row, CALCULATED_SCORE_COLUMN).setCellValue(completeness + creativity + stage);
 
                 JudgeCommentEntity comment = comments.get(new JudgeTeamKey(judgeId, team.getId()));
                 if (comment != null && hasPoints(comment.getStrokes())) {
                     addImage(
                             workbook,
                             drawing,
+                            COMMENT_COLUMN,
+                            rowIndex,
                             COMMENT_COLUMN,
                             rowIndex,
                             Math.round(sheet.getColumnWidthInPixels(COMMENT_COLUMN)),
@@ -163,49 +172,53 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
     private void addProfileImages(
             Workbook workbook,
             Drawing<?> drawing,
-            Sheet sheet,
             JudgeProfileEntity profile) throws IOException {
         if (profile == null) {
             return;
         }
-        addProfileImage(workbook, drawing, sheet, AFFILIATION_COLUMN, profile.getAffiliationStrokes());
-        addProfileImage(workbook, drawing, sheet, POSITION_COLUMN, profile.getPositionStrokes());
-        addProfileImage(workbook, drawing, sheet, NAME_COLUMN, profile.getNameStrokes());
+        addProfileImage(workbook, drawing, AFFILIATION_COLUMN, profile.getAffiliationStrokes());
+        addProfileImage(workbook, drawing, POSITION_COLUMN, profile.getPositionStrokes());
+        addProfileImage(workbook, drawing, NAME_COLUMN, profile.getNameStrokes());
     }
 
     private void addProfileImage(
             Workbook workbook,
             Drawing<?> drawing,
-            Sheet sheet,
             int column,
             JsonNode strokes) throws IOException {
         if (!hasPoints(strokes)) {
             return;
         }
-        int width = 0;
-        for (int current = column; current < column + PROFILE_COLUMN_SPAN; current++) {
-            width += Math.round(sheet.getColumnWidthInPixels(current));
-        }
-        int height = Units.pointsToPixel(row(sheet, PROFILE_ROW).getHeightInPoints());
-        addImage(workbook, drawing, column, PROFILE_ROW, width, height, renderStrokes(strokes));
+        addImage(
+                workbook,
+                drawing,
+                column,
+                PROFILE_ROW,
+                column + PROFILE_COLUMN_SPAN,
+                PROFILE_ROW + 1,
+                0,
+                0,
+                renderStrokes(strokes));
     }
 
     private void addImage(
             Workbook workbook,
             Drawing<?> drawing,
-            int column,
-            int row,
-            int width,
-            int height,
+            int startColumn,
+            int startRow,
+            int endColumn,
+            int endRow,
+            int endColumnOffset,
+            int endRowOffset,
             byte[] image) {
         int pictureIndex = workbook.addPicture(image, Workbook.PICTURE_TYPE_PNG);
         ClientAnchor anchor = workbook.getCreationHelper().createClientAnchor();
-        anchor.setCol1(column);
-        anchor.setCol2(column);
-        anchor.setRow1(row);
-        anchor.setRow2(row);
-        anchor.setDx2(Units.pixelToEMU(width));
-        anchor.setDy2(Units.pixelToEMU(height));
+        anchor.setCol1(startColumn);
+        anchor.setCol2(endColumn);
+        anchor.setRow1(startRow);
+        anchor.setRow2(endRow);
+        anchor.setDx2(Units.pixelToEMU(endColumnOffset));
+        anchor.setDy2(Units.pixelToEMU(endRowOffset));
         anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_DONT_RESIZE);
         drawing.createPicture(anchor, pictureIndex);
     }
@@ -320,8 +333,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
     }
 
     private int dataRow(int teamIndex) {
-        int row = FIRST_DATA_ROW + teamIndex;
-        return row >= PRESERVED_ROW ? row + 1 : row;
+        return FIRST_DATA_ROW + teamIndex;
     }
 
     private String judgeLabel(int index) {

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
@@ -99,14 +99,23 @@ class DownloadJudgeSheetsServiceImplTest {
             assertThat(sheet.getRow(2).getCell(0).getStringCellValue()).isEqualTo("소속/직위/이름");
             assertThat(sheet.getRow(3).getCell(0).getStringCellValue()).isEqualTo("심사순서");
             assertThat(sheet.getRow(3).getCell(1).getStringCellValue()).isEqualTo("팀명");
-            assertThat(sheet.getRow(3).getCell(2).getStringCellValue()).isEqualTo("심사위원 A");
-            assertThat(sheet.getRow(3).getCell(3).getStringCellValue()).isEqualTo("코멘트");
+            assertThat(sheet.getRow(3).getCell(2).getStringCellValue()).isEqualTo("완성도·표현력");
+            assertThat(sheet.getRow(3).getCell(3).getStringCellValue()).isEqualTo("창의력·구성");
+            assertThat(sheet.getRow(3).getCell(4).getStringCellValue()).isEqualTo("무대매너·퍼포먼스");
+            assertThat(sheet.getRow(3).getCell(5).getStringCellValue()).isEqualTo("산출 점수");
+            assertThat(sheet.getRow(3).getCell(6).getStringCellValue()).isEqualTo("코멘트 이미지");
             assertThat(sheet.getRow(4).getCell(0).getNumericCellValue()).isEqualTo(1);
             assertThat(sheet.getRow(4).getCell(1).getStringCellValue()).isEqualTo("팀1");
-            assertThat(sheet.getRow(4).getCell(2).getNumericCellValue()).isEqualTo(60);
+            assertThat(sheet.getRow(4).getCell(2).getNumericCellValue()).isEqualTo(20);
+            assertThat(sheet.getRow(4).getCell(3).getNumericCellValue()).isEqualTo(15);
+            assertThat(sheet.getRow(4).getCell(4).getNumericCellValue()).isEqualTo(25);
+            assertThat(sheet.getRow(4).getCell(5).getNumericCellValue()).isEqualTo(60);
             assertThat(sheet.getRow(5).getCell(0).getNumericCellValue()).isEqualTo(2);
             assertThat(sheet.getRow(5).getCell(1).getStringCellValue()).isEqualTo("팀2");
             assertThat(sheet.getRow(5).getCell(2).getNumericCellValue()).isZero();
+            assertThat(sheet.getRow(5).getCell(3).getNumericCellValue()).isZero();
+            assertThat(sheet.getRow(5).getCell(4).getNumericCellValue()).isZero();
+            assertThat(sheet.getRow(5).getCell(5).getNumericCellValue()).isZero();
             assertThat(workbook.getAllPictures()).hasSize(1);
             assertThat(renderedImageHasColor(workbook.getAllPictures().getFirst(), Color.RED)).isTrue();
             assertThat(renderedImageHasColor(workbook.getAllPictures().getFirst(), new Color(0x12, 0x12, 0x12))).isTrue();
@@ -118,7 +127,7 @@ class DownloadJudgeSheetsServiceImplTest {
     }
 
     @Test
-    void 코멘트를_1000x500_PNG로_렌더링하고_D셀_100x50_안에_고정한다() throws Exception {
+    void 코멘트를_1000x500_PNG로_렌더링하고_G셀_100x50_안에_고정한다() throws Exception {
         List<TeamEntity> teams = java.util.stream.IntStream.rangeClosed(1, 6)
                 .mapToObj(index -> team(index, index))
                 .toList();
@@ -186,7 +195,7 @@ class DownloadJudgeSheetsServiceImplTest {
         given(judgeProfileRepository.findAllWithUser()).willReturn(List.of(
                 profile(judgeA,
                         stroke("#ff0000", 0.1, 0.5, 0.9, 0.5),
-                        emptyStroke(),
+                        stroke("#00ff00", 0.1, 0.5, 0.9, 0.5),
                         stroke("#121212", 0.5, 0.1, 0.5, 0.9)),
                 profile(judgeB,
                         stroke("#0000ff", 0.1, 0.5, 0.9, 0.5),
@@ -202,11 +211,15 @@ class DownloadJudgeSheetsServiceImplTest {
             var pictures = sheet.getDrawingPatriarch().getShapes().stream()
                     .map(XSSFPicture.class::cast)
                     .toList();
-            assertThat(pictures).hasSize(2);
+            assertThat(pictures).hasSize(3);
             assertProfilePicture(sheet, pictures.get(0), 1);
-            assertProfilePicture(sheet, pictures.get(1), 5);
+            assertProfilePicture(sheet, pictures.get(1), 3);
+            assertProfilePicture(sheet, pictures.get(2), 5);
             assertThat(renderedImageHasColor(pictures.get(0).getPictureData(), Color.RED)).isTrue();
-            assertThat(renderedImageHasColor(pictures.get(1).getPictureData(), new Color(0x12, 0x12, 0x12))).isTrue();
+            assertThat(renderedImageHasColor(pictures.get(1).getPictureData(), Color.GREEN)).isTrue();
+            assertThat(renderedImageHasColor(pictures.get(2).getPictureData(), new Color(0x12, 0x12, 0x12))).isTrue();
+            assertThat(sheet.getDrawingPatriarch().getCTDrawing().getTwoCellAnchorList())
+                    .allMatch(anchor -> anchor.getEditAs() == STEditAs.ONE_CELL);
         }
         try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_B_개별심사표.xlsx")))) {
             var pictures = workbook.getSheet("개별 심사표").getDrawingPatriarch().getShapes();
@@ -217,8 +230,8 @@ class DownloadJudgeSheetsServiceImplTest {
     }
 
     @Test
-    void 열세번째_행은_보존하고_아홉번째_팀은_열네번째_행부터_작성한다() throws Exception {
-        List<TeamEntity> teams = java.util.stream.IntStream.rangeClosed(1, 9)
+    void 팀을_중간_빈_행_없이_연속으로_작성한다() throws Exception {
+        List<TeamEntity> teams = java.util.stream.IntStream.rangeClosed(1, 10)
                 .mapToObj(index -> team(index, index))
                 .toList();
         UserEntity judge = user(10L);
@@ -231,8 +244,9 @@ class DownloadJudgeSheetsServiceImplTest {
 
         try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(files.get("심사위원_A_개별심사표.xlsx")))) {
             var sheet = workbook.getSheet("개별 심사표");
-            assertThat(sheet.getRow(12).getCell(0).getStringCellValue()).isEqualTo("13행 보존");
-            assertThat(sheet.getRow(13).getCell(0).getNumericCellValue()).isEqualTo(9);
+            assertThat(sheet.getRow(11).getCell(0).getNumericCellValue()).isEqualTo(8);
+            assertThat(sheet.getRow(12).getCell(0).getNumericCellValue()).isEqualTo(9);
+            assertThat(sheet.getRow(13).getCell(0).getNumericCellValue()).isEqualTo(10);
         }
     }
 
@@ -292,14 +306,14 @@ class DownloadJudgeSheetsServiceImplTest {
 
     private void assertCommentPicture(XSSFWorkbook workbook, int rowIndex) throws IOException {
         var sheet = workbook.getSheet("개별 심사표");
-        assertThat(sheet.getColumnWidthInPixels(3)).isBetween(99.9f, 100.1f);
+        assertThat(sheet.getColumnWidthInPixels(6)).isBetween(99.9f, 100.1f);
         assertThat(sheet.getRow(rowIndex).getHeightInPoints()).isEqualTo(37.5f);
-        assertThat(sheet.getMergedRegions()).noneMatch(region -> region.isInRange(rowIndex, 3));
+        assertThat(sheet.getMergedRegions()).noneMatch(region -> region.isInRange(rowIndex, 6));
 
         XSSFPicture picture = (XSSFPicture) sheet.getDrawingPatriarch().getShapes().getFirst();
         ClientAnchor anchor = picture.getClientAnchor();
-        assertThat(anchor.getCol1()).isEqualTo((short) 3);
-        assertThat(anchor.getCol2()).isEqualTo((short) 3);
+        assertThat(anchor.getCol1()).isEqualTo((short) 6);
+        assertThat(anchor.getCol2()).isEqualTo((short) 6);
         assertThat(anchor.getRow1()).isEqualTo(rowIndex);
         assertThat(anchor.getRow2()).isEqualTo(rowIndex);
         assertThat(anchor.getDx1()).isZero();
@@ -319,17 +333,14 @@ class DownloadJudgeSheetsServiceImplTest {
             XSSFPicture picture,
             int column) throws IOException {
         ClientAnchor anchor = picture.getClientAnchor();
-        int width = Math.round(sheet.getColumnWidthInPixels(column))
-                + Math.round(sheet.getColumnWidthInPixels(column + 1));
-        int height = Units.pointsToPixel(sheet.getRow(2).getHeightInPoints());
         assertThat(anchor.getCol1()).isEqualTo((short) column);
-        assertThat(anchor.getCol2()).isEqualTo((short) column);
+        assertThat(anchor.getCol2()).isEqualTo((short) (column + 2));
         assertThat(anchor.getRow1()).isEqualTo(2);
-        assertThat(anchor.getRow2()).isEqualTo(2);
+        assertThat(anchor.getRow2()).isEqualTo(3);
         assertThat(anchor.getDx1()).isZero();
         assertThat(anchor.getDy1()).isZero();
-        assertThat(anchor.getDx2()).isEqualTo(Units.pixelToEMU(width));
-        assertThat(anchor.getDy2()).isEqualTo(Units.pixelToEMU(height));
+        assertThat(anchor.getDx2()).isZero();
+        assertThat(anchor.getDy2()).isZero();
 
         BufferedImage image = ImageIO.read(new ByteArrayInputStream(picture.getPictureData().getData()));
         assertThat(image.getWidth()).isEqualTo(1000);


### PR DESCRIPTION
## ✨ 작업 내용
> 개별 심사표에서 누락되던 심사위원 필기 프로필을 올바른 병합 셀에 표시하고, 세부 점수 열과 팀 데이터 행 배치를 요구 형식에 맞게 수정했습니다.

- 개별 심사표 3행의 소속·직위·이름 이미지를 각각 `B3:C3`, `D3:E3`, `F3:G3` 병합 범위에 고정했습니다.
- 4행을 `심사순서 / 팀명 / 완성도·표현력 / 창의력·구성 / 무대매너·퍼포먼스 / 산출 점수 / 코멘트 이미지` 순서로 구성했습니다.
- 코멘트 이미지를 G열 100×50px 영역으로 옮겼습니다.
- 기존 13행 건너뛰기 로직을 제거해 팀 데이터를 빈 행 없이 연속 배치했습니다.

---

## 🔍 리뷰 시 참고사항
- 프로필 이미지는 병합 셀보다 큰 픽셀 오프셋을 단일 셀 앵커에 기록해 Excel 호환성이 깨지고 있었습니다. 병합 범위의 실제 시작·종료 경계를 사용하는 앵커로 수정했습니다.
- `PRESERVED_ROW` 계산이 13행을 의도적으로 건너뛰고 있어 해당 로직을 제거했습니다.
- `./gradlew test --tests team.startup.gwangjutalentfestival.domain.excel.service.DownloadJudgeSheetsServiceImplTest`는 통과했습니다.
- 전체 301개 테스트 중 298개가 통과했고, 로컬 MariaDB 미실행으로 컨텍스트·동시성 테스트 3개가 실패했습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #205
