### PR TITLE
개별 심사표 필기 프로필 렌더링 및 헤더 수정

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
@@ -124,8 +124,8 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             cell(headerRow, COMPLETENESS_COLUMN).setCellValue("완성도·표현력");
             cell(headerRow, CREATIVITY_COLUMN).setCellValue("창의력·구성");
             cell(headerRow, STAGE_COLUMN).setCellValue("무대매너·퍼포먼스");
-            cell(headerRow, CALCULATED_SCORE_COLUMN).setCellValue("산출 점수");
-            cell(headerRow, COMMENT_COLUMN).setCellValue("코멘트 이미지");
+            cell(headerRow, CALCULATED_SCORE_COLUMN).setCellValue("총합 점수");
+            cell(headerRow, COMMENT_COLUMN).setCellValue("심사 의견");
             sheet.setColumnWidth(COMMENT_COLUMN,
                     Math.round(COMMENT_CELL_WIDTH / Units.DEFAULT_CHARACTER_WIDTH * 256));
 
@@ -237,7 +237,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             graphics.setStroke(new BasicStroke(2f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
             graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
             for (JsonNode stroke : strokes) {
-                JsonNode points = stroke.path("points");
+                JsonNode points = strokePoints(stroke);
                 if (!points.isArray() || points.isEmpty()) {
                     continue;
                 }
@@ -276,13 +276,17 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             return false;
         }
         for (JsonNode stroke : strokes) {
-            for (JsonNode point : stroke.path("points")) {
+            for (JsonNode point : strokePoints(stroke)) {
                 if (isPoint(point)) {
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    private JsonNode strokePoints(JsonNode stroke) {
+        return stroke.isArray() ? stroke : stroke.path("points");
     }
 
     private boolean isPoint(JsonNode point) {

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
@@ -102,8 +102,8 @@ class DownloadJudgeSheetsServiceImplTest {
             assertThat(sheet.getRow(3).getCell(2).getStringCellValue()).isEqualTo("완성도·표현력");
             assertThat(sheet.getRow(3).getCell(3).getStringCellValue()).isEqualTo("창의력·구성");
             assertThat(sheet.getRow(3).getCell(4).getStringCellValue()).isEqualTo("무대매너·퍼포먼스");
-            assertThat(sheet.getRow(3).getCell(5).getStringCellValue()).isEqualTo("산출 점수");
-            assertThat(sheet.getRow(3).getCell(6).getStringCellValue()).isEqualTo("코멘트 이미지");
+            assertThat(sheet.getRow(3).getCell(5).getStringCellValue()).isEqualTo("총합 점수");
+            assertThat(sheet.getRow(3).getCell(6).getStringCellValue()).isEqualTo("심사 의견");
             assertThat(sheet.getRow(4).getCell(0).getNumericCellValue()).isEqualTo(1);
             assertThat(sheet.getRow(4).getCell(1).getStringCellValue()).isEqualTo("팀1");
             assertThat(sheet.getRow(4).getCell(2).getNumericCellValue()).isEqualTo(20);
@@ -194,12 +194,12 @@ class DownloadJudgeSheetsServiceImplTest {
         given(judgeCommentRepository.findAllWithUserAndTeam()).willReturn(List.of());
         given(judgeProfileRepository.findAllWithUser()).willReturn(List.of(
                 profile(judgeA,
-                        stroke("#ff0000", 0.1, 0.5, 0.9, 0.5),
-                        stroke("#00ff00", 0.1, 0.5, 0.9, 0.5),
-                        stroke("#121212", 0.5, 0.1, 0.5, 0.9)),
+                        path(0.1, 0.5, 0.9, 0.5),
+                        path(0.1, 0.5, 0.9, 0.5),
+                        path(0.5, 0.1, 0.5, 0.9)),
                 profile(judgeB,
-                        stroke("#0000ff", 0.1, 0.5, 0.9, 0.5),
-                        objectMapper.createArrayNode(),
+                        path(0.1, 0.5, 0.9, 0.5),
+                        emptyPath(),
                         objectMapper.createArrayNode())
         ));
         given(userRepository.findAllByRoleOrderByIdAsc(Role.JUDGE)).willReturn(List.of(judgeA, judgeB));
@@ -215,9 +215,9 @@ class DownloadJudgeSheetsServiceImplTest {
             assertProfilePicture(sheet, pictures.get(0), 1);
             assertProfilePicture(sheet, pictures.get(1), 3);
             assertProfilePicture(sheet, pictures.get(2), 5);
-            assertThat(renderedImageHasColor(pictures.get(0).getPictureData(), Color.RED)).isTrue();
-            assertThat(renderedImageHasColor(pictures.get(1).getPictureData(), Color.GREEN)).isTrue();
-            assertThat(renderedImageHasColor(pictures.get(2).getPictureData(), new Color(0x12, 0x12, 0x12))).isTrue();
+            for (XSSFPicture picture : pictures) {
+                assertThat(renderedImageHasColor(picture.getPictureData(), Color.BLACK)).isTrue();
+            }
             assertThat(sheet.getDrawingPatriarch().getCTDrawing().getTwoCellAnchorList())
                     .allMatch(anchor -> anchor.getEditAs() == STEditAs.ONE_CELL);
         }
@@ -225,7 +225,7 @@ class DownloadJudgeSheetsServiceImplTest {
             var pictures = workbook.getSheet("개별 심사표").getDrawingPatriarch().getShapes();
             assertThat(pictures).hasSize(1);
             assertThat(renderedImageHasColor(
-                    ((XSSFPicture) pictures.getFirst()).getPictureData(), Color.BLUE)).isTrue();
+                    ((XSSFPicture) pictures.getFirst()).getPictureData(), Color.BLACK)).isTrue();
         }
     }
 
@@ -422,9 +422,23 @@ class DownloadJudgeSheetsServiceImplTest {
         return strokes;
     }
 
+    private ArrayNode path(double x1, double y1, double x2, double y2) {
+        ArrayNode strokes = objectMapper.createArrayNode();
+        var points = strokes.addArray();
+        points.addObject().put("x", x1).put("y", y1);
+        points.addObject().put("x", x2).put("y", y2);
+        return strokes;
+    }
+
     private ArrayNode emptyStroke() {
         ArrayNode strokes = objectMapper.createArrayNode();
         strokes.addObject().put("color", "#000000").putArray("points");
+        return strokes;
+    }
+
+    private ArrayNode emptyPath() {
+        ArrayNode strokes = objectMapper.createArrayNode();
+        strokes.addArray();
         return strokes;
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
> 실제 DB의 중첩 배열 필기 프로필을 개별 심사표에 렌더링하고, 합계·의견 헤더 명칭을 수정했습니다.

- 코멘트 객체 형식과 프로필 중첩 배열 형식을 공통 렌더러에서 모두 지원합니다.
- 프로필에 색상 정보가 없으면 검은색으로 렌더링합니다.
- `산출 점수`를 `총합 점수`로 변경했습니다.
- `코멘트 이미지`를 `심사 의견`으로 변경했습니다.

---

## 🔍 리뷰 시 참고사항
- 운영 DB의 프로필 데이터는 `[[{ "x": ..., "y": ... }], ...]` 형태지만 기존 렌더러는 각 stroke의 `points` 속성만 읽어 모든 프로필을 빈 값으로 판단했습니다.
- 공통 `strokePoints` 판정으로 기존 코멘트의 `{ "points": [...] }` 형식과 프로필의 중첩 배열 형식을 함께 처리합니다.
- 대상 Excel 테스트는 통과했고, 실제 생성 파일에서 프로필 PNG 3개가 각각 1000×500이며 병합 셀 앵커가 올바른지 확인했습니다.
- 전체 301개 테스트 중 298개가 통과했고, 로컬 MariaDB 미실행으로 컨텍스트·동시성 테스트 3개가 실패했습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #205
