### PR TITLE
개별 심사표 이미지가 표 테두리에 닿지 않게 셀 여백 적용

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/excel/service/impl/DownloadJudgeSheetsServiceImpl.java
@@ -51,6 +51,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
     private static final int IMAGE_PADDING = 10;
     private static final int COMMENT_CELL_WIDTH = 100;
     private static final int COMMENT_CELL_HEIGHT = 50;
+    private static final int CELL_PADDING = 6;
     private static final int PROFILE_ROW = 2;
     private static final int HEADER_ROW = 3;
     private static final int FIRST_DATA_ROW = 4;
@@ -133,7 +134,7 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
             if (drawing == null) {
                 drawing = sheet.createDrawingPatriarch();
             }
-            addProfileImages(workbook, drawing, profile);
+            addProfileImages(workbook, drawing, sheet, profile);
             for (int index = 0; index < teams.size(); index++) {
                 TeamEntity team = teams.get(index);
                 JudgementEntity judgement = scoreMap.get(team.getId());
@@ -155,12 +156,11 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
                     addImage(
                             workbook,
                             drawing,
+                            sheet,
                             COMMENT_COLUMN,
+                            1,
                             rowIndex,
-                            COMMENT_COLUMN,
-                            rowIndex,
-                            Math.round(sheet.getColumnWidthInPixels(COMMENT_COLUMN)),
-                            Units.pointsToPixel(row.getHeightInPoints()),
+                            CELL_PADDING,
                             renderStrokes(comment.getStrokes()));
                 }
             }
