### PR TITLE
참가자 좌석 범위 및 예매 동시성 제어 보강

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatBanRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatBanRepository.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.domain.seat.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatBanEntity;
 
 import java.util.Optional;
@@ -26,5 +28,6 @@ public interface SeatBanRepository extends JpaRepository<SeatBanEntity, Long> {
      * @param seatNumber  좌석 번호
      * @return 차단 엔티티 (없으면 empty)
      */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<SeatBanEntity> findBySeatSectionAndSeatNumber(String seatSection, Integer seatNumber);
 }

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatLockRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatLockRepository.java
@@ -1,0 +1,19 @@
+package team.startup.gwangjutalentfestival.domain.seat.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SeatLockRepository {
+
+    private final EntityManager entityManager;
+
+    public void lock(String seatSection, Integer seatNumber) {
+        String seatKey = seatSection + ":" + seatNumber;
+        entityManager.createNativeQuery("SELECT seat_key FROM seat_lock WHERE seat_key = :seatKey FOR UPDATE")
+                .setParameter("seatKey", seatKey)
+                .getSingleResult();
+    }
+}

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatReservationRepository.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/repository/SeatReservationRepository.java
@@ -1,6 +1,8 @@
 package team.startup.gwangjutalentfestival.domain.seat.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 
@@ -53,6 +55,7 @@ public interface SeatReservationRepository extends JpaRepository<SeatEntity, Lon
      * @param user        사용자 엔티티
      * @return 예약 좌석 엔티티 (없으면 empty)
      */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<SeatEntity> findBySeatSectionAndSeatNumberAndUser(String seatSection, Integer seatNumber, UserEntity user);
 
     /**

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImpl.java
@@ -10,8 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatBanEntity;
 import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyBannedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.BanSeatRequest;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.admin.BanSeatService;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 
@@ -24,6 +27,8 @@ import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 public class BanSeatServiceImpl implements BanSeatService {
 
     private final SeatBanRepository seatBanRepository;
+    private final SeatReservationRepository seatReservationRepository;
+    private final SeatLockRepository seatLockRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
@@ -39,6 +44,11 @@ public class BanSeatServiceImpl implements BanSeatService {
             @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
     })
     public void execute(BanSeatRequest request) {
+        seatLockRepository.lock(request.seatSection(), request.seatNumber());
+        if (seatReservationRepository
+                .existsBySeatSectionAndSeatNumber(request.seatSection(), request.seatNumber())) {
+            throw new SeatAlreadyReservedException();
+        }
         if (seatBanRepository
                 .existsBySeatSectionAndSeatNumber(request.seatSection(), request.seatNumber())) {
             throw new SeatAlreadyBannedException();

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/CancelSeatBanServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/CancelSeatBanServiceImpl.java
@@ -11,6 +11,7 @@ import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBanNotFoundException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.CancelSeatBanRequest;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.admin.CancelSeatBanService;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 
@@ -23,6 +24,7 @@ import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 public class CancelSeatBanServiceImpl implements CancelSeatBanService {
 
     private final SeatBanRepository seatBanRepository;
+    private final SeatLockRepository seatLockRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
@@ -38,6 +40,7 @@ public class CancelSeatBanServiceImpl implements CancelSeatBanService {
             @CacheEvict(value = CacheConfig.SEATS_SECTION, allEntries = true)
     })
     public void execute(CancelSeatBanRequest request) {
+        seatLockRepository.lock(request.seatSection(), request.seatNumber());
         SeatBanEntity seatBan = seatBanRepository
                 .findBySeatSectionAndSeatNumber(request.seatSection(), request.seatNumber())
                 .orElseThrow(SeatBanNotFoundException::new);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/AbstractCancelSeatReservationService.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/AbstractCancelSeatReservationService.java
@@ -4,12 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 
 @RequiredArgsConstructor
 public abstract class AbstractCancelSeatReservationService {
 
     protected final SeatReservationRepository seatReservationRepository;
+    protected final SeatLockRepository seatLockRepository;
     protected final ApplicationEventPublisher applicationEventPublisher;
 
     protected void cancelAndPublish(SeatEntity seat) {

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.CancelSeatReservationService;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
@@ -20,10 +21,11 @@ public class CancelSeatReservationServiceImpl extends AbstractCancelSeatReservat
 
     public CancelSeatReservationServiceImpl(
             SeatReservationRepository seatReservationRepository,
+            SeatLockRepository seatLockRepository,
             ApplicationEventPublisher applicationEventPublisher,
             UserUtil userUtil
     ) {
-        super(seatReservationRepository, applicationEventPublisher);
+        super(seatReservationRepository, seatLockRepository, applicationEventPublisher);
         this.userUtil = userUtil;
     }
 
@@ -36,7 +38,11 @@ public class CancelSeatReservationServiceImpl extends AbstractCancelSeatReservat
     public void execute() {
         UserEntity user = userUtil.getCurrentUser();
 
-        SeatEntity seat = seatReservationRepository.findByUser(user)
+        SeatEntity currentSeat = seatReservationRepository.findByUser(user)
+                .orElseThrow(SeatNotFoundException::new);
+        seatLockRepository.lock(currentSeat.getSeatSection(), currentSeat.getSeatNumber());
+        SeatEntity seat = seatReservationRepository.findBySeatSectionAndSeatNumberAndUser(
+                        currentSeat.getSeatSection(), currentSeat.getSeatNumber(), user)
                 .orElseThrow(SeatNotFoundException::new);
 
         cancelAndPublish(seat);

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImpl.java
@@ -9,6 +9,7 @@ import team.startup.gwangjutalentfestival.global.config.CacheConfig;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.PerformerCancelSeatReservationRequest;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.PerformerCancelSeatReservationService;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
@@ -21,10 +22,11 @@ public class PerformerCancelSeatReservationServiceImpl extends AbstractCancelSea
 
     public PerformerCancelSeatReservationServiceImpl(
             SeatReservationRepository seatReservationRepository,
+            SeatLockRepository seatLockRepository,
             ApplicationEventPublisher applicationEventPublisher,
             UserUtil userUtil
     ) {
-        super(seatReservationRepository, applicationEventPublisher);
+        super(seatReservationRepository, seatLockRepository, applicationEventPublisher);
         this.userUtil = userUtil;
     }
 
@@ -36,6 +38,7 @@ public class PerformerCancelSeatReservationServiceImpl extends AbstractCancelSea
     })
     public void execute(PerformerCancelSeatReservationRequest request) {
         UserEntity user = userUtil.getCurrentUser();
+        seatLockRepository.lock(request.seatSection(), request.seatNumber());
 
         SeatEntity seat = seatReservationRepository.findBySeatSectionAndSeatNumberAndUser(
                 request.seatSection(),

--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImpl.java
@@ -12,6 +12,7 @@ import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.ReservationSeatRequest;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.seat.service.ReservationSeatService;
 import team.startup.gwangjutalentfestival.global.util.OperationMetricRecorder;
@@ -23,6 +24,7 @@ import team.startup.gwangjutalentfestival.global.util.UserUtil;
 public class ReservationSeatServiceImpl implements ReservationSeatService {
 
     private final SeatReservationRepository seatReservationRepository;
+    private final SeatLockRepository seatLockRepository;
     private final SeatReservationValidator seatReservationValidator;
     private final SeatUtil seatUtil;
     private final UserUtil userUtil;
@@ -46,6 +48,7 @@ public class ReservationSeatServiceImpl implements ReservationSeatService {
 
                     seatReservationValidator.validateSeatRange(seatNumber, seatUtil.getMaxSeats(seatSection));
                     seatReservationValidator.validateSeatAccess(seatSection, seatNumber);
+                    seatLockRepository.lock(seatSection, seatNumber);
                     seatReservationValidator.validateReservationLimit();
                     seatReservationValidator.validateSeatAvailability(seatSection, seatNumber);
 

--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
@@ -48,9 +48,11 @@ public class SeatUtil {
 
     public boolean isAllowedForRole(Role role, String section, int seatNumber) {
         boolean performerSeat = switch (section) {
-            case "A" -> seatNumber <= 15 || seatNumber >= 21 && seatNumber <= 23;
-            case "B" -> seatNumber <= 36;
-            case "C" -> seatNumber <= 18;
+            case "A" -> seatNumber >= 16 && seatNumber <= 32;
+            case "B" -> seatNumber >= 13 && seatNumber <= 39
+                    || seatNumber >= 44 && seatNumber <= 48;
+            case "C" -> seatNumber >= 8 && seatNumber <= 13
+                    || seatNumber >= 16 && seatNumber <= 32;
             default -> false;
         };
 

--- a/src/main/resources/db/migration/V3__add_seat_lock.sql
+++ b/src/main/resources/db/migration/V3__add_seat_lock.sql
@@ -1,0 +1,4 @@
+CREATE TABLE seat_lock (
+    seat_key VARCHAR(8) NOT NULL,
+    PRIMARY KEY (seat_key)
+) ENGINE=InnoDB;

--- a/src/main/resources/db/migration/V4__seed_seat_lock.sql
+++ b/src/main/resources/db/migration/V4__seed_seat_lock.sql
@@ -1,0 +1,18 @@
+INSERT IGNORE INTO seat_lock (seat_key)
+WITH RECURSIVE seat_numbers AS (
+    SELECT 1 AS seat_number
+    UNION ALL
+    SELECT seat_number + 1
+    FROM seat_numbers
+    WHERE seat_number < 132
+), sections AS (
+    SELECT 'A' AS seat_section, 101 AS max_seat_number
+    UNION ALL SELECT 'B', 132
+    UNION ALL SELECT 'C', 101
+    UNION ALL SELECT 'D', 89
+    UNION ALL SELECT 'E', 96
+    UNION ALL SELECT 'F', 89
+)
+SELECT CONCAT(seat_section, ':', seat_number)
+FROM sections
+JOIN seat_numbers ON seat_number <= max_seat_number;

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/BanSeatServiceImplTest.java
@@ -8,8 +8,11 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyBannedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.BanSeatRequest;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,10 +30,17 @@ class BanSeatServiceImplTest {
     private SeatBanRepository seatBanRepository;
 
     @Mock
+    private SeatReservationRepository seatReservationRepository;
+
+    @Mock
+    private SeatLockRepository seatLockRepository;
+
+    @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
     private BanSeatServiceImpl service() {
-        return new BanSeatServiceImpl(seatBanRepository, applicationEventPublisher);
+        return new BanSeatServiceImpl(
+                seatBanRepository, seatReservationRepository, seatLockRepository, applicationEventPublisher);
     }
 
     private BanSeatRequest request() {
@@ -43,8 +53,21 @@ class BanSeatServiceImplTest {
 
         service().execute(request());
 
+        verify(seatLockRepository).lock(SEAT_SECTION, SEAT_NUMBER);
         verify(seatBanRepository).saveAndFlush(any());
         verify(applicationEventPublisher).publishEvent(new SeatChangeEvent(SEAT_SECTION, SEAT_NUMBER, false));
+    }
+
+    @Test
+    void 이미_예약된_좌석은_차단할_수_없다() {
+        given(seatReservationRepository
+                .existsBySeatSectionAndSeatNumber(SEAT_SECTION, SEAT_NUMBER)).willReturn(true);
+
+        assertThatThrownBy(() -> service().execute(request()))
+                .isInstanceOf(SeatAlreadyReservedException.class);
+
+        verify(seatBanRepository, never()).saveAndFlush(any());
+        verify(applicationEventPublisher, never()).publishEvent(any());
     }
 
     @Test

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/CancelSeatBanServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/admin/impl/CancelSeatBanServiceImplTest.java
@@ -1,0 +1,63 @@
+package team.startup.gwangjutalentfestival.domain.seat.service.admin.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangjutalentfestival.domain.seat.entity.SeatBanEntity;
+import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBanNotFoundException;
+import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.CancelSeatBanRequest;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CancelSeatBanServiceImplTest {
+
+    private static final String SECTION = "A";
+    private static final int NUMBER = 1;
+    private static final CancelSeatBanRequest REQUEST = new CancelSeatBanRequest(SECTION, NUMBER);
+
+    @InjectMocks
+    private CancelSeatBanServiceImpl service;
+
+    @Mock
+    private SeatBanRepository seatBanRepository;
+
+    @Mock
+    private SeatLockRepository seatLockRepository;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Test
+    void 차단_해제는_좌석을_잠근_뒤_삭제하고_이벤트를_발행한다() {
+        SeatBanEntity ban = SeatBanEntity.builder().seatSection(SECTION).seatNumber(NUMBER).build();
+        given(seatBanRepository.findBySeatSectionAndSeatNumber(SECTION, NUMBER)).willReturn(Optional.of(ban));
+
+        service.execute(REQUEST);
+
+        verify(seatLockRepository).lock(SECTION, NUMBER);
+        verify(seatBanRepository).delete(ban);
+        verify(applicationEventPublisher).publishEvent(new SeatChangeEvent(SECTION, NUMBER, true));
+    }
+
+    @Test
+    void 차단되지_않은_좌석은_해제할_수_없다() {
+        given(seatBanRepository.findBySeatSectionAndSeatNumber(SECTION, NUMBER)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.execute(REQUEST)).isInstanceOf(SeatBanNotFoundException.class);
+
+        verify(seatBanRepository, never()).delete(org.mockito.ArgumentMatchers.any());
+        verify(applicationEventPublisher, never()).publishEvent(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/CancelSeatReservationServiceImplTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
@@ -31,6 +32,9 @@ class CancelSeatReservationServiceImplTest {
     private SeatReservationRepository seatReservationRepository;
 
     @Mock
+    private SeatLockRepository seatLockRepository;
+
+    @Mock
     private UserUtil userUtil;
 
     @Mock
@@ -52,9 +56,12 @@ class CancelSeatReservationServiceImplTest {
     void 정상_예약_취소_성공() {
         given(userUtil.getCurrentUser()).willReturn(user());
         given(seatReservationRepository.findByUser(any())).willReturn(Optional.of(seat()));
+        given(seatReservationRepository.findBySeatSectionAndSeatNumberAndUser(any(), any(), any()))
+                .willReturn(Optional.of(seat()));
 
         cancelSeatReservationService.execute();
 
+        verify(seatLockRepository).lock("A", 1);
         verify(seatReservationRepository).delete(any(SeatEntity.class));
         verify(applicationEventPublisher).publishEvent(new SeatChangeEvent("A", 1, true));
     }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
@@ -131,19 +132,49 @@ class GetSeatsBySectionServiceImplTest {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.PERFORMER);
             GetSeatsBySectionResponse performer = getSeatsBySectionService.execute("A");
-            assertThat(performer.seats().get(14)).isTrue();  // A15
-            assertThat(performer.seats().get(15)).isFalse(); // A16
-            assertThat(performer.seats().get(20)).isTrue();  // A21
-            assertThat(performer.seats().get(23)).isFalse(); // A24
+            assertThat(performer.seats().get(14)).isFalse(); // A15
+            assertThat(performer.seats().get(15)).isTrue();  // A16
+            assertThat(performer.seats().get(31)).isTrue();  // A32
+            assertThat(performer.seats().get(32)).isFalse(); // A33
         }
 
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
             GetSeatsBySectionResponse user = getSeatsBySectionService.execute("A");
-            assertThat(user.seats().get(14)).isFalse();
-            assertThat(user.seats().get(15)).isTrue();
-            assertThat(user.seats().get(20)).isFalse();
-            assertThat(user.seats().get(23)).isTrue();
+            assertThat(user.seats().get(14)).isTrue();
+            assertThat(user.seats().get(15)).isFalse();
+            assertThat(user.seats().get(31)).isFalse();
+            assertThat(user.seats().get(32)).isTrue();
+        }
+    }
+
+    @Test
+    void B와_C구역의_공연자_좌석_경계를_반영한다() {
+        given(seatReservationCustomRepository.findSeatNumbersBySeatSection(anyString())).willReturn(Set.of());
+        given(seatBanCustomRepository.findSeatNumbersBySeatSection(anyString())).willReturn(Set.of());
+
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.PERFORMER);
+
+            GetSeatsBySectionResponse b = getSeatsBySectionService.execute("B");
+            assertThat(b.seats().get(11)).isFalse(); // B12
+            assertThat(b.seats().get(12)).isTrue();  // B13
+            assertThat(b.seats().get(38)).isTrue();  // B39
+            assertThat(b.seats().get(39)).isFalse(); // B40
+            assertThat(b.seats().get(42)).isFalse(); // B43
+            assertThat(b.seats().get(43)).isTrue();  // B44
+            assertThat(b.seats().get(47)).isTrue();  // B48
+            assertThat(b.seats().get(48)).isFalse(); // B49
+
+            GetSeatsBySectionResponse c = getSeatsBySectionService.execute("C");
+            assertThat(c.seats().get(6)).isFalse();  // C7
+            assertThat(c.seats().get(7)).isTrue();   // C8
+            assertThat(c.seats().get(12)).isTrue();  // C13
+            assertThat(c.seats().get(13)).isFalse(); // C14
+            assertThat(c.seats().get(14)).isFalse(); // C15
+            assertThat(c.seats().get(15)).isTrue();  // C16
+            assertThat(c.seats().get(31)).isTrue();  // C32
+            assertThat(c.seats().get(32)).isFalse(); // C33
         }
     }
 

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/PerformerCancelSeatReservationServiceImplTest.java
@@ -9,6 +9,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.PerformerCancelSeatReservationRequest;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.global.util.UserUtil;
@@ -30,6 +31,9 @@ class PerformerCancelSeatReservationServiceImplTest {
 
     @Mock
     private SeatReservationRepository seatReservationRepository;
+
+    @Mock
+    private SeatLockRepository seatLockRepository;
 
     @Mock
     private UserUtil userUtil;
@@ -64,6 +68,7 @@ class PerformerCancelSeatReservationServiceImplTest {
 
         performerCancelSeatReservationService.execute(request());
 
+        verify(seatLockRepository).lock(SEAT_SECTION, SEAT_NUMBER);
         verify(seatReservationRepository).delete(any(SeatEntity.class));
         verify(applicationEventPublisher).publishEvent(new SeatChangeEvent(SEAT_SECTION, SEAT_NUMBER, true));
     }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
@@ -93,7 +93,7 @@ class ReservationSeatConcurrencyTest {
                     try {
                         startLatch.await();
                         setAuth(userId, Role.USER);
-                        reservationSeatService.execute(new ReservationSeatRequest("A", 16));
+                        reservationSeatService.execute(new ReservationSeatRequest("A", 1));
                         successCount.incrementAndGet();
                     } catch (SeatAlreadyReservedException e) {
                         failCount.incrementAndGet();
@@ -132,7 +132,7 @@ class ReservationSeatConcurrencyTest {
 
         long userId = testUsers.get(0).getId();
         String[] sections = {"A", "A"};
-        Integer[] seatNumbers = {16, 17};
+        Integer[] seatNumbers = {1, 2};
 
         try {
             for (int i = 0; i < threadCount; i++) {
@@ -166,5 +166,56 @@ class ReservationSeatConcurrencyTest {
         assertThat(exceptions).isEmpty();
         assertThat(successCount.get()).isEqualTo(1);
         assertThat(limitExceededCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void 동일_PERFORMER가_세_좌석을_동시_예약하면_두_건만_성공한다() throws InterruptedException {
+        UserEntity performer = userRepository.save(UserEntity.builder()
+                .phoneNumber("01088880000")
+                .role(Role.PERFORMER)
+                .build());
+        testUsers.add(performer);
+
+        int threadCount = 3;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger limitExceededCount = new AtomicInteger();
+        int[] seatNumbers = {16, 17, 18};
+
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                final int index = i;
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        setAuth(performer.getId(), Role.PERFORMER);
+                        reservationSeatService.execute(new ReservationSeatRequest("A", seatNumbers[index]));
+                        successCount.incrementAndGet();
+                    } catch (SeatReservationLimitExceededException e) {
+                        limitExceededCount.incrementAndGet();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (Throwable t) {
+                        exceptions.add(t);
+                    } finally {
+                        doneLatch.countDown();
+                        SecurityContextHolder.clearContext();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            executor.shutdown();
+        }
+
+        assertThat(exceptions).isEmpty();
+        assertThat(successCount.get()).isEqualTo(2);
+        assertThat(limitExceededCount.get()).isEqualTo(1);
+        assertThat(seatReservationRepository.countByUserId(performer.getId())).isEqualTo(2);
     }
 }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatServiceImplTest.java
@@ -15,6 +15,7 @@ import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBannedExcept
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotExistsInSectionException;
 import team.startup.gwangjutalentfestival.domain.seat.exception.SeatReservationLimitExceededException;
 import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.ReservationSeatRequest;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatLockRepository;
 import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
 import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
@@ -36,6 +37,9 @@ class ReservationSeatServiceImplTest {
 
     @Mock
     private SeatReservationRepository seatReservationRepository;
+
+    @Mock
+    private SeatLockRepository seatLockRepository;
 
     @Mock
     private SeatReservationValidator seatReservationValidator;
@@ -60,6 +64,7 @@ class ReservationSeatServiceImplTest {
     void setUp() {
         reservationSeatService = new ReservationSeatServiceImpl(
                 seatReservationRepository,
+                seatLockRepository,
                 seatReservationValidator,
                 seatUtil,
                 userUtil,
@@ -86,6 +91,7 @@ class ReservationSeatServiceImplTest {
 
         reservationSeatService.execute(request());
 
+        verify(seatLockRepository).lock(SEAT_SECTION, SEAT_NUMBER);
         verify(seatReservationRepository).saveAndFlush(any(SeatEntity.class));
         verify(applicationEventPublisher).publishEvent(new SeatChangeEvent(SEAT_SECTION, SEAT_NUMBER, false));
     }

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatStateConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatStateConcurrencyTest.java
@@ -1,0 +1,328 @@
+package team.startup.gwangjutalentfestival.domain.seat.service.impl;
+
+import com.google.api.services.drive.Drive;
+import com.google.api.services.sheets.v4.Sheets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import team.startup.gwangjutalentfestival.domain.seat.entity.SeatBanEntity;
+import team.startup.gwangjutalentfestival.domain.seat.entity.SeatEntity;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyBannedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatAlreadyReservedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBanNotFoundException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatBannedException;
+import team.startup.gwangjutalentfestival.domain.seat.exception.SeatNotFoundException;
+import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.BanSeatRequest;
+import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.CancelSeatBanRequest;
+import team.startup.gwangjutalentfestival.domain.seat.presentation.data.request.ReservationSeatRequest;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatBanRepository;
+import team.startup.gwangjutalentfestival.domain.seat.repository.SeatReservationRepository;
+import team.startup.gwangjutalentfestival.domain.seat.service.CancelSeatReservationService;
+import team.startup.gwangjutalentfestival.domain.seat.service.ReservationSeatService;
+import team.startup.gwangjutalentfestival.domain.seat.service.admin.BanSeatService;
+import team.startup.gwangjutalentfestival.domain.seat.service.admin.CancelSeatBanService;
+import team.startup.gwangjutalentfestival.domain.user.entity.UserEntity;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.domain.user.repository.UserRepository;
+import team.startup.gwangjutalentfestival.global.auth.CustomUserDetails;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class SeatStateConcurrencyTest {
+
+    private static final String SECTION = "A";
+    private static final int NUMBER = 1;
+
+    @MockBean
+    Sheets sheets;
+
+    @MockBean
+    Drive drive;
+
+    @Autowired
+    private ReservationSeatService reservationSeatService;
+
+    @Autowired
+    private CancelSeatReservationService cancelSeatReservationService;
+
+    @Autowired
+    private BanSeatService banSeatService;
+
+    @Autowired
+    private CancelSeatBanService cancelSeatBanService;
+
+    @Autowired
+    private SeatReservationRepository seatReservationRepository;
+
+    @Autowired
+    private SeatBanRepository seatBanRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private final List<UserEntity> users = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        seatReservationRepository.deleteAll();
+        seatBanRepository.deleteAll();
+        userRepository.deleteAll(users);
+    }
+
+    @Test
+    void 빈_좌석의_예약과_차단이_동시에_성공하지_않는다() throws InterruptedException {
+        UserEntity user = saveUser(0);
+        AtomicInteger reservationSuccess = new AtomicInteger();
+        AtomicInteger banSuccess = new AtomicInteger();
+
+        List<Throwable> unexpected = runConcurrently(
+                () -> {
+                    setAuth(user);
+                    try {
+                        reservationSeatService.execute(new ReservationSeatRequest(SECTION, NUMBER));
+                        reservationSuccess.incrementAndGet();
+                    } catch (SeatBannedException ignored) {
+                    } finally {
+                        SecurityContextHolder.clearContext();
+                    }
+                },
+                () -> {
+                    try {
+                        banSeatService.execute(new BanSeatRequest(SECTION, NUMBER));
+                        banSuccess.incrementAndGet();
+                    } catch (SeatAlreadyReservedException ignored) {
+                    }
+                }
+        );
+
+        assertThat(unexpected).isEmpty();
+        assertThat(reservationSuccess.get() + banSuccess.get()).isEqualTo(1);
+        assertThat(seatReservationRepository.existsBySeatSectionAndSeatNumber(SECTION, NUMBER))
+                .isNotEqualTo(seatBanRepository.existsBySeatSectionAndSeatNumber(SECTION, NUMBER));
+    }
+
+    @Test
+    void 같은_좌석을_동시에_차단하면_한_건만_성공한다() throws InterruptedException {
+        AtomicInteger success = new AtomicInteger();
+        AtomicInteger duplicate = new AtomicInteger();
+        Runnable ban = () -> {
+            try {
+                banSeatService.execute(new BanSeatRequest(SECTION, NUMBER));
+                success.incrementAndGet();
+            } catch (SeatAlreadyBannedException ignored) {
+                duplicate.incrementAndGet();
+            }
+        };
+
+        List<Throwable> unexpected = runConcurrently(ban, ban);
+
+        assertThat(unexpected).isEmpty();
+        assertThat(success.get()).isEqualTo(1);
+        assertThat(duplicate.get()).isEqualTo(1);
+        assertThat(seatBanRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void 같은_예약을_동시에_취소하면_한_건만_성공한다() throws InterruptedException {
+        UserEntity user = saveUser(1);
+        seatReservationRepository.saveAndFlush(SeatEntity.builder()
+                .seatSection(SECTION)
+                .seatNumber(NUMBER)
+                .user(user)
+                .build());
+        AtomicInteger success = new AtomicInteger();
+        AtomicInteger notFound = new AtomicInteger();
+        Runnable cancel = () -> {
+            setAuth(user);
+            try {
+                cancelSeatReservationService.execute();
+                success.incrementAndGet();
+            } catch (SeatNotFoundException ignored) {
+                notFound.incrementAndGet();
+            } finally {
+                SecurityContextHolder.clearContext();
+            }
+        };
+
+        List<Throwable> unexpected = runConcurrently(cancel, cancel);
+
+        assertThat(unexpected).isEmpty();
+        assertThat(success.get()).isEqualTo(1);
+        assertThat(notFound.get()).isEqualTo(1);
+        assertThat(seatReservationRepository.count()).isZero();
+    }
+
+    @Test
+    void 같은_차단을_동시에_해제하면_한_건만_성공한다() throws InterruptedException {
+        seatBanRepository.saveAndFlush(SeatBanEntity.builder()
+                .seatSection(SECTION)
+                .seatNumber(NUMBER)
+                .build());
+        AtomicInteger success = new AtomicInteger();
+        AtomicInteger notFound = new AtomicInteger();
+        Runnable cancelBan = () -> {
+            try {
+                cancelSeatBanService.execute(new CancelSeatBanRequest(SECTION, NUMBER));
+                success.incrementAndGet();
+            } catch (SeatBanNotFoundException ignored) {
+                notFound.incrementAndGet();
+            }
+        };
+
+        List<Throwable> unexpected = runConcurrently(cancelBan, cancelBan);
+
+        assertThat(unexpected).isEmpty();
+        assertThat(success.get()).isEqualTo(1);
+        assertThat(notFound.get()).isEqualTo(1);
+        assertThat(seatBanRepository.count()).isZero();
+    }
+
+    @Test
+    void 서로_다른_좌석의_예약은_서로를_막지_않는다() throws InterruptedException {
+        List<UserEntity> concurrentUsers = IntStream.range(0, 5)
+                .mapToObj(this::saveUser)
+                .toList();
+        AtomicInteger success = new AtomicInteger();
+        Runnable[] reservations = IntStream.range(0, concurrentUsers.size())
+                .mapToObj(index -> (Runnable) () -> {
+                    setAuth(concurrentUsers.get(index));
+                    try {
+                        reservationSeatService.execute(new ReservationSeatRequest(SECTION, index + 1));
+                        success.incrementAndGet();
+                    } finally {
+                        SecurityContextHolder.clearContext();
+                    }
+                })
+                .toArray(Runnable[]::new);
+
+        List<Throwable> unexpected = runConcurrently(reservations);
+
+        assertThat(unexpected).isEmpty();
+        assertThat(success.get()).isEqualTo(5);
+        assertThat(seatReservationRepository.count()).isEqualTo(5);
+    }
+
+    @Test
+    void 예약_취소와_차단이_경쟁해도_두_상태가_함께_남지_않는다() throws InterruptedException {
+        UserEntity user = saveUser(10);
+        seatReservationRepository.saveAndFlush(SeatEntity.builder()
+                .seatSection(SECTION)
+                .seatNumber(NUMBER)
+                .user(user)
+                .build());
+        AtomicInteger cancelSuccess = new AtomicInteger();
+
+        List<Throwable> unexpected = runConcurrently(
+                () -> {
+                    setAuth(user);
+                    try {
+                        cancelSeatReservationService.execute();
+                        cancelSuccess.incrementAndGet();
+                    } finally {
+                        SecurityContextHolder.clearContext();
+                    }
+                },
+                () -> {
+                    try {
+                        banSeatService.execute(new BanSeatRequest(SECTION, NUMBER));
+                    } catch (SeatAlreadyReservedException ignored) {
+                    }
+                }
+        );
+
+        assertThat(unexpected).isEmpty();
+        assertThat(cancelSuccess.get()).isEqualTo(1);
+        assertThat(seatReservationRepository.existsBySeatSectionAndSeatNumber(SECTION, NUMBER)).isFalse();
+    }
+
+    @Test
+    void 차단_해제와_예약이_경쟁해도_차단과_예약이_함께_남지_않는다() throws InterruptedException {
+        UserEntity user = saveUser(11);
+        seatBanRepository.saveAndFlush(SeatBanEntity.builder()
+                .seatSection(SECTION)
+                .seatNumber(NUMBER)
+                .build());
+        AtomicInteger cancelBanSuccess = new AtomicInteger();
+
+        List<Throwable> unexpected = runConcurrently(
+                () -> {
+                    cancelSeatBanService.execute(new CancelSeatBanRequest(SECTION, NUMBER));
+                    cancelBanSuccess.incrementAndGet();
+                },
+                () -> {
+                    setAuth(user);
+                    try {
+                        reservationSeatService.execute(new ReservationSeatRequest(SECTION, NUMBER));
+                    } catch (SeatBannedException ignored) {
+                    } finally {
+                        SecurityContextHolder.clearContext();
+                    }
+                }
+        );
+
+        assertThat(unexpected).isEmpty();
+        assertThat(cancelBanSuccess.get()).isEqualTo(1);
+        assertThat(seatBanRepository.existsBySeatSectionAndSeatNumber(SECTION, NUMBER)).isFalse();
+    }
+
+    private UserEntity saveUser(int suffix) {
+        UserEntity user = userRepository.save(UserEntity.builder()
+                .phoneNumber("0107777" + String.format("%04d", suffix))
+                .role(Role.USER)
+                .build());
+        users.add(user);
+        return user;
+    }
+
+    private void setAuth(UserEntity user) {
+        CustomUserDetails details = CustomUserDetails.fromToken(user.getId(), user.getRole());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                details, null, details.getAuthorities()));
+        SecurityContextHolder.setContext(context);
+    }
+
+    private List<Throwable> runConcurrently(Runnable... tasks) throws InterruptedException {
+        ExecutorService executor = Executors.newFixedThreadPool(tasks.length);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(tasks.length);
+        List<Throwable> unexpected = Collections.synchronizedList(new ArrayList<>());
+        try {
+            for (Runnable task : tasks) {
+                executor.submit(() -> {
+                    try {
+                        start.await();
+                        task.run();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (Throwable throwable) {
+                        unexpected.add(throwable);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            executor.shutdown();
+        }
+        return unexpected;
+    }
+}

--- a/src/test/java/team/startup/gwangjutalentfestival/global/util/SeatUtilTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/util/SeatUtilTest.java
@@ -5,6 +5,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.api.Test;
 import team.startup.gwangjutalentfestival.domain.user.enums.Role;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SeatUtilTest {
@@ -18,14 +22,53 @@ class SeatUtilTest {
 
     @ParameterizedTest
     @CsvSource({
-            "A, 1, true", "A, 15, true", "A, 16, false", "A, 20, false",
-            "A, 21, true", "A, 23, true", "A, 24, false",
-            "B, 1, true", "B, 36, true", "B, 37, false",
-            "C, 1, true", "C, 18, true", "C, 19, false",
+            "A, 15, false", "A, 16, true", "A, 32, true", "A, 33, false",
+            "B, 12, false", "B, 13, true", "B, 39, true", "B, 40, false",
+            "B, 43, false", "B, 44, true", "B, 48, true", "B, 49, false",
+            "C, 7, false", "C, 8, true", "C, 13, true", "C, 14, false",
+            "C, 15, false", "C, 16, true", "C, 32, true", "C, 33, false",
             "D, 1, false", "E, 1, false", "F, 1, false"
     })
     void 공연자_좌석_범위를_검증한다(String section, int seatNumber, boolean performerAllowed) {
         assertThat(seatUtil.isAllowedForRole(Role.PERFORMER, section, seatNumber)).isEqualTo(performerAllowed);
         assertThat(seatUtil.isAllowedForRole(Role.USER, section, seatNumber)).isEqualTo(!performerAllowed);
+    }
+
+    @Test
+    void 역할별_좌석은_겹치거나_비는_자리_없이_전체_좌석을_나눈다() {
+        Set<String> expectedPerformerSeats = Set.of(
+                range("A", 16, 32),
+                range("B", 13, 39),
+                range("B", 44, 48),
+                range("C", 8, 13),
+                range("C", 16, 32)
+        ).stream().flatMap(List::stream).collect(java.util.stream.Collectors.toSet());
+
+        List<String> allSeats = seatUtil.getSections().stream()
+                .flatMap(section -> range(section, 1, seatUtil.getMaxSeats(section)).stream())
+                .toList();
+        List<String> performerSeats = allSeats.stream()
+                .filter(seat -> allowed(Role.PERFORMER, seat))
+                .toList();
+        List<String> userSeats = allSeats.stream()
+                .filter(seat -> allowed(Role.USER, seat))
+                .toList();
+
+        assertThat(performerSeats).containsExactlyInAnyOrderElementsOf(expectedPerformerSeats);
+        assertThat(performerSeats).hasSize(72);
+        assertThat(userSeats).hasSize(536);
+        assertThat(performerSeats).doesNotContainAnyElementsOf(userSeats);
+        assertThat(performerSeats).hasSize(allSeats.size() - userSeats.size());
+    }
+
+    private List<String> range(String section, int start, int end) {
+        return IntStream.rangeClosed(start, end)
+                .mapToObj(number -> section + ":" + number)
+                .toList();
+    }
+
+    private boolean allowed(Role role, String seat) {
+        String[] parts = seat.split(":");
+        return seatUtil.isAllowedForRole(role, parts[0], Integer.parseInt(parts[1]));
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
> 참가자 좌석 범위를 변경하고 예약·차단·취소의 좌석 단위 동시성 제어와 테스트를 보강했습니다.

- 참가자 예매 좌석을 A 16~32, B 13~39·44~48, C 8~13·16~32로 변경
- 일반 사용자 좌석에서 참가자 전용 좌석 제외
- 예약·차단·취소가 공유하는 좌석 단위 DB 잠금 추가
- 이미 예약된 좌석의 관리자 차단 방지
- 역할 경계 및 예약·차단·취소 동시성 테스트 보강

---

## 🔍 리뷰 시 참고사항
- 예약과 차단이 서로 다른 테이블에 저장되어 빈 좌석에서는 잠글 행이 없었습니다.
- Flyway로 실제 좌석 608개의 잠금 행을 미리 생성하고 MariaDB의 `SELECT ... FOR UPDATE`로 동일 좌석의 상태 변경을 직렬화했습니다.
- 좌석 관련 테스트 76개와 전체 테스트 363개가 통과했습니다.
- DB 마이그레이션으로 `V3__add_seat_lock.sql`, `V4__seed_seat_lock.sql`이 추가됩니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #217
