### PR TITLE
출연진·스태프 좌석 예약 금지

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/global/util/SeatUtil.java
@@ -47,6 +47,17 @@ public class SeatUtil {
     }
 
     public boolean isAllowedForRole(Role role, String section, int seatNumber) {
+        boolean restrictedSeat = switch (section) {
+            case "A" -> seatNumber >= 1 && seatNumber <= 15;
+            case "B" -> seatNumber >= 1 && seatNumber <= 12;
+            case "C" -> seatNumber >= 1 && seatNumber <= 7
+                    || seatNumber >= 14 && seatNumber <= 15;
+            case "E" -> seatNumber >= 1 && seatNumber <= 24
+                    || seatNumber >= 73 && seatNumber <= 96;
+            default -> false;
+        };
+        if (restrictedSeat) return false;
+
         boolean performerSeat = switch (section) {
             case "A" -> seatNumber >= 16 && seatNumber <= 32;
             case "B" -> seatNumber >= 13 && seatNumber <= 39

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/GetSeatsBySectionServiceImplTest.java
@@ -41,7 +41,7 @@ class GetSeatsBySectionServiceImplTest {
     private static final String SECTION = "A";
 
     @Test
-    void 모든_좌석_예약_가능() {
+    void 관리자_조회에도_정적_금지_좌석은_false() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.ADMIN);
             given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
@@ -50,7 +50,8 @@ class GetSeatsBySectionServiceImplTest {
             GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
             assertThat(response.seats()).hasSize(101);
-            assertThat(response.seats()).containsOnly(true);
+            assertThat(response.seats().subList(0, 15)).containsOnly(false);
+            assertThat(response.seats().get(15)).isTrue(); // A16
         }
     }
 
@@ -58,16 +59,16 @@ class GetSeatsBySectionServiceImplTest {
     void 예약된_좌석은_false() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.ADMIN);
-            given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of(2, 4));
+            given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of(20, 22));
             given(seatBanCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
 
             GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
-            assertThat(response.seats().get(0)).isTrue();
-            assertThat(response.seats().get(1)).isFalse(); // 2번
-            assertThat(response.seats().get(2)).isTrue();
-            assertThat(response.seats().get(3)).isFalse(); // 4번
-            assertThat(response.seats().get(4)).isTrue();
+            assertThat(response.seats().get(18)).isTrue();
+            assertThat(response.seats().get(19)).isFalse(); // 20번
+            assertThat(response.seats().get(20)).isTrue();
+            assertThat(response.seats().get(21)).isFalse(); // 22번
+            assertThat(response.seats().get(22)).isTrue();
         }
     }
 
@@ -76,13 +77,14 @@ class GetSeatsBySectionServiceImplTest {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.ADMIN);
             given(seatReservationCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of());
-            given(seatBanCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of(1, 3));
+            given(seatBanCustomRepository.findSeatNumbersBySeatSection(SECTION)).willReturn(Set.of(20, 22));
 
             GetSeatsBySectionResponse response = getSeatsBySectionService.execute(SECTION);
 
-            assertThat(response.seats().get(0)).isFalse(); // 1번
-            assertThat(response.seats().get(1)).isTrue();
-            assertThat(response.seats().get(2)).isFalse(); // 3번
+            assertThat(response.seats().get(18)).isTrue();
+            assertThat(response.seats().get(19)).isFalse(); // 20번
+            assertThat(response.seats().get(20)).isTrue();
+            assertThat(response.seats().get(21)).isFalse(); // 22번
         }
     }
 
@@ -99,7 +101,7 @@ class GetSeatsBySectionServiceImplTest {
     }
 
     @Test
-    void B구역_전체_좌석_예약_가능() {
+    void B구역의_정적_금지_좌석을_반영한다() {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.ADMIN);
             given(seatReservationCustomRepository.findSeatNumbersBySeatSection("B")).willReturn(Set.of());
@@ -108,7 +110,8 @@ class GetSeatsBySectionServiceImplTest {
             GetSeatsBySectionResponse response = getSeatsBySectionService.execute("B");
 
             assertThat(response.seats()).hasSize(132);
-            assertThat(response.seats()).containsOnly(true);
+            assertThat(response.seats().subList(0, 12)).containsOnly(false);
+            assertThat(response.seats().get(12)).isTrue(); // B13
         }
     }
 
