### PR TITLE
역할별 좌석 예매 정책 적용

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/entity/SeatBanEntity.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/entity/SeatBanEntity.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
 /**
  * 관리자가 차단한 좌석 정보를 저장하는 엔티티.
@@ -33,8 +32,4 @@ public class SeatBanEntity {
 
     @Column(name = "seat_number", nullable = false)
     private Integer seatNumber;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false)
-    private Role role;
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/event/SeatChangeEvent.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/event/SeatChangeEvent.java
@@ -4,7 +4,7 @@ package team.startup.gwangjutalentfestival.domain.seat.event;
  * 좌석 상태 변경 시 발행되는 이벤트.
  * 예약 또는 차단 처리 후 SSE로 클라이언트에 변경 사항을 전달하는 데 사용된다.
  *
- * @param seatSection  변경된 좌석의 구역 (A~J)
+ * @param seatSection  변경된 좌석의 구역 (A~F)
  * @param seatNumber   변경된 좌석 번호
  * @param isAvailable  좌석 예약 가능 여부 (true: 예약 가능, false: 예약 불가)
  */

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/InvalidSeatSectionException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/InvalidSeatSectionException.java
@@ -4,7 +4,7 @@ import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
 /**
- * 유효하지 않은 좌석 구역(A~J 범위 외)이 입력되었을 때 발생하는 예외.
+ * 유효하지 않은 좌석 구역(A~F 범위 외)이 입력되었을 때 발생하는 예외.
  */
 public class InvalidSeatSectionException extends GlobalException {
     public InvalidSeatSectionException() {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatBannedException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatBannedException.java
@@ -4,7 +4,7 @@ import team.startup.gwangjutalentfestival.global.exception.ErrorCode;
 import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
 /**
- * 관리자가 차단한 좌석을 예약하려 할 때 발생하는 예외.
+ * 관리자가 차단했거나 현재 역할에 허용되지 않은 좌석을 예약할 때 발생하는 예외.
  */
 public class SeatBannedException extends GlobalException {
     public SeatBannedException() {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatReservationLimitExceededException.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/exception/SeatReservationLimitExceededException.java
@@ -5,7 +5,7 @@ import team.startup.gwangjutalentfestival.global.exception.GlobalException;
 
 /**
  * 사용자가 예약 가능한 좌석 수 제한을 초과했을 때 발생하는 예외.
- * 일반 사용자는 1석, 공연자는 3석까지 예약 가능하다.
+ * 일반 사용자는 1석, 공연자는 2석까지 예약 가능하다.
  */
 public class SeatReservationLimitExceededException extends GlobalException {
     public SeatReservationLimitExceededException() {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatController.java
@@ -100,7 +100,7 @@ public class SeatController {
     /**
      * 특정 구역의 좌석 예약 가능 여부 목록을 조회한다.
      *
-     * @param section 조회할 좌석 구역 (A~J)
+     * @param section 조회할 좌석 구역 (A~F)
      * @return 해당 구역의 좌석별 예약 가능 여부 목록
      */
     @Operation(summary = "구역별 좌석 현황 조회", description = "특정 구역의 좌석 예약 가능 여부 목록을 조회합니다.")

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/BanSeatRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/BanSeatRequest.java
@@ -3,27 +3,23 @@ package team.startup.gwangjutalentfestival.domain.seat.presentation.data.request
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
-import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 
 /**
  * 좌석 차단 요청 DTO.
  *
- * @param seatSection 차단할 좌석 구역 (A, B, C, D, E, F, W 중 하나)
+ * @param seatSection 차단할 좌석 구역 (A, B, C, D, E, F 중 하나)
  * @param seatNumber  차단할 좌석 번호 (1~132)
- * @param role        차단을 적용할 사용자 역할
  */
 public record BanSeatRequest(
         @Pattern(
-                regexp = "^[ABCDEFW]$",
-                message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
+                regexp = "^[ABCDEF]$",
+                message = "좌석 섹션은 A, B, C, D, E, F 중 하나여야 합니다."
         )
         String seatSection,
 
         @Min(value = 1, message = "좌석 번호는 최소 1번부터 존재합니다.")
         @Max(value = SeatUtil.MAX_SEAT_NUMBER, message = "좌석 번호는 최대 132번까지 존재합니다.")
-        Integer seatNumber,
-
-        Role role
+        Integer seatNumber
 ) {
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/CancelSeatBanRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/CancelSeatBanRequest.java
@@ -8,13 +8,13 @@ import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 /**
  * 좌석 차단 취소 요청 DTO.
  *
- * @param seatSection 차단을 해제할 좌석 구역 (A, B, C, D, E, F, W 중 하나)
+ * @param seatSection 차단을 해제할 좌석 구역 (A, B, C, D, E, F 중 하나)
  * @param seatNumber  차단을 해제할 좌석 번호 (1~132)
  */
 public record CancelSeatBanRequest(
         @Pattern(
-                regexp = "^[ABCDEFW]$",
-                message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
+                regexp = "^[ABCDEF]$",
+                message = "좌석 섹션은 A, B, C, D, E, F 중 하나여야 합니다."
         )
         String seatSection,
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/ReservationSeatRequest.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/request/ReservationSeatRequest.java
@@ -8,13 +8,13 @@ import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 /**
  * 좌석 예약 요청 DTO.
  *
- * @param seatSection 예약할 좌석 구역 (A, B, C, D, E, F, W 중 하나)
+ * @param seatSection 예약할 좌석 구역 (A, B, C, D, E, F 중 하나)
  * @param seatNumber  예약할 좌석 번호 (1~132)
  */
 public record ReservationSeatRequest(
         @Pattern(
-                regexp = "^[ABCDEFW]$",
-                message = "좌석 섹션은 A, B, C, D, E, F, W 중 하나여야 합니다."
+                regexp = "^[ABCDEF]$",
+                message = "좌석 섹션은 A, B, C, D, E, F 중 하나여야 합니다."
         )
         String seatSection,
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetAllSeatsResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetAllSeatsResponse.java
@@ -5,7 +5,7 @@ import java.util.Map;
 /**
  * 전체 구역 좌석 현황 응답 DTO.
  *
- * @param sections 구역 코드(A~J)를 키로, 해당 구역의 좌석 목록을 값으로 갖는 맵
+ * @param sections 구역 코드(A~F)를 키로, 해당 구역의 좌석 목록을 값으로 갖는 맵
  */
 public record GetAllSeatsResponse(
     Map<String, GetSeatsBySectionResponse> sections

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetSeatResponse.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/GetSeatResponse.java
@@ -3,7 +3,7 @@ package team.startup.gwangjutalentfestival.domain.seat.presentation.data.respons
 /**
  * 단일 좌석 정보 응답 DTO.
  *
- * @param seatSection 좌석 구역 (A~J)
+ * @param seatSection 좌석 구역 (A~F, 기존 예약은 W 가능)
  * @param seatNumber  좌석 번호
  */
 public record GetSeatResponse(

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/SectionSeatNumber.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/data/response/SectionSeatNumber.java
@@ -4,7 +4,7 @@ package team.startup.gwangjutalentfestival.domain.seat.presentation.data.respons
  * 구역과 좌석 번호를 묶어 전달하는 내부 DTO.
  * QueryDSL 프로젝션 결과를 담는 데 사용된다.
  *
- * @param section    좌석 구역 (A~J)
+ * @param section    좌석 구역 (A~F)
  * @param seatNumber 좌석 번호
  */
 public record SectionSeatNumber(

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/SeatBanCustomRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/SeatBanCustomRepository.java
@@ -1,8 +1,6 @@
 package team.startup.gwangjutalentfestival.domain.seat.repository.custom;
 
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.SectionSeatNumber;
-import team.startup.gwangjutalentfestival.domain.user.enums.Role;
-
 import java.util.List;
 import java.util.Set;
 
@@ -12,19 +10,17 @@ import java.util.Set;
 public interface SeatBanCustomRepository {
 
     /**
-     * 특정 역할에 적용된 모든 차단 좌석의 구역과 번호 목록을 조회한다.
+     * 모든 차단 좌석의 구역과 번호 목록을 조회한다.
      *
-     * @param role 조회할 사용자 역할
      * @return 차단된 좌석의 구역·번호 목록
      */
-    List<SectionSeatNumber> findSeatNumbersByRole(Role role);
+    List<SectionSeatNumber> findAllSeatNumbers();
 
     /**
-     * 특정 구역에서 특정 역할에 적용된 차단 좌석 번호 집합을 조회한다.
+     * 특정 구역의 차단 좌석 번호 집합을 조회한다.
      *
      * @param seatSection 좌석 구역
-     * @param role        사용자 역할
      * @return 차단된 좌석 번호 집합
      */
-    Set<Integer> findSeatNumbersBySeatSectionAndRole(String seatSection, Role role);
+    Set<Integer> findSeatNumbersBySeatSection(String seatSection);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/impl/SeatBanCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/custom/impl/SeatBanCustomRepositoryImpl.java
@@ -7,8 +7,6 @@ import org.springframework.stereotype.Repository;
 import team.startup.gwangjutalentfestival.domain.seat.entity.QSeatBanEntity;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.SectionSeatNumber;
 import team.startup.gwangjutalentfestival.domain.seat.repository.custom.SeatBanCustomRepository;
-import team.startup.gwangjutalentfestival.domain.user.enums.Role;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,7 +26,7 @@ public class SeatBanCustomRepositoryImpl implements SeatBanCustomRepository {
      * {@inheritDoc}
      */
     @Override
-    public List<SectionSeatNumber> findSeatNumbersByRole(Role role) {
+    public List<SectionSeatNumber> findAllSeatNumbers() {
         return queryFactory
                 .select(Projections.constructor(
                         SectionSeatNumber.class,
@@ -36,7 +34,6 @@ public class SeatBanCustomRepositoryImpl implements SeatBanCustomRepository {
                         seatBan.seatNumber
                 ))
                 .from(seatBan)
-                .where(seatBan.role.eq(role))
                 .fetch();
     }
 
@@ -44,11 +41,11 @@ public class SeatBanCustomRepositoryImpl implements SeatBanCustomRepository {
      * {@inheritDoc}
      */
     @Override
-    public Set<Integer> findSeatNumbersBySeatSectionAndRole(String seatSection, Role role) {
+    public Set<Integer> findSeatNumbersBySeatSection(String seatSection) {
         return new HashSet<>(queryFactory
                 .select(seatBan.seatNumber)
                 .from(seatBan)
-                .where(seatBan.seatSection.eq(seatSection).and(seatBan.role.eq(role)))
+                .where(seatBan.seatSection.eq(seatSection))
                 .fetch());
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetSeatsBySectionService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/GetSeatsBySectionService.java
@@ -10,7 +10,7 @@ public interface GetSeatsBySectionService {
     /**
      * 현재 사용자 역할에 맞는 특정 구역의 좌석 가용 여부 목록을 반환한다.
      *
-     * @param section 조회할 좌석 구역 (A~J)
+     * @param section 조회할 좌석 구역 (A~F)
      * @return 해당 구역의 좌석별 예약 가능 여부 목록
      */
     GetSeatsBySectionResponse execute(String section);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.admin.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -11,6 +13,7 @@ import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyBanne
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.BanSeatRequest;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.admin.BanSeatService;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 
 /**
  * {@link BanSeatService}의 구현체.
@@ -26,11 +29,15 @@ public class BanSeatServiceImpl implements BanSeatService {
     /**
      * 요청한 좌석을 차단 처리하고 SSE 이벤트를 발행한다.
      *
-     * @param request 차단할 좌석의 구역, 번호, 적용 역할 정보
+     * @param request 차단할 좌석의 구역과 번호 정보
      * @throws team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyBannedException 이미 차단된 좌석일 때
      */
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheConfig.SEATS_ALL, allEntries = true),
+            @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
+    })
     public void execute(BanSeatRequest request) {
         if (seatBanRepository
                 .existsBySeatSectionAndSeatNumber(request.seatSection(), request.seatNumber())) {
@@ -40,7 +47,6 @@ public class BanSeatServiceImpl implements BanSeatService {
         SeatBanEntity seatBan = SeatBanEntity.builder()
                 .seatSection(request.seatSection())
                 .seatNumber(request.seatNumber())
-                .role(request.role())
                 .build();
 
         try {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/CancelSeatBanServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/CancelSeatBanServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.domain.seat.service.admin.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +12,7 @@ import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBanNotFoundE
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.CancelSeatBanRequest;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.admin.CancelSeatBanService;
+import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 
 /**
  * {@link CancelSeatBanService}의 구현체.
@@ -30,6 +33,10 @@ public class CancelSeatBanServiceImpl implements CancelSeatBanService {
      */
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheConfig.SEATS_ALL, allEntries = true),
+            @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
+    })
     public void execute(CancelSeatBanRequest request) {
         SeatBanEntity seatBan = seatBanRepository
                 .findBySeatSectionAndSeatNumber(request.seatSection(), request.seatNumber())

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetAllSeatsServiceImpl.java
@@ -32,7 +32,7 @@ public class GetAllSeatsServiceImpl implements GetAllSeatsService {
     public GetAllSeatsResponse execute() {
         Role role = UserUtil.getCurrentUserRole();
 
-        List<SectionSeatNumber> seatBans = seatBanCustomRepository.findSeatNumbersByRole(role);
+        List<SectionSeatNumber> seatBans = seatBanCustomRepository.findAllSeatNumbers();
         List<SectionSeatNumber> seatReservations = seatReservationCustomRepository.findAllSeatNumbers();
 
         Map<String, Set<Integer>> seatBansMap = seatBans.stream()
@@ -51,7 +51,7 @@ public class GetAllSeatsServiceImpl implements GetAllSeatsService {
         for (String section : seatUtil.getSections()) {
             Set<Integer> bans = seatBansMap.getOrDefault(section, Set.of());
             Set<Integer> reservations = seatReservationMap.getOrDefault(section, Set.of());
-            responseMap.put(section, seatUtil.buildSeatAvailability(section, bans, reservations));
+            responseMap.put(section, seatUtil.buildSeatAvailability(section, bans, reservations, role));
         }
 
         return new GetAllSeatsResponse(responseMap);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImpl.java
@@ -30,8 +30,8 @@ public class GetSeatsBySectionServiceImpl implements GetSeatsBySectionService {
         Role role = UserUtil.getCurrentUserRole();
 
         Set<Integer> reservedSeatNumbers = seatReservationCustomRepository.findSeatNumbersBySeatSection(section);
-        Set<Integer> bannedSeatNumbers = seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(section, role);
+        Set<Integer> bannedSeatNumbers = seatBanCustomRepository.findSeatNumbersBySeatSection(section);
 
-        return seatUtil.buildSeatAvailability(section, bannedSeatNumbers, reservedSeatNumbers);
+        return seatUtil.buildSeatAvailability(section, bannedSeatNumbers, reservedSeatNumbers, role);
     }
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -45,6 +45,7 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
                     Integer seatNumber = request.seatNumber();
 
                     seatReservationValidator.validateSeatRange(seatNumber, seatUtil.getMaxSeats(seatSection));
+                    seatReservationValidator.validateSeatAccess(seatSection, seatNumber);
                     seatReservationValidator.validateReservationLimit();
                     seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
 

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidator.java
@@ -9,6 +9,7 @@ import team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationL
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
+import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
 
 import static team.startup.gwangjutalentfestival.domain.user.enums.Role.PERFORMER;
@@ -20,8 +21,9 @@ public class SeatReservationValidator {
     private final SeatReservationRepository seatReservationRepository;
     private final SeatBanRepository seatBanRepository;
     private final UserRepository userRepository;
+    private final SeatUtil seatUtil;
 
-    private static final int PERFORMER_SEAT_LIMIT = 3;
+    private static final int PERFORMER_SEAT_LIMIT = 2;
     private static final int DEFAULT_SEAT_LIMIT = 1;
 
     public void validateSeatRange(Integer seatNumber, Integer maxSeats) {
@@ -33,6 +35,12 @@ public class SeatReservationValidator {
     public void validateSeatAvailability(String seatSection, Integer seatNumber) {
         if (seatReservationRepository.existsBySeatSectionAndSeatNumber(seatSection, seatNumber)) throw new SeatAlreadyReservedException();
         if (seatBanRepository.existsBySeatSectionAndSeatNumber(seatSection, seatNumber)) throw new SeatBannedException();
+    }
+
+    public void validateSeatAccess(String seatSection, Integer seatNumber) {
+        if (!seatUtil.isAllowedForRole(UserUtil.getCurrentUserRole(), seatSection, seatNumber)) {
+            throw new SeatBannedException();
+        }
     }
 
     public void validateReservationLimit() {

--- a/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/exception/ErrorCode.java
@@ -45,7 +45,7 @@ public enum ErrorCode {
     // Seat
     SEAT_NOT_EXISTS_IN_SECTION(400, "해당 섹션에 존재하지 않는 좌석입니다."),
     SEAT_ALREADY_RESERVED(400, "이미 예약된 좌석입니다."),
-    SEAT_BANNED(400, "관리자에 의해 금지된 좌석입니다."),
+    SEAT_BANNED(400, "예약할 수 없는 좌석입니다."),
     SEAT_ALREADY_BANNED(400, "이미 금지된 좌석입니다."),
     INVALID_SEAT_SECTION(400, "유효하지 않은 좌석 구역입니다."),
     SEAT_RESERVATION_LIMIT_EXCEEDED(400, "예약 한도를 초과했습니다."),

--- a/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/security/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
                         .requestMatchers("/team/**").hasAnyAuthority(Role.ADMIN.name())
 
                         // seat
-                        .requestMatchers(HttpMethod.POST, "/seat").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/seat").hasAnyAuthority(Role.USER.name(), Role.PERFORMER.name())
                         .requestMatchers(HttpMethod.DELETE, "/seat").hasAnyAuthority(Role.ADMIN.name(), Role.USER.name())
                         .requestMatchers(HttpMethod.POST, "/seat/ban").hasAnyAuthority(Role.ADMIN.name())
                         .requestMatchers(HttpMethod.DELETE, "/seat/ban").hasAnyAuthority(Role.ADMIN.name())

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
@@ -3,6 +3,7 @@ package team.startup.gwangjutalentfestival.global.util;
 import org.springframework.stereotype.Component;
 import team.startup.gwangjutalentfestival.domain.seat.exception.InvalidSeatSectionException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.response.GetSeatsBySectionResponse;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
 import java.util.List;
 import java.util.Map;
@@ -19,7 +20,7 @@ public class SeatUtil {
 
     private static final Map<String, Integer> SEAT_MAP = Map.of(
             "A", 101, "B", 132, "C", 101, "D", 89, "E", 96,
-            "F", 89, "W", 6
+            "F", 89
     );
 
     /**
@@ -45,9 +46,25 @@ public class SeatUtil {
         return SEAT_MAP.get(section);
     }
 
-    public GetSeatsBySectionResponse buildSeatAvailability(String section, Set<Integer> bans, Set<Integer> reservations) {
+    public boolean isAllowedForRole(Role role, String section, int seatNumber) {
+        boolean performerSeat = switch (section) {
+            case "A" -> seatNumber <= 15 || seatNumber >= 21 && seatNumber <= 23;
+            case "B" -> seatNumber <= 36;
+            case "C" -> seatNumber <= 18;
+            default -> false;
+        };
+
+        return role == Role.PERFORMER ? performerSeat : role != Role.USER || !performerSeat;
+    }
+
+    public GetSeatsBySectionResponse buildSeatAvailability(
+            String section,
+            Set<Integer> bans,
+            Set<Integer> reservations,
+            Role role
+    ) {
         List<Boolean> seats = IntStream.rangeClosed(1, getMaxSeats(section))
-                .mapToObj(i -> !bans.contains(i) && !reservations.contains(i))
+                .mapToObj(i -> isAllowedForRole(role, section, i) && !bans.contains(i) && !reservations.contains(i))
                 .toList();
         return new GetSeatsBySectionResponse(seats);
     }

--- a/src/main/resources/db/migration/V2__remove_role_from_seat_ban.sql
+++ b/src/main/resources/db/migration/V2__remove_role_from_seat_ban.sql
@@ -1,0 +1,1 @@
+ALTER TABLE seat_ban DROP COLUMN role;

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImplTest.java
@@ -10,7 +10,6 @@ import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyBannedException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.BanSeatRequest;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
-import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,7 +34,7 @@ class BanSeatServiceImplTest {
     }
 
     private BanSeatRequest request() {
-        return new BanSeatRequest(SEAT_SECTION, SEAT_NUMBER, Role.USER);
+        return new BanSeatRequest(SEAT_SECTION, SEAT_NUMBER);
     }
 
     @Test

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
@@ -42,9 +42,9 @@ class GetSeatsBySectionServiceImplTest {
     @Test
     void 모든_좌석_예약_가능() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
-            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.ADMIN);
             given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
-            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
 
             GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
@@ -56,9 +56,9 @@ class GetSeatsBySectionServiceImplTest {
     @Test
     void 예약된_좌석은_false() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
-            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.ADMIN);
             given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of(2, 4));
-            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
 
             GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
@@ -73,9 +73,9 @@ class GetSeatsBySectionServiceImplTest {
     @Test
     void 차단된_좌석은_false() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
-            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.ADMIN);
             given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
-            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole(SECTION, Role.USER)).willReturn(Set.of(1, 3));
+            given(seatBanCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of(1, 3));
 
             GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
@@ -86,25 +86,23 @@ class GetSeatsBySectionServiceImplTest {
     }
 
     @Test
-    void W구역_전체_좌석_예약_가능() {
+    void W구역은_조회할_수_없다() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
-            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.ADMIN);
             given(seatReservationCustomRepository.findSeatNumbersBySeatSection("W")).willReturn(Set.of());
-            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole("W", Role.USER)).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSection("W")).willReturn(Set.of());
 
-            GetSeatsBySectionResponse response = getSeatsBySectionService.execute("W");
-
-            assertThat(response.seats()).hasSize(6);
-            assertThat(response.seats()).containsOnly(true);
+            assertThatThrownBy(() -> getSeatsBySectionService.execute("W"))
+                    .isInstanceOf(InvalidSeatSectionException.class);
         }
     }
 
     @Test
     void B구역_전체_좌석_예약_가능() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
-            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.ADMIN);
             given(seatReservationCustomRepository.findSeatNumbersBySeatSection("B")).willReturn(Set.of());
-            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole("B", Role.USER)).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSection("B")).willReturn(Set.of());
 
             GetSeatsBySectionResponse response = getSeatsBySectionService.execute("B");
 
@@ -118,10 +116,50 @@ class GetSeatsBySectionServiceImplTest {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
             given(seatReservationCustomRepository.findSeatNumbersBySeatSection("Z")).willReturn(Set.of());
-            given(seatBanCustomRepository.findSeatNumbersBySeatSectionAndRole("Z", Role.USER)).willReturn(Set.of());
+            given(seatBanCustomRepository.findSeatNumbersBySeatSection("Z")).willReturn(Set.of());
 
             assertThatThrownBy(() -> getSeatsBySectionService.execute("Z"))
                     .isInstanceOf(InvalidSeatSectionException.class);
+        }
+    }
+
+    @Test
+    void 공연자와_일반인의_좌석_범위가_분리된다() {
+        given(seatReservationCustomRepository.findSeatNumbersBySeatSection("A")).willReturn(Set.of());
+        given(seatBanCustomRepository.findSeatNumbersBySeatSection("A")).willReturn(Set.of());
+
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.PERFORMER);
+            GetSeatsBySectionResponse performer = getSeatsBySectionService.execute("A");
+            assertThat(performer.seats().get(14)).isTrue();  // A15
+            assertThat(performer.seats().get(15)).isFalse(); // A16
+            assertThat(performer.seats().get(20)).isTrue();  // A21
+            assertThat(performer.seats().get(23)).isFalse(); // A24
+        }
+
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            GetSeatsBySectionResponse user = getSeatsBySectionService.execute("A");
+            assertThat(user.seats().get(14)).isFalse();
+            assertThat(user.seats().get(15)).isTrue();
+            assertThat(user.seats().get(20)).isFalse();
+            assertThat(user.seats().get(23)).isTrue();
+        }
+    }
+
+    @Test
+    void 관리자_밴은_일반인과_공연자에게_모두_적용된다() {
+        given(seatReservationCustomRepository.findSeatNumbersBySeatSection("A")).willReturn(Set.of());
+        given(seatBanCustomRepository.findSeatNumbersBySeatSection("A")).willReturn(Set.of(1, 16));
+
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.PERFORMER);
+            assertThat(getSeatsBySectionService.execute("A").seats().get(0)).isFalse();
+        }
+
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
+            assertThat(getSeatsBySectionService.execute("A").seats().get(15)).isFalse();
         }
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
@@ -93,7 +93,7 @@ class ReservationSeatConcurrencyTest {
                     try {
                         startLatch.await();
                         setAuth(userId, Role.USER);
-                        reservationSeatService.execute(new ReservationSeatRequest("A", 1));
+                        reservationSeatService.execute(new ReservationSeatRequest("A", 16));
                         successCount.incrementAndGet();
                     } catch (SeatAlreadyReservedException e) {
                         failCount.incrementAndGet();
@@ -132,7 +132,7 @@ class ReservationSeatConcurrencyTest {
 
         long userId = testUsers.get(0).getId();
         String[] sections = {"A", "A"};
-        Integer[] seatNumbers = {1, 2};
+        Integer[] seatNumbers = {16, 17};
 
         try {
             for (int i = 0; i < threadCount; i++) {

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
@@ -129,6 +129,15 @@ class ReservationSeatServiceImplTest {
     }
 
     @Test
+    void 역할에_허용되지_않은_좌석_예외() {
+        given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
+        willThrow(SeatBannedException.class).given(seatReservationValidator).validateSeatAccess(SEAT_SECTION, SEAT_NUMBER);
+
+        assertThatThrownBy(() -> reservationSeatService.execute(request()))
+                .isInstanceOf(SeatBannedException.class);
+    }
+
+    @Test
     void 유저_없음_예외() {
         given(seatUtil.getMaxSeats(SEAT_SECTION)).willReturn(MAX_SEATS);
         willThrow(UserNotFoundException.class).given(seatReservationValidator).validateReservationLimit();

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidatorTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidatorTest.java
@@ -16,10 +16,12 @@ import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
+import team.startup.gwangjutalentfestival.global.util.SeatUtil;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockStatic;
 
@@ -37,6 +39,9 @@ class SeatReservationValidatorTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private SeatUtil seatUtil;
 
     private static final String SECTION = "A";
     private static final Integer SEAT_NUMBER = 1;
@@ -73,6 +78,17 @@ class SeatReservationValidatorTest {
     }
 
     @Test
+    void 현재_역할에_허용되지_않은_좌석이면_SeatBannedException이_발생한다() {
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.PERFORMER);
+            given(seatUtil.isAllowedForRole(Role.PERFORMER, SECTION, SEAT_NUMBER)).willReturn(false);
+
+            assertThatThrownBy(() -> validator.validateSeatAccess(SECTION, SEAT_NUMBER))
+                    .isInstanceOf(SeatBannedException.class);
+        }
+    }
+
+    @Test
     void USER_예약_한도_초과시_SeatReservationLimitExceededException이_발생한다() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             UserEntity user = UserEntity.builder().id(USER_ID).role(Role.USER).build();
@@ -93,10 +109,23 @@ class SeatReservationValidatorTest {
             userUtilMock.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.PERFORMER);
             given(userRepository.findByIdForUpdate(USER_ID)).willReturn(Optional.of(user));
-            given(seatReservationRepository.countByUserId(USER_ID)).willReturn(3L);
+            given(seatReservationRepository.countByUserId(USER_ID)).willReturn(2L);
 
             assertThatThrownBy(() -> validator.validateReservationLimit())
                     .isInstanceOf(SeatReservationLimitExceededException.class);
+        }
+    }
+
+    @Test
+    void PERFORMER_1석_보유시_추가_예약이_가능하다() {
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            UserEntity user = UserEntity.builder().id(USER_ID).role(Role.PERFORMER).build();
+            userUtilMock.when(UserUtil::getCurrentUserId).thenReturn(USER_ID);
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.PERFORMER);
+            given(userRepository.findByIdForUpdate(USER_ID)).willReturn(Optional.of(user));
+            given(seatReservationRepository.countByUserId(USER_ID)).willReturn(1L);
+
+            assertThatCode(validator::validateReservationLimit).doesNotThrowAnyException();
         }
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/global/security/RoleBasedApiAuthorizationTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/security/RoleBasedApiAuthorizationTest.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.global.security;
 
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -8,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
@@ -42,6 +45,7 @@ import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEv
 import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventListService;
 import team.startup.gwangjutalentfestival.domain.monitoring.service.GetAnomalyEventSummaryService;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.controller.SeatController;
+import team.startup.gwangjutalentfestival.domain.seat.presentation.controller.SeatAdminController;
 import team.startup.gwangjutalentfestival.domain.seat.service.CancelSeatReservationService;
 import team.startup.gwangjutalentfestival.domain.seat.service.ConnectSseSeatEventService;
 import team.startup.gwangjutalentfestival.domain.seat.service.GetAllSeatsService;
@@ -50,6 +54,8 @@ import team.startup.gwangjutalentfestival.domain.seat.service.GetCurrentUserSeat
 import team.startup.gwangjutalentfestival.domain.seat.service.GetSeatsBySectionService;
 import team.startup.gwangjutalentfestival.domain.seat.service.PerformerCancelSeatReservationService;
 import team.startup.gwangjutalentfestival.domain.seat.service.ReservationSeatService;
+import team.startup.gwangjutalentfestival.domain.seat.service.admin.BanSeatService;
+import team.startup.gwangjutalentfestival.domain.seat.service.admin.CancelSeatBanService;
 import team.startup.gwangjutalentfestival.domain.team.presentation.controller.TeamController;
 import team.startup.gwangjutalentfestival.domain.team.service.GetAllTeamService;
 import team.startup.gwangjutalentfestival.domain.team.service.GetTeamRankingService;
@@ -65,11 +71,15 @@ import team.startup.gwangjutalentfestival.global.security.handler.JwtAuthenticat
 import team.startup.gwangjutalentfestival.global.security.properties.CorsProperties;
 
 import java.util.EnumSet;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 
 /**
  * USER, ADMIN, JUDGE, PERFORMER 역할별 API 접근 허용 상태를 회귀 테스트로 고정한다.
@@ -79,6 +89,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = {
         TeamController.class,
         SeatController.class,
+        SeatAdminController.class,
         JudgeController.class,
         MonitoringController.class,
         ExcelController.class,
@@ -125,6 +136,10 @@ class RoleBasedApiAuthorizationTest {
     private GetAllSeatsService getAllSeatsService;
     @MockBean
     private ConnectSseSeatEventService connectSseSeatEventService;
+    @MockBean
+    private BanSeatService banSeatService;
+    @MockBean
+    private CancelSeatBanService cancelSeatBanService;
 
     @MockBean
     private SaveJudgementScoreService saveJudgementScoreService;
@@ -175,6 +190,14 @@ class RoleBasedApiAuthorizationTest {
     private TokenBlacklistRepository tokenBlacklistRepository;
     @MockBean
     private StringRedisTemplate stringRedisTemplate;
+    @MockBean
+    private ValueOperations<String, String> valueOperations;
+
+    @BeforeEach
+    void setUpRateLimit() {
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+    }
 
     private record Endpoint(
             String description,
@@ -200,6 +223,12 @@ class RoleBasedApiAuthorizationTest {
     private static final List<Endpoint> ENDPOINTS = List.of(
             new Endpoint("팀 공연 순서 변경", HttpMethod.PATCH, "/team/order", new String[0],
                     "{\"orderItems\":[{\"teamId\":1,\"order\":1}]}", 204, Set.of(Role.ADMIN)),
+            new Endpoint("좌석 예약", HttpMethod.POST, "/seat", new String[0],
+                    "{\"seatSection\":\"A\",\"seatNumber\":1}", 201, Set.of(Role.USER, Role.PERFORMER)),
+            new Endpoint("좌석 차단", HttpMethod.POST, "/seat/ban", new String[0],
+                    "{\"seatSection\":\"A\",\"seatNumber\":1}", 201, Set.of(Role.ADMIN)),
+            new Endpoint("좌석 차단 해제", HttpMethod.DELETE, "/seat/ban", new String[0],
+                    "{\"seatSection\":\"A\",\"seatNumber\":1}", 204, Set.of(Role.ADMIN)),
             new Endpoint("구역별 좌석 조회", HttpMethod.GET, "/seat", new String[]{"section", "A"}, null, 200,
                     Set.of(Role.ADMIN, Role.USER, Role.PERFORMER)),
             new Endpoint("내 좌석 조회", HttpMethod.GET, "/seat/myself", new String[0], null, 200,
@@ -252,5 +281,16 @@ class RoleBasedApiAuthorizationTest {
                         )
                 )
         );
+    }
+
+    @Test
+    void ADMIN이_W구역을_차단하면_400을_반환한다() throws Exception {
+        String token = jwtProvider.generateAccessToken(1L, Role.ADMIN);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/seat/ban")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"seatSection\":\"W\",\"seatNumber\":1}"))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/global/util/SeatUtilTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/util/SeatUtilTest.java
@@ -1,0 +1,31 @@
+package team.startup.gwangjutalentfestival.global.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.api.Test;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SeatUtilTest {
+
+    private final SeatUtil seatUtil = new SeatUtil();
+
+    @Test
+    void 장애인석_W구역은_제공하지_않는다() {
+        assertThat(seatUtil.getSections()).containsExactly("A", "B", "C", "D", "E", "F");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "A, 1, true", "A, 15, true", "A, 16, false", "A, 20, false",
+            "A, 21, true", "A, 23, true", "A, 24, false",
+            "B, 1, true", "B, 36, true", "B, 37, false",
+            "C, 1, true", "C, 18, true", "C, 19, false",
+            "D, 1, false", "E, 1, false", "F, 1, false"
+    })
+    void 공연자_좌석_범위를_검증한다(String section, int seatNumber, boolean performerAllowed) {
+        assertThat(seatUtil.isAllowedForRole(Role.PERFORMER, section, seatNumber)).isEqualTo(performerAllowed);
+        assertThat(seatUtil.isAllowedForRole(Role.USER, section, seatNumber)).isEqualTo(!performerAllowed);
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
> 좌석 예매 정책을 역할별로 분리하고 관리자 밴을 공통 정책으로 정리했습니다.

- W 장애인석을 신규 조회·예매 대상에서 제거했습니다.
- 공연자는 A 1~15·21~23, B 1~36, C 1~18만 최대 2석까지 예매할 수 있습니다.
- 일반인은 공연자 전용석을 제외한 좌석만 조회·예매할 수 있습니다.
- 역할상 허용되지 않은 좌석은 조회 시 `false`, 예매 시 400으로 처리합니다.
- 관리자 밴을 USER·PERFORMER 공통으로 적용하고 밴/해제 시 좌석 캐시를 비웁니다.
- `POST /seat/ban` 요청의 `role`을 제거하고 `seat_ban.role`을 삭제하는 Flyway V2 마이그레이션을 추가했습니다.
- `POST /seat` 접근 권한을 USER·PERFORMER로 제한했습니다.

---

## 🔍 리뷰 시 참고사항
- 기존 W 예약, 역할 범위와 충돌하는 예약, 공연자의 기존 3석 예약은 삭제하지 않습니다.
- 기존 예약은 계속 조회·취소할 수 있고 신규 예매부터 새 정책이 적용됩니다.
- `POST /seat/ban` 요청 스펙은 `{ "seatSection": "A", "seatNumber": 1 }`로 변경됩니다.
- 새 임시 MariaDB에서 Flyway `B1 → V2`, JPA `validate`, 전체 테스트를 검증했습니다.

---

## ✅ 체크리스트
- [x] 문서 변경이 필요한 부분을 수정했습니다.
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했습니다.
- [x] 필요한 테스트 코드를 작성하거나 수정했습니다.
- [x] Merge 대상 브랜치를 `develop`로 설정했습니다.
- [x] PR에 관련 없는 `.claude/settings.json` 변경을 제외했습니다.
- [x] 리뷰어를 설정했습니다.

---

## 📎 관련 이슈(선택)
- Closes #214