### PR TITLE
RoleBasedApiAuthorizationTest에서 DiscordWebhookClient 미스캔으로 인한 CI 빌드 실패 수정

### DIFF
--- a/src/test/java/team/startup/gwangjutalentfestival/global/security/RoleBasedApiAuthorizationTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/security/RoleBasedApiAuthorizationTest.java
@@ -34,6 +34,7 @@ import team.startup.gwangjutalentfestival.domain.judge.service.GetJudgementServi
 import team.startup.gwangjutalentfestival.domain.judge.service.JudgeProfileService;
 import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgeCommentService;
 import team.startup.gwangjutalentfestival.domain.judge.service.SaveJudgementScoreService;
+import team.startup.gwangjutalentfestival.domain.monitoring.client.DiscordWebhookClient;
 import team.startup.gwangjutalentfestival.domain.monitoring.presentation.controller.MonitoringController;
 import team.startup.gwangjutalentfestival.domain.monitoring.service.CreateIncidentFeedbackService;
 import team.startup.gwangjutalentfestival.domain.monitoring.service.ExportDatasetService;
@@ -152,6 +153,8 @@ class RoleBasedApiAuthorizationTest {
     private GetAnomalyEventSummaryService getAnomalyEventSummaryService;
     @MockBean
     private ExportDatasetService exportDatasetService;
+    @MockBean
+    private DiscordWebhookClient discordWebhookClient;
 
     @MockBean
     private DownloadJudgingSummaryExcelService downloadJudgingSummaryExcelService;


### PR DESCRIPTION
## Summary
- `add/discord-request-alert` PR에서 추가된 `RequestAlertFilter`가 `@WebMvcTest` 슬라이스 테스트에서 `Filter` 타입으로 자동 스캔되지만, 해당 필터가 의존하는 `DiscordWebhookClient`는 슬라이스 컨텍스트에 포함되지 않아 `NoSuchBeanDefinitionException`이 발생해 CI 빌드(`RoleBasedApiAuthorizationTest`)가 실패하고 있었습니다.
- `RoleBasedApiAuthorizationTest`에 `DiscordWebhookClient`를 `@MockBean`으로 추가해 해결했습니다.

## Test plan
- [x] `./gradlew test --tests "team.startup.gwangjutalentfestival.global.security.RoleBasedApiAuthorizationTest"` 통과 확인
- [x] 전체 `./gradlew test` 실행 시 해당 테스트 정상 통과 확인 (남은 실패 2건은 로컬 MySQL 인증 방식 차이로 인한 환경 문제이며, CI에서 사용하는 MariaDB 컨테이너와는 무관함)