@@ -141,10 +144,30 @@ class GetSeatsBySectionServiceImplTest {
         try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
             userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(Role.USER);
             GetSeatsBySectionResponse user = getSeatsBySectionService.execute("A");
-            assertThat(user.seats().get(14)).isTrue();
+            assertThat(user.seats().get(14)).isFalse();
             assertThat(user.seats().get(15)).isFalse();
             assertThat(user.seats().get(31)).isFalse();
             assertThat(user.seats().get(32)).isTrue();
+        }
+    }
+
+    @Test
+    void E구역의_정적_금지_좌석을_반영한다() {
+        given(seatReservationCustomRepository.findSeatNumbersBySeatSection("E")).willReturn(Set.of());
+        given(seatBanCustomRepository.findSeatNumbersBySeatSection("E")).willReturn(Set.of());
+
+        for (Role role : Set.of(Role.USER, Role.ADMIN)) {
+            try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+                userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(role);
+                GetSeatsBySectionResponse response = getSeatsBySectionService.execute("E");
+
+                assertThat(response.seats().get(0)).isFalse();  // E1
+                assertThat(response.seats().get(23)).isFalse(); // E24
+                assertThat(response.seats().get(24)).isTrue();  // E25
+                assertThat(response.seats().get(71)).isTrue();  // E72
+                assertThat(response.seats().get(72)).isFalse(); // E73
+                assertThat(response.seats().get(95)).isFalse(); // E96
+            }
         }
     }
 

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/ReservationSeatConcurrencyTest.java
@@ -93,7 +93,7 @@ class ReservationSeatConcurrencyTest {
                     try {
                         startLatch.await();
                         setAuth(userId, Role.USER);
-                        reservationSeatService.execute(new ReservationSeatRequest("A", 1));
+                        reservationSeatService.execute(new ReservationSeatRequest("A", 33));
                         successCount.incrementAndGet();
                     } catch (SeatAlreadyReservedException e) {
                         failCount.incrementAndGet();
@@ -132,7 +132,7 @@ class ReservationSeatConcurrencyTest {
 
         long userId = testUsers.get(0).getId();
         String[] sections = {"A", "A"};
-        Integer[] seatNumbers = {1, 2};
+        Integer[] seatNumbers = {33, 34};
 
         try {
             for (int i = 0; i < threadCount; i++) {

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidatorTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatReservationValidatorTest.java
@@ -2,6 +2,8 @@ package team.startup.gwangjutalentfestival.domain.seat.service.impl;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -85,6 +87,30 @@ class SeatReservationValidatorTest {
 
             assertThatThrownBy(() -> validator.validateSeatAccess(SECTION, SEAT_NUMBER))
                     .isInstanceOf(SeatBannedException.class);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "A, 1", "A, 15",
+            "B, 1", "B, 12",
+            "C, 1", "C, 7", "C, 14", "C, 15",
+            "E, 1", "E, 24", "E, 73", "E, 96"
+    })
+    void 정적_금지_좌석은_모든_역할의_예약을_거부한다(String section, int seatNumber) {
+        SeatReservationValidator realValidator = new SeatReservationValidator(
+                seatReservationRepository,
+                seatBanRepository,
+                userRepository,
+                new SeatUtil()
+        );
+
+        try (MockedStatic<UserUtil> userUtilMock = mockStatic(UserUtil.class)) {
+            for (Role role : Role.values()) {
+                userUtilMock.when(UserUtil::getCurrentUserRole).thenReturn(role);
+                assertThatThrownBy(() -> realValidator.validateSeatAccess(section, seatNumber))
+                        .isInstanceOf(SeatBannedException.class);
+            }
         }
     }
 

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatStateConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/service/impl/SeatStateConcurrencyTest.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SeatStateConcurrencyTest {
 
     private static final String SECTION = "A";
-    private static final int NUMBER = 1;
+    private static final int NUMBER = 33;
 
     @MockBean
     Sheets sheets;
@@ -203,7 +203,7 @@ class SeatStateConcurrencyTest {
                 .mapToObj(index -> (Runnable) () -> {
                     setAuth(concurrentUsers.get(index));
                     try {
-                        reservationSeatService.execute(new ReservationSeatRequest(SECTION, index + 1));
+                        reservationSeatService.execute(new ReservationSeatRequest(SECTION, NUMBER + index));
                         success.incrementAndGet();
                     } finally {
                         SecurityContextHolder.clearContext();

--- a/src/test/java/team/startup/gwangjutalentfestival/global/util/SeatUtilTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/global/util/SeatUtilTest.java
@@ -31,17 +31,24 @@ class SeatUtilTest {
     })
     void 공연자_좌석_범위를_검증한다(String section, int seatNumber, boolean performerAllowed) {
         assertThat(seatUtil.isAllowedForRole(Role.PERFORMER, section, seatNumber)).isEqualTo(performerAllowed);
-        assertThat(seatUtil.isAllowedForRole(Role.USER, section, seatNumber)).isEqualTo(!performerAllowed);
     }
 
     @Test
-    void 역할별_좌석은_겹치거나_비는_자리_없이_전체_좌석을_나눈다() {
+    void 역할별_좌석과_정적_금지_좌석을_전체_좌석에서_분리한다() {
         Set<String> expectedPerformerSeats = Set.of(
                 range("A", 16, 32),
                 range("B", 13, 39),
                 range("B", 44, 48),
                 range("C", 8, 13),
                 range("C", 16, 32)
+        ).stream().flatMap(List::stream).collect(java.util.stream.Collectors.toSet());
+        Set<String> restrictedSeats = Set.of(
+                range("A", 1, 15),
+                range("B", 1, 12),
+                range("C", 1, 7),
+                range("C", 14, 15),
+                range("E", 1, 24),
+                range("E", 73, 96)
         ).stream().flatMap(List::stream).collect(java.util.stream.Collectors.toSet());
 
         List<String> allSeats = seatUtil.getSections().stream()
@@ -53,12 +60,20 @@ class SeatUtilTest {
         List<String> userSeats = allSeats.stream()
                 .filter(seat -> allowed(Role.USER, seat))
                 .toList();
+        List<String> expectedUserSeats = allSeats.stream()
+                .filter(seat -> !expectedPerformerSeats.contains(seat) && !restrictedSeats.contains(seat))
+                .toList();
 
         assertThat(performerSeats).containsExactlyInAnyOrderElementsOf(expectedPerformerSeats);
         assertThat(performerSeats).hasSize(72);
-        assertThat(userSeats).hasSize(536);
+        assertThat(restrictedSeats).hasSize(84);
+        assertThat(userSeats).containsExactlyInAnyOrderElementsOf(expectedUserSeats);
+        assertThat(userSeats).hasSize(452);
         assertThat(performerSeats).doesNotContainAnyElementsOf(userSeats);
-        assertThat(performerSeats).hasSize(allSeats.size() - userSeats.size());
+        assertThat(performerSeats).hasSize(allSeats.size() - userSeats.size() - restrictedSeats.size());
+        for (Role role : Role.values()) {
+            assertThat(restrictedSeats).allSatisfy(seat -> assertThat(allowed(role, seat)).isFalse());
+        }
     }
 
     private List<String> range(String section, int start, int end) {


### PR DESCRIPTION
## ✨ 작업 내용
> 출연진·스태프 전용 좌석 84석을 모든 역할에서 예약 불가 처리했습니다.

- A 1~15, B 1~12, C 1~7·14~15, E 1~24·73~96 정적 금지
- 참가자 전용 72석 유지 및 일반 사용자 가능 좌석 452석으로 조정
- 좌석 조회와 실제 예약 검증에 동일한 금지 규칙 적용
- 기존 동시성 테스트의 일반 사용자 좌석을 허용 구간으로 변경

---

## 🔍 리뷰 시 참고사항
- DB 차단 데이터나 마이그레이션 없이 `SeatUtil`의 공통 접근 판정으로 처리했습니다.
- 금지 구간의 기존 예약 데이터는 삭제하지 않으며 조회와 취소가 가능합니다.
- 좌석 테스트 89개와 전체 테스트 388개가 통과했습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #221
