### PR TITLE
팀 전체 조회에 분야 및 신청자명 필드 추가

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/entity/TeamEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/entity/TeamEntity.java
@@ -37,6 +37,9 @@ public class TeamEntity {
     @Enumerated(EnumType.STRING)
     private TeamGenre teamGenre;
 
+    @Column(name = "applicant_name")
+    private String applicantName;
+
     @Column(name = "perform_order")
     private Integer performOrder;
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/response/GetTeamResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/presentation/data/response/GetTeamResponse.java
@@ -1,20 +1,25 @@
 package team.startup.gwangjutalentfestival.domain.team.presentation.data.response;
 
+import team.startup.gwangjutalentfestival.domain.team.enums.TeamGenre;
 import team.startup.gwangjutalentfestival.domain.team.enums.TeamStatus;
 
 /**
  * 팀 정보 조회 응답 DTO.
  *
- * @param teamId       팀 ID
- * @param teamName     팀 이름
- * @param school       소속 학교
- * @param performOrder 공연 순서
- * @param status       현재 공연 상태
+ * @param teamId        팀 ID
+ * @param teamName      팀 이름
+ * @param school        소속 학교
+ * @param teamGenre     공연 분야
+ * @param applicantName 신청자명
+ * @param performOrder  공연 순서
+ * @param status        현재 공연 상태
  */
 public record GetTeamResponse(
         Long teamId,
         String teamName,
         String school,
+        TeamGenre teamGenre,
+        String applicantName,
         Integer performOrder,
         TeamStatus status
 ) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetAllTeamServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/team/service/impl/GetAllTeamServiceImpl.java
@@ -36,6 +36,8 @@ public class GetAllTeamServiceImpl implements GetAllTeamService {
                         t.getId(),
                         t.getTeamName(),
                         t.getSchool(),
+                        t.getTeamGenre(),
+                        t.getApplicantName(),
                         t.getPerformOrder(),
                         t.getTeamStatus()
                 )).toList();


### PR DESCRIPTION
## Summary
- 팀 전체 조회(`GET /team`) 응답에 공연 분야(`teamGenre`)와 신청자명(`applicantName`) 필드를 추가했습니다.
- 기존 스키마에 신청자명에 대응하는 필드가 없어 `TeamEntity`에 `applicant_name` 컬럼을 새로 추가했습니다 (nullable, ddl-auto: update로 자동 반영).

## Test plan
- [x] `./gradlew compileJava compileTestJava` 컴파일 확인
- [x] team 도메인 관련 단위 테스트 통과 확인 (DB 연결이 필요한 통합 테스트는 로컬 환경 제약으로 사전에도 실패하던 항목이라 이번 변경과 무관함)