@@ -172,18 +172,20 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
     private void addProfileImages(
             Workbook workbook,
             Drawing<?> drawing,
+            Sheet sheet,
             JudgeProfileEntity profile) throws IOException {
         if (profile == null) {
             return;
         }
-        addProfileImage(workbook, drawing, AFFILIATION_COLUMN, profile.getAffiliationStrokes());
-        addProfileImage(workbook, drawing, POSITION_COLUMN, profile.getPositionStrokes());
-        addProfileImage(workbook, drawing, NAME_COLUMN, profile.getNameStrokes());
+        addProfileImage(workbook, drawing, sheet, AFFILIATION_COLUMN, profile.getAffiliationStrokes());
+        addProfileImage(workbook, drawing, sheet, POSITION_COLUMN, profile.getPositionStrokes());
+        addProfileImage(workbook, drawing, sheet, NAME_COLUMN, profile.getNameStrokes());
     }
 
     private void addProfileImage(
             Workbook workbook,
             Drawing<?> drawing,
+            Sheet sheet,
             int column,
             JsonNode strokes) throws IOException {
         if (!hasPoints(strokes)) {
@@ -192,35 +194,55 @@ public class DownloadJudgeSheetsServiceImpl implements DownloadJudgeSheetsServic
         addImage(
                 workbook,
                 drawing,
+                sheet,
                 column,
+                PROFILE_COLUMN_SPAN,
                 PROFILE_ROW,
-                column + PROFILE_COLUMN_SPAN,
-                PROFILE_ROW + 1,
-                0,
-                0,
+                CELL_PADDING,
                 renderStrokes(strokes));
     }
 
+    /**
+     * 이미지를 대상 영역 안쪽에 배치한다.
+     * <p>영역은 {@code startColumn}부터 {@code columnSpan}개 열과 {@code rowIndex} 한 행이며,
+     * 네 방향 모두 {@code paddingPx}만큼 안으로 들여 표 테두리에 획이 닿지 않게 한다.
+     * 여백이 영역보다 크면 해당 축의 여백을 버린다.</p>
+     */
     private void addImage(
             Workbook workbook,
             Drawing<?> drawing,
+            Sheet sheet,
             int startColumn,
-            int startRow,
-            int endColumn,
-            int endRow,
-            int endColumnOffset,
-            int endRowOffset,
+            int columnSpan,
+            int rowIndex,
+            int paddingPx,
             byte[] image) {
+        int lastColumn = startColumn + columnSpan - 1;
+        int areaWidth = 0;
+        for (int column = startColumn; column <= lastColumn; column++) {
+            areaWidth += Math.round(sheet.getColumnWidthInPixels(column));
+        }
+        int lastColumnWidth = Math.round(sheet.getColumnWidthInPixels(lastColumn));
+        int rowHeight = Units.pointsToPixel(row(sheet, rowIndex).getHeightInPoints());
+        int horizontalPadding = fitPadding(paddingPx, areaWidth);
+        int verticalPadding = fitPadding(paddingPx, rowHeight);
+
         int pictureIndex = workbook.addPicture(image, Workbook.PICTURE_TYPE_PNG);
         ClientAnchor anchor = workbook.getCreationHelper().createClientAnchor();
         anchor.setCol1(startColumn);
-        anchor.setCol2(endColumn);
-        anchor.setRow1(startRow);
-        anchor.setRow2(endRow);
-        anchor.setDx2(Units.pixelToEMU(endColumnOffset));
-        anchor.setDy2(Units.pixelToEMU(endRowOffset));
+        anchor.setDx1(Units.pixelToEMU(horizontalPadding));
+        anchor.setCol2(lastColumn);
+        anchor.setDx2(Units.pixelToEMU(lastColumnWidth - horizontalPadding));
+        anchor.setRow1(rowIndex);
+        anchor.setDy1(Units.pixelToEMU(verticalPadding));
+        anchor.setRow2(rowIndex);
+        anchor.setDy2(Units.pixelToEMU(rowHeight - verticalPadding));
         anchor.setAnchorType(ClientAnchor.AnchorType.MOVE_DONT_RESIZE);
         drawing.createPicture(anchor, pictureIndex);
+    }
+
+    private int fitPadding(int paddingPx, int availablePx) {
+        return availablePx > paddingPx * 2 ? paddingPx : 0;
     }
 
     private byte[] renderStrokes(JsonNode strokes) throws IOException {

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/excel/service/DownloadJudgeSheetsServiceImplTest.java
@@ -59,6 +59,11 @@ class DownloadJudgeSheetsServiceImplTest {
     @Mock private GoogleExcelAdapter googleExcelAdapter;
     @Mock private GoogleExcelProperties googleExcelProperties;
 
+    /** 이미지가 표 테두리에 닿지 않도록 네 방향에 두는 여백. 프로덕션 CELL_PADDING과 같은 값. */
+    private static final int CELL_PADDING = 6;
+    private static final int PROFILE_ROW_HEIGHT = 50;
+    private static final int CELL_WIDTH = 100;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
     private DownloadJudgeSheetsServiceImpl service;
 
@@ -261,6 +266,10 @@ class DownloadJudgeSheetsServiceImplTest {
             }
             sheet.getRow(0).getCell(0).setCellValue("원본 제목");
             sheet.getRow(2).getCell(0).setCellValue("소속/직위/이름");
+            sheet.getRow(2).setHeightInPoints((float) Units.pixelToPoints(PROFILE_ROW_HEIGHT));
+            for (int column = 0; column < 7; column++) {
+                sheet.setColumnWidth(column, Math.round(100 / Units.DEFAULT_CHARACTER_WIDTH * 256));
+            }
             sheet.addMergedRegion(new CellRangeAddress(2, 2, 1, 2));
             sheet.addMergedRegion(new CellRangeAddress(2, 2, 3, 4));
             sheet.addMergedRegion(new CellRangeAddress(2, 2, 5, 6));
@@ -316,10 +325,7 @@ class DownloadJudgeSheetsServiceImplTest {
         assertThat(anchor.getCol2()).isEqualTo((short) 6);
         assertThat(anchor.getRow1()).isEqualTo(rowIndex);
         assertThat(anchor.getRow2()).isEqualTo(rowIndex);
-        assertThat(anchor.getDx1()).isZero();
-        assertThat(anchor.getDy1()).isZero();
-        assertThat(anchor.getDx2()).isEqualTo(Units.pixelToEMU(100));
-        assertThat(anchor.getDy2()).isEqualTo(Units.pixelToEMU(50));
+        assertCellPadding(anchor, CELL_WIDTH, 50);
         XSSFDrawing drawing = sheet.getDrawingPatriarch();
         assertThat(drawing.getCTDrawing().getTwoCellAnchorArray(0).getEditAs()).isEqualTo(STEditAs.ONE_CELL);
 
@@ -334,17 +340,28 @@ class DownloadJudgeSheetsServiceImplTest {
             int column) throws IOException {
         ClientAnchor anchor = picture.getClientAnchor();
         assertThat(anchor.getCol1()).isEqualTo((short) column);
-        assertThat(anchor.getCol2()).isEqualTo((short) (column + 2));
+        assertThat(anchor.getCol2()).isEqualTo((short) (column + 1));
         assertThat(anchor.getRow1()).isEqualTo(2);
-        assertThat(anchor.getRow2()).isEqualTo(3);
-        assertThat(anchor.getDx1()).isZero();
-        assertThat(anchor.getDy1()).isZero();
-        assertThat(anchor.getDx2()).isZero();
-        assertThat(anchor.getDy2()).isZero();
+        assertThat(anchor.getRow2()).isEqualTo(2);
+        assertCellPadding(anchor, CELL_WIDTH, PROFILE_ROW_HEIGHT);
 
         BufferedImage image = ImageIO.read(new ByteArrayInputStream(picture.getPictureData().getData()));
         assertThat(image.getWidth()).isEqualTo(1000);
         assertThat(image.getHeight()).isEqualTo(500);
+    }
+
+    /**
+     * 이미지가 대상 영역의 네 테두리에 닿지 않는지 검증한다.
+     * <p>{@code lastColumnWidth}는 앵커 종료 열의 너비, {@code rowHeight}는 대상 행 높이(px)다.</p>
+     */
+    private void assertCellPadding(ClientAnchor anchor, int lastColumnWidth, int rowHeight) {
+        assertThat(anchor.getDx1()).isEqualTo(Units.pixelToEMU(CELL_PADDING));
+        assertThat(anchor.getDy1()).isEqualTo(Units.pixelToEMU(CELL_PADDING));
+        assertThat(anchor.getDx2()).isEqualTo(Units.pixelToEMU(lastColumnWidth - CELL_PADDING));
+        assertThat(anchor.getDy2()).isEqualTo(Units.pixelToEMU(rowHeight - CELL_PADDING));
+        assertThat(anchor.getDx1()).isPositive();
+        assertThat(anchor.getDy1()).isPositive();
+        assertThat(anchor.getDy2()).isLessThan(Units.pixelToEMU(rowHeight));
     }
 
     private Map<String, byte[]> zipEntries(byte[] zip) throws IOException {


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

개별 심사표 xlsx에서 손글씨 이미지가 표 테두리 위에 겹쳐 보이던 문제를 수정했습니다.

- 3행 서명 이미지(소속/직위/이름) 3개
- 각 데이터 행 G열 심사 의견 필기 이미지

두 이미지 모두 담당 셀 안쪽으로 네 방향 6px씩 들여 배치합니다.

---

## 🔍 리뷰 시 참고사항

**원인**

`addImage()`가 앵커의 `dx2`/`dy2`에 셀 너비·행 높이를 그대로 넣어 이미지가 셀을 가장자리까지 채웠습니다. 서명은 `col2 = column + PROFILE_COLUMN_SPAN`, `row2 = PROFILE_ROW + 1`로 병합셀 경계에 정확히 붙었고, 심사 의견은 `dx2 = 100px`, `dy2 = 50px`로 G 셀을 꽉 채웠습니다. `renderStrokes()`의 세로 여백은 캔버스 높이의 2%뿐이라(50px 행에서 1px) 완충이 되지 않았습니다.

**변경**

`addImage()`를 "셀을 채우는" 방식에서 "영역 안쪽에 여백을 두고 배치하는" 방식으로 교체했습니다. 호출부가 넘기던 `endColumnOffset` / `endRowOffset` 계산이 사라지고 `(startColumn, columnSpan, rowIndex, paddingPx)`만 넘깁니다. 서명과 심사 의견이 같은 헬퍼를 쓰므로 여백이 `CELL_PADDING` 상수 하나로 관리됩니다.

`fitPadding()`은 행 높이나 열 너비가 여백의 두 배보다 좁을 때 해당 축의 여백을 버립니다. 좁은 셀에서 `dx2 < dx1`이 되어 앵커가 뒤집히는 것을 막습니다.

**검증**

실제 Google 템플릿(`심사위원 개별 심사표`)을 내려받아 생성한 xlsx의 앵커 좌표를 대조했습니다. 캔버스 네 변에 모두 닿는 최악 케이스 필기(`x=0.0`, `x=1.0`, `y=0.0`, `y=1.0`)로 확인했습니다.

| | 수정 전 | 수정 후 |
|---|---|---|
| 서명 세로 | y 107~154 (아래 붙음) | y 107~148 |
| 서명 가로 | x 102~306 (좌측 붙음) | x 108~299 |
| 심사 의견 | y 204~254, x 528~628 (사방 붙음) | y 210~248, x 534~622 |

3행 경계가 y=101~154이므로 위아래·좌우 각 6px씩 확보됩니다.

**범위에서 제외한 것**

원본 이미지 비율 유지, 획 bbox 기준 crop, 심사 의견의 G+H 두 열 확장은 이번 PR에 포함하지 않았습니다. 이미지는 여전히 대상 영역 크기에 맞춰 늘어납니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요? — 해당 없음
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요? — 실제 템플릿으로 xlsx 생성 후 앵커 좌표 대조
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요? — `assertCellPadding()` 추가, 기존 단정 갱신
- [x] Merge 대상 브랜치를 올바르게 설정했나요? — `develop`
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #