### PR TITLE
좌석 변경 SSE 실시간 전달 안정화

### DIFF
--- a/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatController.java
+++ b/src/main/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -161,8 +162,11 @@ public class SeatController {
             @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰")
     })
     @GetMapping(value = "/changes", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter connectSse() {
-        return connectSseSeatEventService.execute();
+    public ResponseEntity<SseEmitter> connectSse() {
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache().noTransform())
+                .header("X-Accel-Buffering", "no")
+                .body(connectSseSeatEventService.execute());
     }
 
     /**

--- a/src/test/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatSseStreamingTest.java
+++ b/src/test/java/team/startup/gwangjutalentfestival/domain/seat/presentation/controller/SeatSseStreamingTest.java
@@ -1,0 +1,99 @@
+package team.startup.gwangjutalentfestival.domain.seat.presentation.controller;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import team.startup.gwangjutalentfestival.domain.seat.event.SeatChangeEvent;
+import team.startup.gwangjutalentfestival.domain.seat.event.handler.SeatChangeEventListener;
+import team.startup.gwangjutalentfestival.domain.seat.service.CancelSeatReservationService;
+import team.startup.gwangjutalentfestival.domain.seat.service.GetAllSeatsService;
+import team.startup.gwangjutalentfestival.domain.seat.service.GetByCurrentPerformerSeatsService;
+import team.startup.gwangjutalentfestival.domain.seat.service.GetCurrentUserSeatService;
+import team.startup.gwangjutalentfestival.domain.seat.service.GetSeatsBySectionService;
+import team.startup.gwangjutalentfestival.domain.seat.service.PerformerCancelSeatReservationService;
+import team.startup.gwangjutalentfestival.domain.seat.service.ReservationSeatService;
+import team.startup.gwangjutalentfestival.domain.seat.service.impl.ConnectSseSeatEventServiceImpl;
+import team.startup.gwangjutalentfestival.domain.user.enums.Role;
+import team.startup.gwangjutalentfestival.global.auth.CustomUserDetails;
+import team.startup.gwangjutalentfestival.global.sse.SeatSseEmitterManager;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class SeatSseStreamingTest {
+
+    private MockMvc mockMvc;
+    private SeatSseEmitterManager emitterManager;
+    private SeatChangeEventListener eventListener;
+
+    @BeforeEach
+    void setUp() {
+        emitterManager = new SeatSseEmitterManager();
+        TaskScheduler taskScheduler = mock(TaskScheduler.class);
+        ScheduledFuture<?> heartbeat = mock(ScheduledFuture.class);
+        doReturn(heartbeat).when(taskScheduler)
+                .scheduleAtFixedRate(any(Runnable.class), any(Duration.class));
+
+        ConnectSseSeatEventServiceImpl connectService =
+                new ConnectSseSeatEventServiceImpl(emitterManager, taskScheduler);
+        eventListener = new SeatChangeEventListener(emitterManager);
+
+        SeatController controller = new SeatController(
+                mock(ReservationSeatService.class),
+                mock(CancelSeatReservationService.class),
+                mock(PerformerCancelSeatReservationService.class),
+                mock(GetCurrentUserSeatService.class),
+                mock(GetByCurrentPerformerSeatsService.class),
+                mock(GetSeatsBySectionService.class),
+                mock(GetAllSeatsService.class),
+                connectService
+        );
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+        CustomUserDetails user = CustomUserDetails.fromToken(1L, Role.USER);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        emitterManager.getAllEmitters().forEach(emitter -> emitter.complete());
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 연결_후_좌석_변경_이벤트를_같은_스트림으로_즉시_전송한다() throws Exception {
+        MvcResult result = mockMvc.perform(get("/seat/changes"))
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        eventListener.execute(new SeatChangeEvent("A", 16, false));
+        emitterManager.getAllEmitters().forEach(emitter -> emitter.complete());
+
+        mockMvc.perform(asyncDispatch(result))
+                .andExpect(header().string("Cache-Control", "no-cache, no-transform"))
+                .andExpect(header().string("X-Accel-Buffering", "no"))
+                .andExpect(content().string(containsString("event:connected")))
+                .andExpect(content().string(containsString("event:SEAT_CHANGE")))
+                .andExpect(content().string(containsString(
+                        "data:{\"seatSection\":\"A\",\"seatNumber\":16,\"isAvailable\":false}")));
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약해주세요.

- 좌석 SSE 응답에 `no-cache, no-transform`을 적용해 중간 프록시의 캐시·변환을 방지했습니다.
- `X-Accel-Buffering: no` 헤더를 적용해 프록시 응답 버퍼링을 방지했습니다.
- SSE 연결 후 `connected`와 `SEAT_CHANGE` 프레임이 같은 스트림으로 전달되는 통합 테스트를 추가했습니다.

---

## 🔍 리뷰 시 참고사항
- 브라우저에는 프론트 프록시가 생성한 주석형 heartbeat만 보이고 백엔드 SSE 프레임이 보이지 않아, 서버 응답의 중간 버퍼링 방지 계약을 명시했습니다.
- 프론트 코드는 변경하지 않았습니다.
- `./gradlew test` 전체 테스트를 통과했습니다.

---

## ✅ 체크리스트
- [x] 문서(README, `.env.example` 등) 변경이 필요한 경우 작성 또는 수정했나요?
- [x] 작업한 코드가 정상적으로 동작하는 것을 직접 확인했나요?
- [x] 필요한 경우 테스트 코드를 작성하거나 수정했나요?
- [x] Merge 대상 브랜치를 올바르게 설정했나요?
- [x] PR에 관련 없는 작업이 포함되지 않았나요?
- [x] 적절한 라벨과 리뷰어를 설정했나요?

---

## 📎 관련 이슈(선택)
- Close #226
